### PR TITLE
[LIB-433] Use of multiple character sets may lead to incorrectly en- and decoded strings

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/StringValueType.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/StringValueType.java
@@ -47,15 +47,15 @@ import org.dcm4che3.util.StringUtils;
  * @author Gunter Zeilinger <gunterze@gmail.com>
  */
 enum StringValueType implements ValueType {
-    ASCII(false, true, null, null),
-    STRING(true, true, "\\", null),
-    TEXT(true, false, "\n\f\r", null),
-    UR(false, false, null, null),
-    DA(false, true, null, TemporalType.DA),
-    DT(false, true, null, TemporalType.DT),
-    TM(false, true, null, TemporalType.TM),
-    PN(true, true, "^=\\", null),
-    DS(false, true, null, null) {
+    ASCII(false, true, null),
+    STRING(true, true, null),
+    TEXT(true, false, null),
+    UR(false, false, null),
+    DA(false, true, TemporalType.DA),
+    DT(false, true, TemporalType.DT),
+    TM(false, true, TemporalType.TM),
+    PN(true, true, null),
+    DS(false, true, null) {
 
         @Override
         public byte[] toBytes(Object val, SpecificCharacterSet cs) {
@@ -63,7 +63,7 @@ enum StringValueType implements ValueType {
             if (val instanceof double[])
                 val = toStrings((double[]) val);
             return super.toBytes(val, cs);
-        } 
+        }
 
         @Override
         public String toString(Object val, boolean bigEndian, int valueIndex,
@@ -77,7 +77,7 @@ enum StringValueType implements ValueType {
                                 : defVal;
             }
             return super.toString(val, bigEndian, valueIndex, defVal);
-        } 
+        }
 
         @Override
         public Object toStrings(Object val, boolean bigEndian,
@@ -106,7 +106,7 @@ enum StringValueType implements ValueType {
             return valueIndex < ds.length && !Double.isNaN(ds[valueIndex])
                     ? (float) ds[valueIndex]
                     : defVal;
-        } 
+        }
 
         @Override
         public float[] toFloats(Object val, boolean bigEndian) {
@@ -124,7 +124,7 @@ enum StringValueType implements ValueType {
             return valueIndex < ds.length && !Double.isNaN(ds[valueIndex])
                     ? ds[valueIndex]
                     : defVal;
-        } 
+        }
 
         @Override
         public double[] toDoubles(Object val, boolean bigEndian) {
@@ -143,7 +143,7 @@ enum StringValueType implements ValueType {
             for (int i = 0; i < fs.length; i++)
                 ss[i] = StringUtils.formatDS(fs[i]);
             return ss;
-        } 
+        }
 
         @Override
         public Object toValue(double[] ds, boolean bigEndian) {
@@ -151,7 +151,7 @@ enum StringValueType implements ValueType {
                 return Value.NULL;
 
             return ds;
-        } 
+        }
 
         @Override
         public boolean prompt(Object val, boolean bigEndian,
@@ -161,7 +161,7 @@ enum StringValueType implements ValueType {
             return super.prompt(val, bigEndian, cs, maxChars, sb);
         }
     },
-    IS(false, true, null, null) {
+    IS(false, true, null) {
 
         @Override
         public boolean isIntValue() {
@@ -174,7 +174,7 @@ enum StringValueType implements ValueType {
             if (val instanceof int[])
                 val = toStrings((int[]) val);
             return super.toBytes(val, cs);
-        } 
+        }
 
         @Override
         public String toString(Object val, boolean bigEndian, int valueIndex,
@@ -188,7 +188,7 @@ enum StringValueType implements ValueType {
                                 : defVal;
             }
             return super.toString(val, bigEndian, valueIndex, defVal);
-        } 
+        }
 
         @Override
         public Object toStrings(Object val, boolean bigEndian,
@@ -217,7 +217,7 @@ enum StringValueType implements ValueType {
             return valueIndex < is.length && is[valueIndex] != Integer.MIN_VALUE
                     ? is[valueIndex]
                     : defVal;
-        } 
+        }
 
         @Override
         public int[] toInts(Object val, boolean bigEndian) {
@@ -230,7 +230,7 @@ enum StringValueType implements ValueType {
                 return Value.NULL;
 
             return is;
-        } 
+        }
 
         @Override
         public boolean prompt(Object val, boolean bigEndian,
@@ -243,16 +243,13 @@ enum StringValueType implements ValueType {
 
     final boolean useSpecificCharacterSet;
     final boolean multipleValues;
-    final String delimiters;
     final TemporalType temporalType; 
 
-    StringValueType(boolean useSpecificCharacterSet, boolean multipleValues,
-                    String delimiters, TemporalType temperalType) {
+    StringValueType(boolean useSpecificCharacterSet, boolean multipleValues, TemporalType temporalType) {
         this.useSpecificCharacterSet = useSpecificCharacterSet;
         this.multipleValues = multipleValues;
-        this.delimiters = delimiters;
-        this.temporalType = temperalType;
-   }
+        this.temporalType = temporalType;
+    }
 
     @Override
     public boolean isStringValue() {
@@ -295,14 +292,13 @@ enum StringValueType implements ValueType {
             return (byte[]) val;
 
         if (val instanceof String)
-            return cs(cs).encode((String) val, delimiters);
+            return cs(cs).encode((String) val, this);
 
         if (val instanceof String[])
-            return cs(cs).encode(
-                    StringUtils.concat((String[]) val, '\\'), delimiters);
+            return cs(cs).encode(StringUtils.concat((String[]) val, '\\'), this);
 
         throw new UnsupportedOperationException();
-    } 
+    }
 
     @Override
     public String toString(Object val, boolean bigEndian, int valueIndex,
@@ -319,14 +315,14 @@ enum StringValueType implements ValueType {
         }
 
         throw new UnsupportedOperationException();
-    } 
+    }
 
     @Override
     public Object toStrings(Object val, boolean bigEndian,
             SpecificCharacterSet cs) {
 
         if (val instanceof byte[]) {
-            String s = cs(cs).decode((byte[]) val);
+            String s = cs(cs).decode((byte[]) val, this);
             return multipleValues ? StringUtils.splitAndTrim(s, '\\') : StringUtils.trimTrailing(s);
         }
 
@@ -335,41 +331,40 @@ enum StringValueType implements ValueType {
             return val;
 
         throw new UnsupportedOperationException();
-    } 
+    }
 
     @Override
     public int toInt(Object val, boolean bigEndian, int valueIndex,
             int defVal) {
         throw new UnsupportedOperationException();
-    } 
+    }
 
     @Override
     public int[] toInts(Object val, boolean bigEndian) {
         throw new UnsupportedOperationException();
-    } 
+    }
 
     @Override
     public float toFloat(Object val, boolean bigEndian, int valueIndex,
             float defVal) {
         throw new UnsupportedOperationException();
-    } 
+    }
 
     @Override
     public float[] toFloats(Object val, boolean bigEndian) {
         throw new UnsupportedOperationException();
-    } 
+    }
 
     @Override
     public double toDouble(Object val, boolean bigEndian, int valueIndex,
             double defVal) {
         throw new UnsupportedOperationException();
-    } 
+    }
 
     @Override
     public double[] toDoubles(Object val, boolean bigEndian) {
         throw new UnsupportedOperationException();
-    } 
-
+    }
 
     @Override
     public Date toDate(Object val, TimeZone tz, int valueIndex, boolean ceil,
@@ -420,7 +415,7 @@ enum StringValueType implements ValueType {
     @Override
     public Object toValue(byte[] b) {
         return b != null && b.length > 0 ? b : Value.NULL;
-    } 
+    }
 
     @Override
     public Object toValue(String s, boolean bigEndian) {
@@ -428,7 +423,7 @@ enum StringValueType implements ValueType {
             return Value.NULL;
 
         return s;
-    } 
+    }
 
     @Override
     public Object toValue(String[] ss, boolean bigEndian) {
@@ -439,22 +434,22 @@ enum StringValueType implements ValueType {
             return toValue(ss[0], bigEndian);
 
         return ss;
-    } 
+    }
 
     @Override
     public Object toValue(int[] is, boolean bigEndian) {
         throw new UnsupportedOperationException();
-    } 
+    }
 
     @Override
     public Object toValue(float[] fs, boolean bigEndian) {
         throw new UnsupportedOperationException();
-    } 
+    }
 
     @Override
     public Object toValue(double[] ds, boolean bigEndian) {
         throw new UnsupportedOperationException();
-    } 
+    }
 
     @Override
     public Object toValue(Date[] ds, TimeZone tz, DatePrecision precision) {
@@ -478,7 +473,7 @@ enum StringValueType implements ValueType {
     public boolean prompt(Object val, boolean bigEndian,
             SpecificCharacterSet cs, int maxChars, StringBuilder sb) {
         if (val instanceof byte[])
-            return prompt(cs(cs).decode((byte[]) val), maxChars, sb);
+            return prompt(cs(cs).decode((byte[]) val, this), maxChars, sb);
 
         if (val instanceof String)
             return prompt((String) val, maxChars, sb);
@@ -527,4 +522,5 @@ enum StringValueType implements ValueType {
 
         throw new UnsupportedOperationException();
     }
+
 }

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/SpecificCharacterSetTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/SpecificCharacterSetTest.java
@@ -39,20 +39,16 @@
 package org.dcm4che3.data;
 
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
-import org.dcm4che3.data.SpecificCharacterSet;
 import org.junit.Test;
-
-import java.nio.charset.Charset;
 
 /**
  * @author Gunter Zeilinger <gunterze@gmail.com>
  */
 public class SpecificCharacterSetTest {
 
-    private static final String LT_DELIMS = "\n\f\r";
-    private static final String PN_DELIMS = "^=\\";
     private static final String GERMAN_PERSON_NAME = "Äneas^Rüdiger";
     private static final String FRENCH_PERSON_NAME = "Buc^Jérôme";
     private static final String RUSSIAN_PERSON_NAME = "Люкceмбypг";
@@ -65,19 +61,23 @@ public class SpecificCharacterSetTest {
             "ﾔﾏﾀﾞ^ﾀﾛｳ=山田^太郎=やまだ^たろう";
     private static final String KOREAN_PERSON_NAME =
             "Hong^Gildong=洪^吉洞=홍^길동";
-    private static final String KOREAN_LONG_TEXT = 
-            "The 1st line includes 길동.\r\n" +
-            "The 2nd line includes 길동, too.\r\n" +
-            "The 3rd line.";
+    private static final String KOREAN_LONG_TEXT =
+            "The first line includes 한글.\r\n" +
+            "The second line includes 한글, too.\r\n" +
+            "The third line";
     private static final String CHINESE_PERSON_NAME_GB2312 =
             "Zhang^XiaoDong=张^小东=";
     private static final String CHINESE_LONG_TEXT_GB2312 =
             "1.第一行文字。\r\n" +
-            "2.第一行文字。\r\n" +
-            "3.第一行文字。\r\n";
+            "2.第二行文字。\r\n" +
+            "3.第三行文字。\r\n";
     private static final String CHINESE_PERSON_NAME_UTF8 =
             "Wang^XiaoDong=王^小東=";
-    private static final String CHINESE_PERSON_NAME_GB18030 =
+    private static final String CHINESE_LONG_TEXT_UTF8_GB18030 =
+            "The first line includes 中文.\r\n" +
+            "The second line includes 中文, too.\r\n" +
+            "The third line.";
+    private static final String CHINESE_PERSON_NAME_GB18030_GBK =
             "Wang^XiaoDong=王^小东=";
 
     private static final byte[] GERMAN_PERSON_NAME_BYTE = {
@@ -118,7 +118,7 @@ public class SpecificCharacterSetTest {
             (byte) 0x24, (byte) 0x5e, (byte) 0x24, (byte) 0x40, (byte) 0x1b,
             (byte) 0x28, (byte) 0x42, (byte) 0x5e, (byte) 0x1b, (byte) 0x24,
             (byte) 0x42, (byte) 0x24, (byte) 0x3f, (byte) 0x24, (byte) 0x6d,
-            (byte) 0x24, (byte) 0x26, (byte) 0x1b, (byte) 0x28, (byte) 0x42 };
+            (byte) 0x24, (byte) 0x26 };
 
     private static final byte[] JAPANESE_PERSON_NAME_JISX0201_BYTES = {
             (byte) 0xd4, (byte) 0xcf, (byte) 0xc0, (byte) 0xde, (byte) 0x5e,
@@ -131,8 +131,7 @@ public class SpecificCharacterSetTest {
             (byte) 0x64, (byte) 0x24, (byte) 0x5e, (byte) 0x24, (byte) 0x40,
             (byte) 0x1b, (byte) 0x28, (byte) 0x4a, (byte) 0x5e, (byte) 0x1b,
             (byte) 0x24, (byte) 0x42, (byte) 0x24, (byte) 0x3f, (byte) 0x24,
-            (byte) 0x6d, (byte) 0x24, (byte) 0x26, (byte) 0x1b, (byte) 0x28,
-            (byte) 0x4a };
+            (byte) 0x6d, (byte) 0x24, (byte) 0x26 };
 
     private static final byte[] KOREAN_PERSON_NAME_BYTES = {
             (byte) 0x48, (byte) 0x6f, (byte) 0x6e, (byte) 0x67, (byte) 0x5e,
@@ -146,46 +145,47 @@ public class SpecificCharacterSetTest {
             (byte) 0xb1, (byte) 0xe6, (byte) 0xb5, (byte) 0xbf };
 
     private static final byte[] KOREAN_LONG_TEXT_BYTES = {
-            (byte) 0x1b, (byte) 0x24, (byte) 0x29, (byte) 0x43, (byte) 0x54,
-            (byte) 0x68, (byte) 0x65, (byte) 0x20, (byte) 0x31, (byte) 0x73,
-            (byte) 0x74, (byte) 0x20, (byte) 0x6c, (byte) 0x69, (byte) 0x6e,
-            (byte) 0x65, (byte) 0x20, (byte) 0x69, (byte) 0x6e, (byte) 0x63,
-            (byte) 0x6c, (byte) 0x75, (byte) 0x64, (byte) 0x65, (byte) 0x73,
-            (byte) 0x20, (byte) 0xb1, (byte) 0xe6, (byte) 0xb5, (byte) 0xbf,
-            (byte) 0x2e, (byte) 0x0d, (byte) 0x0a, (byte) 0x1b, (byte) 0x24,
-            (byte) 0x29, (byte) 0x43, (byte) 0x54, (byte) 0x68, (byte) 0x65,
-            (byte) 0x20, (byte) 0x32, (byte) 0x6e, (byte) 0x64, (byte) 0x20,
+            (byte) 0x54, (byte) 0x68, (byte) 0x65, (byte) 0x20, (byte) 0x66,
+            (byte) 0x69, (byte) 0x72, (byte) 0x73, (byte) 0x74, (byte) 0x20,
             (byte) 0x6c, (byte) 0x69, (byte) 0x6e, (byte) 0x65, (byte) 0x20,
             (byte) 0x69, (byte) 0x6e, (byte) 0x63, (byte) 0x6c, (byte) 0x75,
-            (byte) 0x64, (byte) 0x65, (byte) 0x73, (byte) 0x20, (byte) 0xb1,
-            (byte) 0xe6, (byte) 0xb5, (byte) 0xbf, (byte) 0x2c, (byte) 0x20,
+            (byte) 0x64, (byte) 0x65, (byte) 0x73, (byte) 0x20, (byte) 0x1b,
+            (byte) 0x24, (byte) 0x29, (byte) 0x43, (byte) 0xc7, (byte) 0xd1,
+            (byte) 0xb1, (byte) 0xdb, (byte) 0x2e, (byte) 0x0d, (byte) 0x0a,
+            (byte) 0x54, (byte) 0x68, (byte) 0x65, (byte) 0x20, (byte) 0x73,
+            (byte) 0x65, (byte) 0x63, (byte) 0x6f, (byte) 0x6e, (byte) 0x64,
+            (byte) 0x20, (byte) 0x6c, (byte) 0x69, (byte) 0x6e, (byte) 0x65,
+            (byte) 0x20, (byte) 0x69, (byte) 0x6e, (byte) 0x63, (byte) 0x6c,
+            (byte) 0x75, (byte) 0x64, (byte) 0x65, (byte) 0x73, (byte) 0x20,
+            (byte) 0x1b, (byte) 0x24, (byte) 0x29, (byte) 0x43, (byte) 0xc7,
+            (byte) 0xd1, (byte) 0xb1, (byte) 0xdb, (byte) 0x2c, (byte) 0x20,
             (byte) 0x74, (byte) 0x6f, (byte) 0x6f, (byte) 0x2e, (byte) 0x0d,
             (byte) 0x0a, (byte) 0x54, (byte) 0x68, (byte) 0x65, (byte) 0x20,
-            (byte) 0x33, (byte) 0x72, (byte) 0x64, (byte) 0x20, (byte) 0x6c,
-            (byte) 0x69, (byte) 0x6e, (byte) 0x65, (byte) 0x2e };
+            (byte) 0x74, (byte) 0x68, (byte) 0x69, (byte) 0x72, (byte) 0x64,
+            (byte) 0x20, (byte) 0x6c, (byte) 0x69, (byte) 0x6e, (byte) 0x65 };
 
     private static final byte[] CHINESE_PERSON_NAME_GB2312_BYTES = {
-            (byte) 0x5A, (byte) 0x68, (byte) 0x61, (byte) 0x6E, (byte) 0x67,
-            (byte) 0x5E, (byte) 0x58, (byte) 0x69, (byte) 0x61, (byte) 0x6F,
-            (byte) 0x44, (byte) 0x6F, (byte) 0x6E, (byte) 0x67, (byte) 0x3D,
-            (byte) 0x1B, (byte) 0x24, (byte) 0x29, (byte) 0x41, (byte) 0xD5,
-            (byte) 0xC5, (byte) 0x5E, (byte) 0x1B, (byte) 0x24, (byte) 0x29,
-            (byte) 0x41, (byte) 0xD0, (byte) 0xA1, (byte) 0xB6, (byte) 0xAB,
-            (byte) 0x3D };
+            (byte) 0x5a, (byte) 0x68, (byte) 0x61, (byte) 0x6e, (byte) 0x67,
+            (byte) 0x5e, (byte) 0x58, (byte) 0x69, (byte) 0x61, (byte) 0x6f,
+            (byte) 0x44, (byte) 0x6f, (byte) 0x6e, (byte) 0x67, (byte) 0x3d,
+            (byte) 0x1b, (byte) 0x24, (byte) 0x29, (byte) 0x41, (byte) 0xd5,
+            (byte) 0xc5, (byte) 0x5e, (byte) 0x1b, (byte) 0x24, (byte) 0x29,
+            (byte) 0x41, (byte) 0xd0, (byte) 0xa1, (byte) 0xb6, (byte) 0xab,
+            (byte) 0x3d };
 
     private static final byte[] CHINESE_LONG_TEXT_GB2312_BYTES = {
-            (byte) 0x1B, (byte) 0x24, (byte) 0x29, (byte) 0x41, (byte) 0x31,
-            (byte) 0x2E, (byte) 0xB5, (byte) 0xDA, (byte) 0xD2, (byte) 0xBB,
-            (byte) 0xD0, (byte) 0xD0, (byte) 0xCE, (byte) 0xC4, (byte) 0xD7,
-            (byte) 0xD6, (byte) 0xA1, (byte) 0xA3, (byte) 0x0D, (byte) 0x0A,
-            (byte) 0x1B, (byte) 0x24, (byte) 0x29, (byte) 0x41, (byte) 0x32,
-            (byte) 0x2E, (byte) 0xB5, (byte) 0xDA, (byte) 0xD2, (byte) 0xBB,
-            (byte) 0xD0, (byte) 0xD0, (byte) 0xCE, (byte) 0xC4, (byte) 0xD7,
-            (byte) 0xD6, (byte) 0xA1, (byte) 0xA3, (byte) 0x0D, (byte) 0x0A,
-            (byte) 0x1B, (byte) 0x24, (byte) 0x29, (byte) 0x41, (byte) 0x33,
-            (byte) 0x2E, (byte) 0xB5, (byte) 0xDA, (byte) 0xD2, (byte) 0xBB,
-            (byte) 0xD0, (byte) 0xD0, (byte) 0xCE, (byte) 0xC4, (byte) 0xD7,
-            (byte) 0xD6, (byte) 0xA1, (byte) 0xA3, (byte) 0x0D, (byte) 0x0A };
+            (byte) 0x31, (byte) 0x2e, (byte) 0x1b, (byte) 0x24, (byte) 0x29,
+            (byte) 0x41, (byte) 0xb5, (byte) 0xda, (byte) 0xd2, (byte) 0xbb,
+            (byte) 0xd0, (byte) 0xd0, (byte) 0xce, (byte) 0xc4, (byte) 0xd7,
+            (byte) 0xd6, (byte) 0xa1, (byte) 0xa3, (byte) 0x0d, (byte) 0x0a,
+            (byte) 0x32, (byte) 0x2e, (byte) 0x1b, (byte) 0x24, (byte) 0x29,
+            (byte) 0x41, (byte) 0xb5, (byte) 0xda, (byte) 0xb6, (byte) 0xfe,
+            (byte) 0xd0, (byte) 0xd0, (byte) 0xce, (byte) 0xc4, (byte) 0xd7,
+            (byte) 0xd6, (byte) 0xa1, (byte) 0xa3, (byte) 0x0d, (byte) 0x0a,
+            (byte) 0x33, (byte) 0x2e, (byte) 0x1b, (byte) 0x24, (byte) 0x29,
+            (byte) 0x41, (byte) 0xb5, (byte) 0xda, (byte) 0xc8, (byte) 0xfd,
+            (byte) 0xd0, (byte) 0xd0, (byte) 0xce, (byte) 0xc4, (byte) 0xd7,
+            (byte) 0xd6, (byte) 0xa1, (byte) 0xa3, (byte) 0x0d, (byte) 0x0a };
 
     private static final byte[] CHINESE_PERSON_NAME_UTF8_BYTES = {
             (byte) 0x57, (byte) 0x61, (byte) 0x6e, (byte) 0x67, (byte) 0x5e,
@@ -194,7 +194,46 @@ public class SpecificCharacterSetTest {
             (byte) 0x8e, (byte) 0x8b, (byte) 0x5e, (byte) 0xe5, (byte) 0xb0,
             (byte) 0x8f, (byte) 0xe6, (byte) 0x9d, (byte) 0xb1, (byte) 0x3d };
 
-    private static final byte[] CHINESE_PERSON_NAME_GB18030_BYTES = {
+    private static final byte[] CHINESE_LONG_TEXT_UTF8_BYTES = {
+            (byte) 0x54, (byte) 0x68, (byte) 0x65, (byte) 0x20, (byte) 0x66,
+            (byte) 0x69, (byte) 0x72, (byte) 0x73, (byte) 0x74, (byte) 0x20,
+            (byte) 0x6c, (byte) 0x69, (byte) 0x6e, (byte) 0x65, (byte) 0x20,
+            (byte) 0x69, (byte) 0x6e, (byte) 0x63, (byte) 0x6c, (byte) 0x75,
+            (byte) 0x64, (byte) 0x65, (byte) 0x73, (byte) 0x20, (byte) 0xe4,
+            (byte) 0xb8, (byte) 0xad, (byte) 0xe6, (byte) 0x96, (byte) 0x87,
+            (byte) 0x2e, (byte) 0x0d, (byte) 0x0a, (byte) 0x54, (byte) 0x68,
+            (byte) 0x65, (byte) 0x20, (byte) 0x73, (byte) 0x65, (byte) 0x63,
+            (byte) 0x6f, (byte) 0x6e, (byte) 0x64, (byte) 0x20, (byte) 0x6c,
+            (byte) 0x69, (byte) 0x6e, (byte) 0x65, (byte) 0x20, (byte) 0x69,
+            (byte) 0x6e, (byte) 0x63, (byte) 0x6c, (byte) 0x75, (byte) 0x64,
+            (byte) 0x65, (byte) 0x73, (byte) 0x20, (byte) 0xe4, (byte) 0xb8,
+            (byte) 0xad, (byte) 0xe6, (byte) 0x96, (byte) 0x87, (byte) 0x2c,
+            (byte) 0x20, (byte) 0x74, (byte) 0x6f, (byte) 0x6f, (byte) 0x2e,
+            (byte) 0x0d, (byte) 0x0a, (byte) 0x54, (byte) 0x68, (byte) 0x65,
+            (byte) 0x20, (byte) 0x74, (byte) 0x68, (byte) 0x69, (byte) 0x72,
+            (byte) 0x64, (byte) 0x20, (byte) 0x6c, (byte) 0x69, (byte) 0x6e,
+            (byte) 0x65, (byte) 0x2e };
+
+    private static final byte[] CHINESE_LONG_TEXT_GB18030_BYTES = {
+            (byte) 0x54, (byte) 0x68, (byte) 0x65, (byte) 0x20, (byte) 0x66,
+            (byte) 0x69, (byte) 0x72, (byte) 0x73, (byte) 0x74, (byte) 0x20,
+            (byte) 0x6c, (byte) 0x69, (byte) 0x6e, (byte) 0x65, (byte) 0x20,
+            (byte) 0x69, (byte) 0x6e, (byte) 0x63, (byte) 0x6c, (byte) 0x75,
+            (byte) 0x64, (byte) 0x65, (byte) 0x73, (byte) 0x20, (byte) 0xd6,
+            (byte) 0xd0, (byte) 0xce, (byte) 0xc4, (byte) 0x2e, (byte) 0x0d,
+            (byte) 0x0a, (byte) 0x54, (byte) 0x68, (byte) 0x65, (byte) 0x20,
+            (byte) 0x73, (byte) 0x65, (byte) 0x63, (byte) 0x6f, (byte) 0x6e,
+            (byte) 0x64, (byte) 0x20, (byte) 0x6c, (byte) 0x69, (byte) 0x6e,
+            (byte) 0x65, (byte) 0x20, (byte) 0x69, (byte) 0x6e, (byte) 0x63,
+            (byte) 0x6c, (byte) 0x75, (byte) 0x64, (byte) 0x65, (byte) 0x73,
+            (byte) 0x20, (byte) 0xd6, (byte) 0xd0, (byte) 0xce, (byte) 0xc4,
+            (byte) 0x2c, (byte) 0x20, (byte) 0x74, (byte) 0x6f, (byte) 0x6f,
+            (byte) 0x2e, (byte) 0x0d, (byte) 0x0a, (byte) 0x54, (byte) 0x68,
+            (byte) 0x65, (byte) 0x20, (byte) 0x74, (byte) 0x68, (byte) 0x69,
+            (byte) 0x72, (byte) 0x64, (byte) 0x20, (byte) 0x6c, (byte) 0x69,
+            (byte) 0x6e, (byte) 0x65, (byte) 0x2e };
+
+    private static final byte[] CHINESE_PERSON_NAME_GB18030_GBK_BYTES = {
             (byte) 0x57, (byte) 0x61, (byte) 0x6e, (byte) 0x67, (byte) 0x5e,
             (byte) 0x58, (byte) 0x69, (byte) 0x61, (byte) 0x6f, (byte) 0x44,
             (byte) 0x6f, (byte) 0x6e, (byte) 0x67, (byte) 0x3d, (byte) 0xcd,
@@ -222,23 +261,19 @@ public class SpecificCharacterSetTest {
     }
 
     private SpecificCharacterSet jisX0208() {
-        return SpecificCharacterSet.valueOf(
-                new String[] { null, "ISO 2022 IR 87" });
+        return SpecificCharacterSet.valueOf(new String[] { null, "ISO 2022 IR 87" });
     }
 
     private SpecificCharacterSet jisX0201() {
-        return SpecificCharacterSet.valueOf(
-                new String[] { "ISO 2022 IR 13", "ISO 2022 IR 87" });
+        return SpecificCharacterSet.valueOf(new String[] { "ISO 2022 IR 13", "ISO 2022 IR 87" });
     }
 
     private SpecificCharacterSet ksx1001() {
-        return SpecificCharacterSet.valueOf(
-                new String[] { null, "ISO 2022 IR 149" });
+        return SpecificCharacterSet.valueOf(new String[] { null, "ISO 2022 IR 149" });
     }
 
     private SpecificCharacterSet gb2312() {
-        return SpecificCharacterSet.valueOf(
-                new String[] { null, "ISO 2022 IR 58" });
+        return SpecificCharacterSet.valueOf(new String[] { null, "ISO 2022 IR 58" });
     }
 
     private SpecificCharacterSet utf8() {
@@ -256,181 +291,205 @@ public class SpecificCharacterSetTest {
     @Test
     public void testEncodeGermanPersonName() {
         assertArrayEquals(GERMAN_PERSON_NAME_BYTE,
-                iso8859_1().encode(GERMAN_PERSON_NAME, PN_DELIMS));
+                iso8859_1().encode(GERMAN_PERSON_NAME, StringValueType.PN));
     }
 
     @Test
     public void testDecodeGermanPersonName() {
         assertEquals(GERMAN_PERSON_NAME,
-                iso8859_1().decode(GERMAN_PERSON_NAME_BYTE));
+                iso8859_1().decode(GERMAN_PERSON_NAME_BYTE, StringValueType.PN));
     }
 
     @Test
     public void testEncodeFrenchPersonName() {
         assertArrayEquals(FRENCH_PERSON_NAME_BYTE,
-                iso8859_1().encode(FRENCH_PERSON_NAME, PN_DELIMS));
+                iso8859_1().encode(FRENCH_PERSON_NAME, StringValueType.PN));
     }
 
     @Test
     public void testDecodeFrenchPersonName() {
         assertEquals(FRENCH_PERSON_NAME,
-                iso8859_1().decode(FRENCH_PERSON_NAME_BYTE));
+                iso8859_1().decode(FRENCH_PERSON_NAME_BYTE, StringValueType.PN));
     }
 
     @Test
     public void testEncodeRussianPersonName() {
         assertArrayEquals(RUSSIAN_PERSON_NAME_BYTE,
-                iso8859_5().encode(RUSSIAN_PERSON_NAME, PN_DELIMS));
+                iso8859_5().encode(RUSSIAN_PERSON_NAME, StringValueType.PN));
     }
 
     @Test
     public void testDecodeRussianPersonName() {
         assertEquals(RUSSIAN_PERSON_NAME,
-                iso8859_5().decode(RUSSIAN_PERSON_NAME_BYTE));
+                iso8859_5().decode(RUSSIAN_PERSON_NAME_BYTE, StringValueType.PN));
     }
 
     @Test
     public void testEncodeArabicPersonName() {
         assertArrayEquals(ARABIC_PERSON_NAME_BYTE,
-                iso8859_6().encode(ARABIC_PERSON_NAME, PN_DELIMS));
+                iso8859_6().encode(ARABIC_PERSON_NAME, StringValueType.PN));
     }
 
     @Test
     public void testDecodeArabicPersonName() {
         assertEquals(ARABIC_PERSON_NAME,
-                iso8859_6().decode(ARABIC_PERSON_NAME_BYTE));
+                iso8859_6().decode(ARABIC_PERSON_NAME_BYTE, StringValueType.PN));
     }
 
     @Test
     public void testEncodeGreekPersonName() {
         assertArrayEquals(GREEK_PERSON_NAME_BYTE,
-                iso8859_7().encode(GREEK_PERSON_NAME, PN_DELIMS));
+                iso8859_7().encode(GREEK_PERSON_NAME, StringValueType.PN));
     }
 
     @Test
     public void testDecodeGreekPersonName() {
         assertEquals(GREEK_PERSON_NAME,
-                iso8859_7().decode(GREEK_PERSON_NAME_BYTE));
+                iso8859_7().decode(GREEK_PERSON_NAME_BYTE, StringValueType.PN));
     }
 
     @Test
     public void testEncodeHebrewPersonName() {
         assertArrayEquals(HEBREW_PERSON_NAME_BYTE,
-                iso8859_8().encode(HEBREW_PERSON_NAME, PN_DELIMS));
+                iso8859_8().encode(HEBREW_PERSON_NAME, StringValueType.PN));
     }
 
     @Test
     public void testDecodeHebrewPersonName() {
         assertEquals(HEBREW_PERSON_NAME,
-                iso8859_8().decode(HEBREW_PERSON_NAME_BYTE));
+                iso8859_8().decode(HEBREW_PERSON_NAME_BYTE, StringValueType.PN));
     }
 
     @Test
     public void testEncodeJapanesePersonNameASCII() {
         assertArrayEquals(JAPANESE_PERSON_NAME_ASCII_BYTES,
-                jisX0208().encode(JAPANESE_PERSON_NAME_ASCII, PN_DELIMS));
+                jisX0208().encode(JAPANESE_PERSON_NAME_ASCII, StringValueType.PN));
     }
 
     @Test
     public void testDecodeJapanesePersonNameASCII() {
         assertEquals(JAPANESE_PERSON_NAME_ASCII,
-                jisX0208().decode(JAPANESE_PERSON_NAME_ASCII_BYTES));
+                jisX0208().decode(JAPANESE_PERSON_NAME_ASCII_BYTES, StringValueType.PN));
     }
 
