### PR TITLE
DicomImageReader: Ignore embedded overlays with Overlay Bit Position < Bits Stored

### DIFF
--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/plugins/dcm/DicomImageReader.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/plugins/dcm/DicomImageReader.java
@@ -400,7 +400,11 @@ public class DicomImageReader extends ImageReader {
         int length = ovlyRows * ovlyColumns;
 
         byte[] ovlyData = new byte[(((length+7)>>>3)+1)&(~1)] ;
-        Overlays.extractFromPixeldata(raster, mask, ovlyData, 0, length);
+        if (bitPosition < bitsStored)
+            LOG.info("Ignore embedded overlay #{} from bit #{} < bits stored: {}",
+                    (gg0000 >>> 17) + 1, bitPosition, bitsStored);
+        else
+            Overlays.extractFromPixeldata(raster, mask, ovlyData, 0, length);
         return ovlyData;
     }
 


### PR DESCRIPTION
dcm4che/dcm4chee-arc-light#883