### PR TITLE
Fix offset calculation with rescaleSlope

### DIFF
--- a/dcm4che-image/src/main/java/org/dcm4che3/image/LookupTableFactory.java
+++ b/dcm4che-image/src/main/java/org/dcm4che3/image/LookupTableFactory.java
@@ -233,7 +233,7 @@ public class LookupTableFactory {
                     : storedValue;
             if (w != 0) {
                 size = Math.max(2,Math.abs(Math.round(w/m)));
-                offset = Math.round(c/m-b) - size/2;
+                offset = Math.round((c-b)/m) - size/2;
             } else {
                 offset = inBits.minValue();
                 size = inBits.maxValue() - inBits.minValue() + 1;


### PR DESCRIPTION
We were having problems with images provided by a Aquilion/LB. Either they were coming out all black or some other incorrect brightness value. 

After some searching we came to the conclusion that the non default rescaleSlope and rescaleIntercept were causing issues in defining the offset. In our test image a rescaleSlope of 2.059 and a rescaleIntercept of -32754.

The entire LUT is build while compensating for the rescaleSlope, but the rescaleIntercept was never compensated. For non 1 values of rescaleSlope this caused issues with any rescaleIntercept set because the rescaleIntercept was never divided by the rescaleSlope before being applied to values. This caused all values to be outside of the LUT range, resulting in a completely black image.

The fix here is to also apply the rescaleSlope to the offset before being used in the LUT.

The images generated with the fix match the display of the image we see in the Horos viewer. So it looks like we made the correct fix here. Fix was tested on 5.10.6, haven't been able to get the newest version working due to opencv dependency issues...