-     @Test
+    @Test
     public void testEncodeJapanesePersonNameJISX0201() {
         assertArrayEquals(JAPANESE_PERSON_NAME_JISX0201_BYTES,
-                jisX0201().encode(JAPANESE_PERSON_NAME_JISX0201, PN_DELIMS));
+                jisX0201().encode(JAPANESE_PERSON_NAME_JISX0201, StringValueType.PN));
     }
 
     @Test
     public void testDecodeJapanesePersonNameJISX0201() {
         assertEquals(JAPANESE_PERSON_NAME_JISX0201,
-                jisX0201().decode(JAPANESE_PERSON_NAME_JISX0201_BYTES));
+                jisX0201().decode(JAPANESE_PERSON_NAME_JISX0201_BYTES, StringValueType.PN));
     }
 
     @Test
     public void testEncodeKoreanPersonName() {
         assertArrayEquals(KOREAN_PERSON_NAME_BYTES,
-                ksx1001().encode(KOREAN_PERSON_NAME, PN_DELIMS));
+                ksx1001().encode(KOREAN_PERSON_NAME, StringValueType.PN));
     }
 
     @Test
     public void testDecodeKoreanPersonName() {
         assertEquals(KOREAN_PERSON_NAME,
-                ksx1001().decode(KOREAN_PERSON_NAME_BYTES));
+                ksx1001().decode(KOREAN_PERSON_NAME_BYTES, StringValueType.PN));
     }
 
     @Test
     public void testEncodeKoreanLongText() {
         assertArrayEquals(KOREAN_LONG_TEXT_BYTES,
-                ksx1001().encode(KOREAN_LONG_TEXT, LT_DELIMS));
+                ksx1001().encode(KOREAN_LONG_TEXT, StringValueType.TEXT));
     }
