### PR TITLE
Changes to fix issue 245, failing to read the entire image in images …

### DIFF
--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/plugins/dcm/DicomImageReader.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/plugins/dcm/DicomImageReader.java
@@ -444,12 +444,13 @@ public class DicomImageReader extends ImageReader implements Closeable {
         if (decompressor != null) {
             openiis();
             try {
-                decompressor.setInput(iisOfFrame(frameIndex));
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Start decompressing frame #" + (frameIndex + 1));
+                ImageInputStream iisOfFrame = iisOfFrame(frameIndex);
+                // Reading this up front sets the required values so that opencv succeeds - it is less than optimal performance wise
+                iisOfFrame.length();
+                decompressor.setInput(iisOfFrame);
+                LOG.debug("Start decompressing frame #{}", (frameIndex + 1));
                 BufferedImage bi = decompressor.read(0, decompressParam(param));
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Finished decompressing frame #" + (frameIndex + 1));
+                LOG.debug("Finished decompressing frame #{}", (frameIndex + 1));
                 if (samples > 1)
                     return bi;
                 
@@ -518,7 +519,7 @@ public class DicomImageReader extends ImageReader implements Closeable {
             return null;
         } else {
             iisOfFrame = new SegmentedInputImageStream(
-                    iis, pixelDataFragments, frameIndex);
+                    iis, pixelDataFragments, frames==1 ? -1 : frameIndex);
             ((SegmentedInputImageStream) iisOfFrame).setImageDescriptor(imageDescriptor);
         }
         return patchJpegLS != null


### PR DESCRIPTION
There were 2 issues, plus a dependency from opencv on the internal code that probably shouldn't have been included.  The first issue was that for multiple part images, we need to pass in -1 for the frame number to indicate read-all.  The second was an EOF over-run issue causing a null pointer.
The dependency was that opencv used the actual number of segments from the internal segmented input to read the response, and that wasn't computed up front, so it was allocating an array size too large.  The work around is to read the size up front, although that is less than optimal as it does a double read.