### PR TITLE
Proxy Manager for Connection

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Connection.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Connection.java
@@ -63,8 +63,8 @@ import org.dcm4che3.conf.core.api.ConfigurableClass;
 import org.dcm4che3.conf.core.api.ConfigurableProperty;
 import org.dcm4che3.conf.core.api.ConfigurableProperty.Tag;
 import org.dcm4che3.conf.core.api.LDAP;
-import org.dcm4che3.net.proxy.BasicProxyManager;
 import org.dcm4che3.net.proxy.ProxyManager;
+import org.dcm4che3.net.proxy.ProxyService;
 import org.dcm4che3.util.SafeClose;
 import org.dcm4che3.util.StringUtils;
 import org.slf4j.Logger;
@@ -221,7 +221,8 @@ public class Connection implements Serializable {
     )
     private Protocol protocol = Protocol.DICOM;
 
-    private ProxyManager proxyManager = new BasicProxyManager();
+    // TODO AP - CONFIG PROXY FOR CONNECTION
+    private ProxyManager proxyManager = ProxyService.getInstance().getDefaultProxyManager();
     
 	private static final EnumMap<Protocol, TCPProtocolHandler> tcpHandlers =
             new EnumMap<Protocol, TCPProtocolHandler>(Protocol.class);

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Connection.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Connection.java
@@ -63,7 +63,7 @@ import org.dcm4che3.conf.core.api.ConfigurableClass;
 import org.dcm4che3.conf.core.api.ConfigurableProperty;
 import org.dcm4che3.conf.core.api.ConfigurableProperty.Tag;
 import org.dcm4che3.conf.core.api.LDAP;
-import org.dcm4che3.net.proxy.CommonProxyManager;
+import org.dcm4che3.net.proxy.BasicProxyManager;
 import org.dcm4che3.net.proxy.ProxyManager;
 import org.dcm4che3.util.SafeClose;
 import org.dcm4che3.util.StringUtils;
@@ -221,7 +221,7 @@ public class Connection implements Serializable {
     )
     private Protocol protocol = Protocol.DICOM;
 
