### PR TITLE
Bugfix for Issue #150: Spooled syslog messages will never be send after restart

### DIFF
--- a/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
+++ b/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
@@ -727,6 +727,7 @@ public class AuditLogger {
             GeneralSecurityException, IOException {
         if (getNumberOfQueuedMessages() > 0) {
             spoolMessage(msg);
+            scheduleRetry();
         } else {
             try {
                 activeConnection().sendMessage(msg);


### PR DESCRIPTION
Scheduler will be restarted after spooling the message if enabled.