### PR TITLE
Prevent read of tag beyond specified len (issue #159) 

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -527,6 +527,14 @@ public class DicomInputStream extends FilterInputStream
                     break;
                 throw e;
             }
+            
+            // dcm4che3#159 - Skip child tags which exceed maximum specified len.
+            if (!undeflen && (pos + length) > endPos){ 
+                LOG.warn("Tag {} with length of {} exceeds specified len of {}.  Skipping.", TagUtils.toString(tag), length, len);
+                skip(endPos - pos);
+                break;
+            }
+            
             if (hasStopTag && tag == stopTag)
                 break;
             if (vr != null) {


### PR DESCRIPTION
While reading attributes of a defined length, skip tags that exceed to boundaries of the provided length.  This can happen with incorrectly encoded instance (for example, explicitly encoded tags with UN sequence item).  