-    
+
     @Test
     public void testDecodeKoreanLongText() {
         assertEquals(KOREAN_LONG_TEXT,
-                ksx1001().decode(KOREAN_LONG_TEXT_BYTES));
+                ksx1001().decode(KOREAN_LONG_TEXT_BYTES, StringValueType.TEXT));
     }
 
     @Test
     public void testEncodeChinesePersonNameGB2312() {
         assertArrayEquals(CHINESE_PERSON_NAME_GB2312_BYTES,
-                gb2312().encode(CHINESE_PERSON_NAME_GB2312, PN_DELIMS));
+                gb2312().encode(CHINESE_PERSON_NAME_GB2312, StringValueType.PN));
     }
 
     @Test
     public void testDecodeChinesePersonNameGB2312() {
         assertEquals(CHINESE_PERSON_NAME_GB2312,
-                gb2312().decode(CHINESE_PERSON_NAME_GB2312_BYTES));
+                gb2312().decode(CHINESE_PERSON_NAME_GB2312_BYTES, StringValueType.PN));
     }
 
     @Test
     public void testEncodeChineseLongTextGB2312() {
         assertArrayEquals(CHINESE_LONG_TEXT_GB2312_BYTES,
-                gb2312().encode(CHINESE_LONG_TEXT_GB2312, LT_DELIMS));
+                gb2312().encode(CHINESE_LONG_TEXT_GB2312, StringValueType.TEXT));
     }
 
     @Test
     public void testDecodeChineseLongTextGB2312() {
         assertEquals(CHINESE_LONG_TEXT_GB2312,
-                gb2312().decode(CHINESE_LONG_TEXT_GB2312_BYTES));
+                gb2312().decode(CHINESE_LONG_TEXT_GB2312_BYTES, StringValueType.TEXT));
     }
 
     @Test
     public void testEncodeChinesePersonNameUTF8() {
         assertArrayEquals(CHINESE_PERSON_NAME_UTF8_BYTES,
-                utf8().encode(CHINESE_PERSON_NAME_UTF8, PN_DELIMS));
+                utf8().encode(CHINESE_PERSON_NAME_UTF8, StringValueType.PN));
     }
 
     @Test
     public void testDecodeChinesePersonNameUTF8() {
         assertEquals(CHINESE_PERSON_NAME_UTF8,
-                utf8().decode(CHINESE_PERSON_NAME_UTF8_BYTES));
+                utf8().decode(CHINESE_PERSON_NAME_UTF8_BYTES, StringValueType.PN));
+    }
+
+    @Test
+    public void testEncodeChineseLongTextUTF8() {
+        assertArrayEquals(CHINESE_LONG_TEXT_UTF8_BYTES,
+                utf8().encode(CHINESE_LONG_TEXT_UTF8_GB18030, StringValueType.TEXT));
+    }
+
+    @Test
+    public void testDecodeChineseLongTextUTF8() {
+        assertEquals(CHINESE_LONG_TEXT_UTF8_GB18030,
+                utf8().decode(CHINESE_LONG_TEXT_UTF8_BYTES, StringValueType.TEXT));
     }
 
     @Test
     public void testEncodeChinesePersonNameGB18030() {
-        assertArrayEquals(CHINESE_PERSON_NAME_GB18030_BYTES,
-                gb18030().encode(CHINESE_PERSON_NAME_GB18030, PN_DELIMS));
+        assertArrayEquals(CHINESE_PERSON_NAME_GB18030_GBK_BYTES,
+                gb18030().encode(CHINESE_PERSON_NAME_GB18030_GBK, StringValueType.PN));
     }
 
     @Test
     public void testDecodeChinesePersonNameGB18030() {
-        assertEquals(CHINESE_PERSON_NAME_GB18030,
-                gb18030().decode(CHINESE_PERSON_NAME_GB18030_BYTES));
+        assertEquals(CHINESE_PERSON_NAME_GB18030_GBK,
+                gb18030().decode(CHINESE_PERSON_NAME_GB18030_GBK_BYTES, StringValueType.PN));
+    }
+
+    @Test
+    public void testEncodeChineseLongTextGB18030() {
+        assertArrayEquals(CHINESE_LONG_TEXT_GB18030_BYTES,
+                gb18030().encode(CHINESE_LONG_TEXT_UTF8_GB18030, StringValueType.TEXT));
+    }
+
+    @Test
+    public void testDecodeChineseLongTextGB18030() {
+        assertEquals(CHINESE_PERSON_NAME_GB18030_GBK,
+                gb18030().decode(CHINESE_PERSON_NAME_GB18030_GBK_BYTES, StringValueType.TEXT));
     }
 
     @Test
     public void testEncodeChinesePersonNameGBK() {
-        assertArrayEquals(CHINESE_PERSON_NAME_GB18030_BYTES,
-                gbk().encode(CHINESE_PERSON_NAME_GB18030, PN_DELIMS));
+        assertArrayEquals(CHINESE_PERSON_NAME_GB18030_GBK_BYTES,
+                gbk().encode(CHINESE_PERSON_NAME_GB18030_GBK, StringValueType.PN));
     }
 
     @Test
     public void testDecodeChinesePersonNameGBK() {
-        assertEquals(CHINESE_PERSON_NAME_GB18030,
-                gbk().decode(CHINESE_PERSON_NAME_GB18030_BYTES));
+        assertEquals(CHINESE_PERSON_NAME_GB18030_GBK,
+                gbk().decode(CHINESE_PERSON_NAME_GB18030_GBK_BYTES, StringValueType.PN));
     }
 
 }


