### PR TITLE
Fix Thread deadlock if a sending SCU sends unexpected A-RELEASE-REQ

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
@@ -475,7 +475,7 @@ public class Association {
                 try {
                     try {
                         while (!(state == State.Sta1 || state == State.Sta13))
-                            decoder.nextPDU();
+                            decoder.nextPDU( null );
                     } catch (AAbort aa) {
                         abort(aa);
                     } catch (IOException e) {

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/PDUDecoder.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/PDUDecoder.java
@@ -153,7 +153,7 @@ class PDUDecoder extends PDVInputStream {
         return getBytes(getUnsignedShort());
     }
 
-    public void nextPDU() throws IOException {
+    public void nextPDU(Integer expectedPDUType) throws IOException {
         checkThread();
         Association.LOG.trace("{}: waiting for PDU", as);
         readFully(0, 10);
@@ -163,6 +163,11 @@ class PDUDecoder extends PDVInputStream {
         pdulen = getInt();
         Association.LOG.trace("{} >> PDU[type={}, len={}]",
                 new Object[] { as, pdutype, pdulen & 0xFFFFFFFFL });
+        
+        if(expectedPDUType != null && expectedPDUType != pdutype) {
+            return;
+        }
+        
         switch (pdutype) {
         case PDUType.A_ASSOCIATE_RQ:
             readPDU();
@@ -507,7 +512,7 @@ class PDUDecoder extends PDVInputStream {
     private void nextPDV(int expectedPDVType, int expectedPCID)
             throws IOException {
         if (!hasRemaining()) {
-            nextPDU();
+            nextPDU( PDUType.P_DATA_TF );
             if (pdutype != PDUType.P_DATA_TF) {
                 Association.LOG.info(
                         "{}: Expected P-DATA-TF PDU but received PDU[type={}]",


### PR DESCRIPTION
Hi Gunther,

I just opened this pull request to make you are aware of a nasty issue.
I fixed a bug in the PDU handling that you might be interested in, as also your branch seems to be vulnerable to it. See commit: 49f22b6 on RC81
Problematic message flow:

    SCU starts DIMSE request
    SCU is sending DATA PDUs
    Suddenly in the middle of the DATA PDU stream the SCU sends an A-RELEASE-REQ (the last DATA PDU has not been sent yet)
    The association on SCP side get's deadlocked as the handling thread enters a wait() and is never woken up again.

The described SCU behavior was seen on production sides.

Reason:
Association is bound to a single thread that handles all incoming PDUs.
When sending an A-RELEASE-REQ
the Association.handleAReleaseRQ() method is called which calls waitForPerformingOps()
This method checks if the DIMSE request is still being handled (performing > 0) and if so puts the thread to WAIT. The only one that would be able to decrease performing and notify the thread would be the thread itself. So defacto the waiting thread waits for itself -> Forever.

Fix:
My fix is effective but not a clean solution (main reason was time pressure) as it just shortcuts the handling in case of unexpcted PDUs when DATA PDUs are expected. Probably you will decide to come up with a more clean approach. A clean fix would be great to be integreted into the master branch as well