### PR TITLE
dcm4che-tools-findscu: study.csv.xsl does not convert multiple values for Specific Character Set correctly, if the first value is empty

### DIFF
--- a/dcm4che-assembly/src/etc/findscu/study.csv.xsl
+++ b/dcm4che-assembly/src/etc/findscu/study.csv.xsl
@@ -87,12 +87,12 @@
   </xsl:template>
 
   <xsl:template match="Value">
-    <xsl:if test="position()>1">\</xsl:if>
+    <xsl:if test="@number != 1">\</xsl:if>
     <xsl:value-of select="text()"/>
   </xsl:template>
 
   <xsl:template match="PersonName">
-    <xsl:if test="position()>1">\</xsl:if>
+    <xsl:if test="@number != 1">\</xsl:if>
     <xsl:apply-templates select="Alphabetic"/>
     <xsl:if test="Ideographic or Phonetic">
       <xsl:text>=</xsl:text>


### PR DESCRIPTION
dcm4che/dcm4chee-arc-light#880