### PR TITLE
Handle invalid values with VR.DS or VR.IS more lenient

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -768,10 +768,11 @@ public class Attributes implements Serializable {
             vr = vrs[index];
         else
             updateVR(index, vr);
-        if (vr == VR.IS)
-            value = decodeISValue(index);
 
         try {
+            if (vr == VR.IS)
+                value = decodeISValue(index);
+
             return vr.toInt(value, bigEndian, valueIndex, defVal);
         } catch (UnsupportedOperationException e) {
             LOG.info("Attempt to access {} {} as int", TagUtils.toString(tag), vr);
@@ -803,10 +804,11 @@ public class Attributes implements Serializable {
             vr = vrs[index];
         else
             updateVR(index, vr);
-        if (vr == VR.IS)
-            value = decodeISValue(index);
 
         try {
+            if (vr == VR.IS)
+                value = decodeISValue(index);
+
             return vr.toInts(value, bigEndian);
         } catch (UnsupportedOperationException e) {
             LOG.info("Attempt to access {} {} as int", TagUtils.toString(tag), vr);
@@ -850,10 +852,11 @@ public class Attributes implements Serializable {
             vr = vrs[index];
         else
             updateVR(index, vr);
-        if (vr == VR.DS)
-            value = decodeDSValue(index);
 
         try {
+            if (vr == VR.DS)
+                value = decodeDSValue(index);
+
             return vr.toFloat(value, bigEndian, valueIndex, defVal);
         } catch (UnsupportedOperationException e) {
             LOG.info("Attempt to access {} {} as float", TagUtils.toString(tag), vr);
@@ -885,10 +888,11 @@ public class Attributes implements Serializable {
             vr = vrs[index];
         else
             updateVR(index, vr);
-        if (vr == VR.DS)
-            value = decodeDSValue(index);
 
         try {
+            if (vr == VR.DS)
+                value = decodeDSValue(index);
+
             return vr.toFloats(value, bigEndian);
         } catch (UnsupportedOperationException e) {
             LOG.info("Attempt to access {} {} as float", TagUtils.toString(tag), vr);
@@ -932,10 +936,11 @@ public class Attributes implements Serializable {
             vr = vrs[index];
         else
             updateVR(index, vr);
-        if (vr == VR.DS)
-            value = decodeDSValue(index);
 
         try {
+            if (vr == VR.DS)
+                value = decodeDSValue(index);
+
             return vr.toDouble(value, bigEndian, valueIndex, defVal);
         } catch (UnsupportedOperationException e) {
             LOG.info("Attempt to access {} {} as double", TagUtils.toString(tag), vr);
@@ -967,9 +972,11 @@ public class Attributes implements Serializable {
             vr = vrs[index];
         else
             updateVR(index, vr);
-        if (vr == VR.DS)
-            value = decodeDSValue(index);
+
         try {
+            if (vr == VR.DS)
+                value = decodeDSValue(index);
+
             return vr.toDoubles(value, bigEndian);
         } catch (UnsupportedOperationException e) {
             LOG.info("Attempt to access {} {} as double", TagUtils.toString(tag), vr);


### PR DESCRIPTION
Getting a tag with VR.DS or VR.IS that has an invalid format should not throw a NumberFormatException, but should return the default value instead.
The access to the invalid tag should be logged.

Fixes #193, IEI-50691, IEI-51624, IEI-52241, IEI-31466