### PR TITLE
Fix typo in MSGID field in the HEADER of the SYSLOG -MSG in emitted Audit Message

### DIFF
--- a/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
+++ b/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
@@ -131,7 +131,7 @@ public class AuditLogger extends DeviceExtension {
         debug            // (7)  -- debug-level messages
     }
 
-    public static final String MESSAGE_ID = "IHE+RFC3881";
+    public static final String MESSAGE_ID = "IHE+RFC-3881";
 
     private static final int[] DIGITS_0X = {
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',


### PR DESCRIPTION
dcm4che/dcm4chee-arc-light#645