### PR TITLE
dcm4che-tool-cfind: extend sample mwl.xml with keys for attributes extracted from HL7 orders by dcm4chee-arc-light

### DIFF
--- a/dcm4che-assembly/src/etc/findscu/mwl.xml
+++ b/dcm4che-assembly/src/etc/findscu/mwl.xml
@@ -1,27 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <NativeDicomModel xml:space="preserve">
-    <DicomAttribute keyword="SpecificCharacterSet" tag="00080005" vr="CS"/>
     <DicomAttribute keyword="AccessionNumber" tag="00080050" vr="SH"/>
+    <DicomAttribute keyword="IssuerOfAccessionNumberSequence" tag="00080051" vr="SQ"/>
     <DicomAttribute keyword="ReferringPhysicianName" tag="00080090" vr="PN"/>
     <DicomAttribute keyword="PatientName" tag="00100010" vr="PN"/>
     <DicomAttribute keyword="PatientID" tag="00100020" vr="LO"/>
     <DicomAttribute keyword="IssuerOfPatientID" tag="00100021" vr="LO"/>
     <DicomAttribute keyword="PatientBirthDate" tag="00100030" vr="DA"/>
     <DicomAttribute keyword="PatientSex" tag="00100040" vr="CS"/>
+    <DicomAttribute keyword="OtherPatientIDSequence" tag="00101002" vr="SQ"/>
     <DicomAttribute keyword="MedicalAlerts" tag="00102000" vr="LO"/>
     <DicomAttribute keyword="PregnancyStatus" tag="001021C0" vr="US"/>
+    <DicomAttribute keyword="PatientSpeciesDescription" tag="00102201" vr="LO"/>
+    <DicomAttribute keyword="PatientSpeciesCodeSequence" tag="00102202" vr="SQ"/>
+    <DicomAttribute keyword="Patient​Sex​Neutered" tag="00102203" vr="CS"/>
+    <DicomAttribute keyword="PatientBreedDescription" tag="00102292" vr="LO"/>
+    <DicomAttribute keyword="PatientBreedCodeSequence" tag="00102293" vr="SQ"/>
+    <DicomAttribute keyword="ResponsiblePerson" tag="00102297" vr="PN"/>
+    <DicomAttribute keyword="ResponsiblePersonRole" tag="00102298" vr="CS"/>
     <DicomAttribute keyword="StudyInstanceUID" tag="0020000D" vr="UI"/>
-    <DicomAttribute keyword="NumberOfPatientRelatedStudies" tag="00201200" vr="IS"/>
     <DicomAttribute keyword="RequestingPhysician" tag="00321032" vr="PN"/>
     <DicomAttribute keyword="RequestedProcedureDescription" tag="00321060" vr="LO"/>
+    <DicomAttribute keyword="RequestedProcedureCodeSequence" tag="00321064" vr="SQ"/>
     <DicomAttribute keyword="AdmissionID" tag="00380010" vr="LO"/>
     <DicomAttribute keyword="IssuerOfAdmissionIDSequence" tag="00380014" vr="SQ"/>
     <DicomAttribute keyword="OrderPlacerIdentifierSequence" tag="00400026" vr="SQ"/>
     <DicomAttribute keyword="OrderFillerIdentifierSequence" tag="00400027" vr="SQ"/>
     <DicomAttribute keyword="ScheduledProcedureStepSequence" tag="00400100" vr="SQ"/>
     <DicomAttribute keyword="RequestedProcedureID" tag="00401001" vr="SH"/>
+    <DicomAttribute keyword="Reason​For​The​Requested​Procedure" tag="00401002" vr="LO"/>
     <DicomAttribute keyword="RequestedProcedurePriority" tag="00401003" vr="SH"/>
     <DicomAttribute keyword="PatientTransportArrangements" tag="00401004" vr="LO"/>
+    <DicomAttribute keyword="ReasonForRequestedProcedureCodeSequence" tag="0040100A" vr="SQ"/>
     <DicomAttribute keyword="PlacerOrderNumberImagingServiceRequest" tag="00402016" vr="LO"/>
     <DicomAttribute keyword="FillerOrderNumberImagingServiceRequest" tag="00402017" vr="LO"/>
 </NativeDicomModel>


### PR DESCRIPTION
dcm4che/dcm4chee-arc-light#820