### PR TITLE
Be tolerant of nulls for IS and DS values in JSON encoding.

### DIFF
--- a/dcm4che-json/src/main/java/org/dcm4che3/json/JSONReader.java
+++ b/dcm4che-json/src/main/java/org/dcm4che3/json/JSONReader.java
@@ -386,7 +386,8 @@ public class JSONReader {
         double[] toDoubles() {
             double[] ds = new double[values.size()];
             for (int i = 0; i < ds.length; i++) {
-                ds[i] = ((Number) values.get(i)).doubleValue();
+                Number value = (Number) values.get(i);
+                ds[i] = value != null ? value.doubleValue() : 0;
             }
             return ds;
         }
@@ -394,7 +395,8 @@ public class JSONReader {
         int[] toInts() {
             int[] is = new int[values.size()];
             for (int i = 0; i < is.length; i++) {
-                is[i] = ((Number) values.get(i)).intValue();
+                Number value = (Number) values.get(i);
+                is[i] = value != null ? value.intValue() : 0;
             }
             return is;
         }


### PR DESCRIPTION
When writing out poorly formatted IS and DS values dcm4che replaces
the poorly formated value with a null. The resulting JSON can not
be read back in by dcm4che.

JSONWriter.java
```
            case DS:
                try {
                    gen.write(StringUtils.parseDS(s));
                } catch (NumberFormatException e) {
                    LOG.info("illegal DS value: {} - encoded as null", s);
                    gen.writeNull();
                }
                break;
            case IS:
                try {
                    gen.write(StringUtils.parseIS(s));
                } catch (NumberFormatException e) {
                    LOG.info("illegal IS value: {} - encoded as null", s);
                    gen.writeNull();
                }
                break;
```