### PR TITLE
Update native codec library to 4.0.0-dcmR2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <weasis.version>3.0.2-rc1</weasis.version>
-    <weasis.opencv.native.version>4.0.0-dcmR1</weasis.opencv.native.version>
+    <weasis.opencv.native.version>4.0.0-dcmR2</weasis.opencv.native.version>
     <keycloak.version>4.4.0.Final</keycloak.version>
     <jaxws-tools-maven-plugin.version>1.2.2.Final</jaxws-tools-maven-plugin.version>
     <jbossws-cxf-client.version>5.2.1.Final</jbossws-cxf-client.version>


### PR DESCRIPTION
It should fix the issue of the Linux backward compatibility described [here](https://github.com/dcm4che/dcm4che/pull/340).

Now the backward compatibility of the native library is supported from the most recent version to:
Linux 64-bit: GLIBC_2.14
Linux 32-bit: GLIBC_2.11
Mac OS X: 10.9
Windows 32-bit and 64-bit: at least Windows Vista

This new build has not been tested intensively. 
