### PR TITLE
Correct xml space preserve

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/SAXWriter.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/SAXWriter.java
@@ -140,7 +140,7 @@ public class SAXWriter implements DicomInputHandler {
 
     private void startDocument() throws SAXException {
         ch.startDocument();
-        startElement("NativeDicomModel", "xml-space", "preserved");
+        startElement("NativeDicomModel", "xml:space", "preserve");
     }
 
     private void endDocument() throws SAXException {


### PR DESCRIPTION
The correct form to specify that all white space in an xml should be preserved is xml:space="preserve" and not  xml-space="preserved". For more details on this please visit http://www.w3.org/TR/xml11/#sec-white-space
