### PR TITLE
Switch Auditing to TCP TLS

### DIFF
--- a/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/SyslogProtocolHandler.java
+++ b/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/SyslogProtocolHandler.java
@@ -60,7 +60,7 @@ enum SyslogProtocolHandler implements TCPProtocolHandler, UDPProtocolHandler {
     INSTANCE;
 
     private static final int INIT_MSG_LEN = 8192;
-    private static final int MAX_MSG_LEN = 65536;
+    private static final int MAX_MSG_LEN = 1024*1024*20; //20mb
     private static final int MAX_MSG_PREFIX = 200;
     private static final int MSG_PROMPT_LEN = 8192;
 


### PR DESCRIPTION
I extendend the supported MAX_MSG_LEN of the SyslogProtocolHandler to 20 Mb from of 64 Kb, as the SyslogProtocolHandler implements both UDP and TCP handlers and TCP is not limited to 64 Kb (moreover, for UDP the 64 kb limit will be enforced by the protocol anyway).  