### PR TITLE
[#LIB-158] added audit answer to audit logging

### DIFF
--- a/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditAnswer.java
+++ b/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditAnswer.java
@@ -1,0 +1,33 @@
+package org.dcm4che3.net.audit;
+
+/**
+ * This interface provides methods to query the status of an audit logging, the message itself
+ * (formatted as a string, for e.g. local logging) and an exception that may have occurred. You can
+ * and must not rely on an exception being present in all cases of failure though, it may be null.
+ * The message may also be null if there was an error creating the string but in this case the
+ * exception has to return a value.
+ */
+public interface AuditAnswer {
+
+    /**
+     * The status of the audit logging process
+     */
+    public enum AuditStatus {
+        SUCCESS, FAILURE;
+    }
+
+    /**
+     * @return the audit status
+     */
+    public abstract AuditStatus getAuditStatus();
+
+    /**
+     * @return null if the status is {@link AuditStatus#SUCCESS}, may contain an exception otherwise
+     */
+    public abstract Exception getException();
+
+    /**
+     * @return the audited message as String
+     */
+    public abstract String getMessage();
+}

--- a/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/impl/DefaultAuditAnswer.java
+++ b/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/impl/DefaultAuditAnswer.java
@@ -1,0 +1,55 @@
+package org.dcm4che3.net.audit.impl;
+
+import org.dcm4che3.net.audit.AuditAnswer;
+
+public class DefaultAuditAnswer implements AuditAnswer {
+
+    private AuditStatus status;
+    private String      message;
+    private Exception   e;
+
+    private DefaultAuditAnswer(AuditStatus status, String message, Exception e) {
+        this.status = status;
+        this.message = message;
+        this.e = e;
+    }
+
+    /**
+     * This factory method creates a success answer with the given message.
+     * 
+     * @param message
+     *        the audit message
+     * @return
+     */
+    public static AuditAnswer createSuccessAnswer(String message) {
+        return new DefaultAuditAnswer(AuditStatus.SUCCESS, message, null);
+    }
+
+    /**
+     * This factory method creates a failure answer with the given message and exception.
+     * 
+     * @param message
+     *        the audit message
+     * @param e
+     *        an optional exception
+     * @return
+     */
+    public static AuditAnswer createFailureAnswer(String message, Exception e) {
+        return new DefaultAuditAnswer(AuditStatus.FAILURE, message, e);
+    }
+
+    @Override
+    public AuditStatus getAuditStatus() {
+        return status;
+    }
+
+    @Override
+    public Exception getException() {
+        return e;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
Instead of returning just nothing and printing a stack trace to System.err I'd like to return an object describing the status of the audit, including the audited message and an exception that possibly occurred while building or sending the message.