### PR TITLE
ApplicationEntityCache: treat not installed AEs as not configured

### DIFF
--- a/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/ApplicationEntityCache.java
+++ b/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/ApplicationEntityCache.java
@@ -63,6 +63,9 @@ public class ApplicationEntityCache
         if (ae == null)
             throw new ConfigurationNotFoundException(
                     "Unknown AE: " + aet);
+        if (!ae.isInstalled())
+            throw new ConfigurationNotFoundException(
+                    "AE: " + aet + " not installed");
         return ae;
     }
 }


### PR DESCRIPTION
Do not return not installed AEs by ApplicationEntityCache.findApplicationEntity(), but throw ConfigurationNotFoundException

dcm4che/dcm4chee-arc-light#688