### PR TITLE
Content-type needs to be properly quoted for StowRS request

### DIFF
--- a/dcm4che-tool/dcm4che-tool-stowrs/src/main/java/org/dcm4che3/tool/stowrs/StowRS.java
+++ b/dcm4che-tool/dcm4che-tool-stowrs/src/main/java/org/dcm4che3/tool/stowrs/StowRS.java
@@ -386,7 +386,7 @@ public class StowRS {
         connection.setRequestMethod("POST");
 
         String metaDataType = mediaType == StowMetaDataType.XML ? "application/dicom+xml" : "application/json";
-        connection.setRequestProperty("Content-Type", "multipart/related; type=" + metaDataType + "; boundary=" + MULTIPART_BOUNDARY);
+        connection.setRequestProperty("Content-Type", "multipart/related; type=\"" + metaDataType + "\"; boundary=" + MULTIPART_BOUNDARY);
         String bulkDataTransferSyntax = "transfer-syntax=" + transferSyntax;
 
         MediaType pixelDataMediaType = getBulkDataMediaType(metadata);
@@ -513,7 +513,7 @@ public class StowRS {
         connection.setDoInput(true);
         connection.setInstanceFollowRedirects(false);
         connection.setRequestMethod("POST");
-        connection.setRequestProperty("Content-Type", "multipart/related; type=application/dicom; boundary=" + MULTIPART_BOUNDARY);
+        connection.setRequestProperty("Content-Type", "multipart/related; type=\"application/dicom\"; boundary=" + MULTIPART_BOUNDARY);
         connection.setRequestProperty("Accept", "application/dicom+xml");
         connection.setRequestProperty("charset", "utf-8");
         connection.setUseCaches(false);


### PR DESCRIPTION
Per RFC 2387 section 3.4:
(https://tools.ietf.org/html/rfc2387#section-3.4)

   Note that the parameter values will usually require quoting.  Msg-id
   contains the special characters "<", ">", "@", and perhaps other
   special characters.  If msg-id contains quoted-strings, those quote
   marks must be escaped.  Similarly, the type parameter contains the
   special character "/".