### PR DESCRIPTION
Proposed solution to fix [[LIB-433]](http://www.dcm4che.org/jira/browse/LIB-433)

I revised and extended the org.dcm4che3.data.SpecificCharacterSet class to:
- provide support for code extension techniques conforming to DICOM 2016c (G0 and G1 code elements may come from different character sets)
- fix the switched esc sequences of ISO 2022 IR 87 and ISO 2022 IR 159 (should be G0 esc sequences)
- fix the defined term of the default character repertoire (no value required; ISO_IR 100 should not be used, as the default character repertoire is ISO_IR 6)
- en- and decode unsupported characters according to the DICOM standard (DICOM PS3.5 2016c, 6.1.2.3 Encoding of Character Repertoires)
- encapsulate the invocation of the default/first character set for delimiters and control characters (e.g. no need to pass delimiters to the encode() method)
- avoid the inclusion of an escape sequence at the end of a data element
- add the TAB character as control character (added in DICOM 2015b)
- handle two special cases regarding ISO 2022 IR 13 (G0 identical to ISO 2022 IR 6 except two characters)

Furthermore, I adapted the org.dcm4che3.data.StringValueType class to remove the use of delimiters (the en- and decoder methods only needs to know if the VR is PN).
Last but not least, the org.dcm4che3.data.SpecificCharacterSetTest class was adapted and extended.
