### PR TITLE
SocketException on association release fix #244

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
@@ -374,7 +374,9 @@ public class Association {
         LOG.info("{} << A-RELEASE-RQ", name);
         enterState(State.Sta7);
         stopTimeout();
-        encoder.writeAReleaseRQ();
+        synchronized (this) {
+            encoder.writeAReleaseRQ();
+        }
         startReleaseTimeout();
     }
 


### PR DESCRIPTION
Multithreading bug resulting in java.net.SocketException on Association.writeAReleaseRQ.
See #244 for details.