### PR TITLE
Proposal: add support for specifying a stop tag matching strategy …

### DIFF
--- a/dcm4che-core/src/test/java/org/dcm4che3/io/DicomInputStreamTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/io/DicomInputStreamTest.java
@@ -9,7 +9,6 @@ import org.dcm4che3.data.Tag;
 import org.dcm4che3.data.Attributes;
 import org.dcm4che3.data.Sequence;
 import org.dcm4che3.io.DicomInputStream.IncludeBulkData;
-import org.dcm4che3.io.DicomInputStream.StopTagMatchingStrategy;
 import org.junit.Test;
 
 /**
@@ -53,25 +52,23 @@ public class DicomInputStreamTest {
     }
 
     @Test
-    public void testStopStrategyExactMatch() throws Exception {
+    public void testReadDatasetExcludesStopTagByDefault() throws Exception {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         DicomInputStream in = new DicomInputStream(
                 new File(cl.getResource("OT-PAL-8-face").toURI()));
         try {
             in.setAddBulkDataReferences(true);
             in.setIncludeBulkData(IncludeBulkData.URI);
-            in.setStopTagMatchingStrategy(StopTagMatchingStrategy.ExactMatch);
-            // this stop tag doesn't exist, so the full object should be read
-            Attributes attrs = in.readDataset(-1, Tag.SeriesInstanceUID + 1);
-            assertTrue(attrs.contains(Tag.PixelData));
-            assertEquals(Tag.PixelData, in.tag());
+            Attributes attrs = in.readDataset(-1, Tag.BitsAllocated);
+            assertFalse(attrs.contains(Tag.BitsAllocated));
+            assertEquals(Tag.BitsAllocated, in.tag());
         } finally {
             in.close();
         }
     }
 
     @Test
-    public void testStopStrategyMatchOrExceedExclusive() throws Exception {
+    public void testReadDatasetIncludeStopTag() throws Exception {
 
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         DicomInputStream in = new DicomInputStream(
@@ -79,31 +76,9 @@ public class DicomInputStreamTest {
         try {
             in.setAddBulkDataReferences(true);
             in.setIncludeBulkData(IncludeBulkData.URI);
-            in.setStopTagMatchingStrategy(StopTagMatchingStrategy.MatchOrExceed);
-            // expect to stop reading dataset just before reading series iuid
-            Attributes attrs = in.readDataset(-1, Tag.SeriesInstanceUID);
-            assertTrue(!attrs.contains(Tag.SeriesInstanceUID));
-            assertEquals(Tag.SeriesInstanceUID, in.tag());
-        } finally {
-            in.close();
-        }
-    }
-
-    @Test
-    public void testStopStrategyMatchOrExceedInclusive() throws Exception {
-
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        DicomInputStream in = new DicomInputStream(
-                new File(cl.getResource("OT-PAL-8-face").toURI()));
-        try {
-            in.setAddBulkDataReferences(true);
-            in.setIncludeBulkData(IncludeBulkData.URI);
-            in.setStopTagMatchingStrategy(StopTagMatchingStrategy.MatchOrExceed);
-            // expect to stop reading dataset right after reading series iuid
-            Attributes attrs = in.readDataset(-1, Tag.SeriesInstanceUID + 1);
-            assertTrue(attrs.contains(Tag.SeriesInstanceUID));
-            // next tag after SeriesInstanceUID in this object
-            assertEquals(Tag.SeriesNumber, in.tag());
+            Attributes attrs = in.readDataset(-1, Tag.BitsAllocated, true);
+            assertTrue(attrs.contains(Tag.BitsAllocated));
+            assertEquals(Tag.BitsStored, in.tag());
         } finally {
             in.close();
         }


### PR DESCRIPTION
… when reading DICOM datasets via DicomInputStream. This would allow clients to perform [in/ex]clusive reads up to specific tags, without prior knowledge of which stop tags are actually available in the underlying stream (e.g. when using the MatchOrExceed strategy, dis.readDataset( -1, Tag.SeriesInstanceUID + 1 ) will read the stream up to and including series instance UID, leaving the stream positioned at the next element). The original implementation of this interface, and the default behaviour are preserved for backward compatibility.

@gunterze I'm interested to hear your thoughts on this approach. The problem we are trying to solve is as that we have an input stream positioned at the header of the pixel data element and would like to use DicomInputStream to read only the pixel data, leaving the underlying stream positioned at the beginning of the next tag. Essentially we want to use Tag.PixelData as the stop tag, but would like the read be inclusive of the stop tag.

An alternative interface that would satisfy this objective might look something like:

public Attributes readDataset(int len, int stopTag, boolean stopInclusive);

This approach would also satisfy our immediate need, but would still require that the client somehow predict what elements are present in the stream; which may be too restrictive. For example if we call readDataset( -1, Tag.PixelData ) but the object does not contain pixel data, then the whole stream will be read and there is no opportunity to unread those tags with values larger than 7FE00010, if present:

readDataset( -1, Tag.PixelData );
readDataset( -1, Tag.DigitalSignaturesSequence ); // too late