### PR TITLE
DicomInputStream builder bug fixed

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -148,8 +148,17 @@ public class DicomInputStream extends FilterInputStream
     }
 
     public DicomInputStream(File file) throws IOException {
-        this(new FileInputStream(file));
+        super(new BufferedInputStream(new FileInputStream(file)));
         uri = file.toURI().toString();
+        try {
+            guessTransferSyntax();
+        }catch(IOException ioException) {
+            try {
+                if(this.in != null)
+                    this.in.close();
+            }catch(Exception ignore) {} 
+            throw ioException;
+        } 
     }
 
     public final String getTransferSyntax() {


### PR DESCRIPTION
Now it tries to close the FileInputStream if something was wrong guessing the transfer syntax.
Related to #151 