### PR TITLE
Fix #91 dcm4che-conf-core-api jar contains extra classes

### DIFF
--- a/dcm4che-conf/dcm4che-conf-core-api/pom.xml
+++ b/dcm4che-conf/dcm4che-conf-core-api/pom.xml
@@ -34,7 +34,7 @@
                         
                         temporary solution is export all package including internal package
                         -->
-                        <Export-Package>*</Export-Package>
+                        <Export-Package>org.dcm4che3.conf.*</Export-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Avoid exporting also org.apache.* packages.
Fixes #91.