### PR TITLE
Minor fix

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/SAXWriter.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/SAXWriter.java
@@ -335,7 +335,8 @@ public class SAXWriter implements DicomInputHandler {
         int vm = vr.vmOf(val);
         for (int i = 0; i < vm; i++) {
             String s = vr.toString(val, bigEndian, i, null);
-            addAttribute("number", Integer.toString(i + 1));
+            if (s != null)
+                addAttribute("number", Integer.toString(i + 1));
             if (vr == VR.PN) {
                 PersonName pn = new PersonName(s, true);
                 startElement("PersonName");


### PR DESCRIPTION
For the case of an empty CS value, it has been noticed that the `number` attribute gets allocated to the next tag. Not adding the attribute when the value is `null` seems to solve the problem.

For more details on this issue, take the case of a DICOM file containing the following two tags:
```
(0008,0008)	ImageType 	DERIVED\SECONDARY\
(0008,0016)	SOPClassUID	1.2.840.10008.5.1.4.1.1.7
```
The xml conversion for these two is:
```xml
    <DicomAttribute keyword="ImageType" tag="00080008" vr="CS">
        <Value number="1">DERIVED</Value>
        <Value number="2">SECONDARY</Value>
    </DicomAttribute>
    <DicomAttribute number="3" keyword="SOPClassUID" tag="00080016" vr="UI">
        <Value number="1">1.2.840.10008.5.1.4.1.1.7</Value>
    </DicomAttribute>
```
Please note the redundant `number="3"` associated to the SOPClassUid tag.