### PR TITLE
SyslogProtocolHandler to use his own ThreadPoolExecutor

### DIFF
--- a/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/SyslogProtocolHandler.java
+++ b/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/SyslogProtocolHandler.java
@@ -75,8 +75,8 @@ enum SyslogProtocolHandler implements TCPProtocolHandler, UDPProtocolHandler {
 
     private SyslogProtocolHandler()
     {
-        this.executor = new ThreadPoolExecutor(0, 20, 60L, TimeUnit.SECONDS, new SynchronousQueue<>());
-        //this.executor = null;
+        //this.executor = new ThreadPoolExecutor(0, 20, 60L, TimeUnit.SECONDS, new SynchronousQueue<>());
+        this.executor = null;
     }
 
     @Override


### PR DESCRIPTION
I prepared SyslogProtocolHandler to use his own ThreadPoolExecutor instead of the common Device Executor. At the moment the own Executor is commented out in the constructor, so the behavior is exactly as before (using the Device's Executor). In the branch "generic-config" is already uncommented. Maybe should be made configurable.