-    private ProxyManager proxyManager = new CommonProxyManager();
+    private ProxyManager proxyManager = new BasicProxyManager();
     
 	private static final EnumMap<Protocol, TCPProtocolHandler> tcpHandlers =
             new EnumMap<Protocol, TCPProtocolHandler>(Protocol.class);

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/BasicProxyManager.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/BasicProxyManager.java
@@ -17,8 +17,8 @@ import org.dcm4che3.util.Base64;
  */
 public class BasicProxyManager implements ProxyManager {
 
-	private static String PROVIDER_NAME = "org.dcm4che";
-	private static String VERSION = "1.0";
+	public static String PROVIDER_NAME = "org.dcm4che.basic";
+	public static String VERSION = "1.0";
 	
 	@Override
 	public String getProviderName() {

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/BasicProxyManager.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/BasicProxyManager.java
@@ -15,7 +15,7 @@ import org.dcm4che3.util.Base64;
  * @author Amaury Pernette
  * 
  */
-public class CommonProxyManager implements ProxyManager {
+public class BasicProxyManager implements ProxyManager {
 
 	private static String PROVIDER_NAME = "org.dcm4che";
 	private static String VERSION = "1.0";
@@ -30,11 +30,6 @@ public class CommonProxyManager implements ProxyManager {
 		return VERSION;
 	}
 
-	
-	public static void main(String[] args) {
-		ProxyService.getInstance().getProxyManager("org.dcm4che", "1.0");
-	}
-	
 	@Override
 	public void doProxyHandshake(Socket s, String hostname, int port,
 			String userauth, int connectTimeout) throws IOException {

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/CommonProxyManager.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/CommonProxyManager.java
@@ -1,0 +1,81 @@
+package org.dcm4che3.net.proxy;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+
+import org.dcm4che3.util.Base64;
+
+/**
+ * Define basic proxy authentication processing.
+ * This code come from old Connection.doProxyHandshake() method (before refactoring).
+ *
+ * @author Amaury Pernette
+ * 
+ */
+public class CommonProxyManager implements ProxyManager {
+
+	@Override
+	public void doProxyHandshake(Socket s, String hostname, int port,
+			String userauth, int connectTimeout) throws IOException {
+
+        StringBuilder request = new StringBuilder(128);
+        request.append("CONNECT ")
+                .append(hostname).append(':').append(port)
+                .append(" HTTP/1.1\r\nHost: ")
+                .append(hostname).append(':').append(port);
+        if (userauth != null) {
+            byte[] b = userauth.getBytes("UTF-8");
+            char[] base64 = new char[(b.length + 2) / 3 * 4];
+            Base64.encode(b, 0, b.length, base64, 0);
+            request.append("\r\nProxy-Authorization: basic ")
+                    .append(base64);
+        }
+        request.append("\r\n\r\n");
+        OutputStream out = s.getOutputStream();
+        out.write(request.toString().getBytes("US-ASCII"));
+        out.flush();
+
+        s.setSoTimeout(connectTimeout);
+        @SuppressWarnings("resource")
+        String response = new HTTPResponse(s).toString();
+        s.setSoTimeout(0);
+        if (!response.startsWith("HTTP/1.1 2"))
+            throw new IOException("Unable to tunnel through " + s
+                    + ". Proxy returns \"" + response + '\"');
+
+	}
+
+    private static class HTTPResponse extends ByteArrayOutputStream {
+
+        private final String rsp;
+
+        public HTTPResponse(Socket s) throws IOException {
+            super(64);
+            InputStream in = s.getInputStream();
+            boolean eol = false;
+            int b;
+            while ((b = in.read()) != -1) {
+                write(b);
+                if (b == '\n') {
+                    if (eol) {
+                        rsp = new String(super.buf, 0, super.count, "US-ASCII");
+                        return;
+                    }
+                    eol = true;
+                } else if (b != '\r') {
+                    eol = false;
+                }
+            }
+            throw new IOException("Unexpected EOF from " + s);
+        }
+
+        @Override
+        public String toString() {
+            return rsp;
+        }
+    }
+
+}

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/CommonProxyManager.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/CommonProxyManager.java
@@ -17,6 +17,24 @@ import org.dcm4che3.util.Base64;
  */
 public class CommonProxyManager implements ProxyManager {
 
+	private static String PROVIDER_NAME = "org.dcm4che";
+	private static String VERSION = "1.0";
+	
+	@Override
+	public String getProviderName() {
+		return PROVIDER_NAME;
+	}
+
+	@Override
+	public String getVersion() {
+		return VERSION;
+	}
+
+	
+	public static void main(String[] args) {
+		ProxyService.getInstance().getProxyManager("org.dcm4che", "1.0");
+	}
+	
 	@Override
 	public void doProxyHandshake(Socket s, String hostname, int port,
 			String userauth, int connectTimeout) throws IOException {
@@ -77,5 +95,4 @@ public class CommonProxyManager implements ProxyManager {
             return rsp;
         }
     }
-
 }

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/ProxyManager.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/ProxyManager.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.net.Socket;
 
 /**
- * Define operation for proxy authentication processing
+ * Define Service Provider Interface for proxy manager (authentication processing)
  *
  * @author Amaury Pernette
  * 
@@ -13,5 +13,8 @@ public interface ProxyManager {
 
 	void doProxyHandshake(final Socket s, final String hostname, final int port, final String userauth,
 			final int connectTimeout) throws IOException;
+	
+	String getProviderName();
+	String getVersion();
 	
 }

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/ProxyManager.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/ProxyManager.java
@@ -1,0 +1,17 @@
+package org.dcm4che3.net.proxy;
+
+import java.io.IOException;
+import java.net.Socket;
+
+/**
+ * Define operation for proxy authentication processing
+ *
+ * @author Amaury Pernette
+ * 
+ */
+public interface ProxyManager {
+
+	void doProxyHandshake(final Socket s, final String hostname, final int port, final String userauth,
+			final int connectTimeout) throws IOException;
+	
+}

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/ProxyService.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/ProxyService.java
@@ -1,0 +1,75 @@
+package org.dcm4che3.net.proxy;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.TreeMap;
+
+/**
+ * Service that retrieves the Service Provider Implementations of Proxy Manager.
+ * 
+ * @author Amaury Pernette
+ *
+ */
+public class ProxyService {
+
+	// Initialize-on-Demand Holder Class Idiom
+	private static class SingletonHolder {
+		private static ProxyService service = new ProxyService();
+	}
+	
+	private Map<String, Map<String, ProxyManager>> managersModel;
+	
+	private ProxyService() {
+		this.managersModel = new HashMap<String, Map<String,ProxyManager>>();		
+		final ServiceLoader<ProxyManager> loader = ServiceLoader.load(ProxyManager.class);
+		// Load managers in internal model
+		final Iterator<ProxyManager> managers = loader.iterator();
+		while (managers.hasNext()) {
+			final ProxyManager proxyManager = managers.next();			
+			// Manager provider map
+			final String providerName = proxyManager.getProviderName();
+			if(!this.managersModel.containsKey(providerName)) {
+				this.managersModel.put(providerName, new TreeMap<String, ProxyManager>());
+			}
+			final Map<String, ProxyManager> providerManagers = this.managersModel.get(providerName);
+			// Manager version
+			final String version = proxyManager.getVersion();
+			providerManagers.put(version, proxyManager);
+		}
+	}
+	
+	public static synchronized ProxyService getInstance() {
+		return SingletonHolder.service;
+//		if(service == null){
+//			service = new ProxyService();
+//		}
+//		return service;
+	}
+	
+	public ProxyManager getProxyManager(final String managerProviderName, final String managerVersion) {
+		if(managerProviderName != null && !managerProviderName.isEmpty()){
+			// Get managers for this provider
+			final Map<String, ProxyManager> providerManagers = this.managersModel.get(managerProviderName);
+			if(providerManagers != null && !providerManagers.isEmpty()) {
+				ProxyManager manager = null;
+				if(managerVersion != null && !managerVersion.isEmpty()) {
+					// Get specific version
+					manager = providerManagers.get(managerVersion);
+				}
+				// If no specified version or unavailable version : get the last available
+				if(manager == null) {
+					final List<String> versions = new ArrayList<String>(providerManagers.keySet());
+					Collections.reverse(versions);
+					manager = providerManagers.get(versions.get(0));
+				}
+			}				
+		}
+		return null;
+	}
+}

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/ProxyService.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/proxy/ProxyService.java
@@ -18,6 +18,9 @@ import java.util.TreeMap;
  */
 public class ProxyService {
 
+	private static String DEFAULT_PROVIDER_NAME = BasicProxyManager.PROVIDER_NAME;
+	private static String DEFAULT_VERSION = BasicProxyManager.VERSION;
+	
 	// Initialize-on-Demand Holder Class Idiom
 	private static class SingletonHolder {
 		private static ProxyService service = new ProxyService();
@@ -46,10 +49,6 @@ public class ProxyService {
 	
 	public static synchronized ProxyService getInstance() {
 		return SingletonHolder.service;
-//		if(service == null){
-//			service = new ProxyService();
-//		}
-//		return service;
 	}
 	
 	public ProxyManager getProxyManager(final String managerProviderName, final String managerVersion) {
@@ -61,15 +60,31 @@ public class ProxyService {
 				if(managerVersion != null && !managerVersion.isEmpty()) {
 					// Get specific version
 					manager = providerManagers.get(managerVersion);
-				}
-				// If no specified version or unavailable version : get the last available
-				if(manager == null) {
+				} else {
+					// If no specified version : get the last available
 					final List<String> versions = new ArrayList<String>(providerManagers.keySet());
 					Collections.reverse(versions);
 					manager = providerManagers.get(versions.get(0));
 				}
+				return manager;
 			}				
 		}
 		return null;
+	}
+	
+	public ProxyManager getDefaultProxyManager() {
+		return getProxyManager(DEFAULT_PROVIDER_NAME, DEFAULT_VERSION);
+	}
+	
+	public List<String> getAvailableProviders() {
+		return new ArrayList<String>(this.managersModel.keySet());
+	}
+
+	public List<String> getAvailableVersionsFor(final String provider) {
+		final List<String> versions = new ArrayList<String>();
+		if(this.managersModel.containsKey(provider)){
+			versions.addAll(this.managersModel.get(provider).keySet());
+		}
+		return versions;
 	}
 }

--- a/dcm4che-net/src/main/resources/META-INF/services/org.dcm4che3.net.proxy.ProxyManager
+++ b/dcm4che-net/src/main/resources/META-INF/services/org.dcm4che3.net.proxy.ProxyManager
@@ -1,0 +1,1 @@
+org.dcm4che3.net.proxy.BasicProxyManager


### PR DESCRIPTION
**Goal :** delegate "Proxy Handshake" of *Connection* class in a simple manager (strategy pattern) and get "entry point" to define new handshake algorithm.

In summary, I created a new interface *ProxyManager* with the *doProxyHandshake(...)* method and defined a *CommonProxyManager* class with the current implementation of *Connection* class.
We can now define new implementation (with new manager) and programmatically set the new algorithm to realize a custom handshake.
So, I don't change the current mechanism and just create entry point.

I need this to implement a Digest authentication (and maybe more).
What do you think about ?
