### PR TITLE
JSONWriter option to write human readable tags

### DIFF
--- a/dcm4che-json/src/main/java/org/dcm4che3/json/JSONWriter.java
+++ b/dcm4che-json/src/main/java/org/dcm4che3/json/JSONWriter.java
@@ -77,7 +77,7 @@ public class JSONWriter implements DicomInputHandler {
 
     private TagDict tagDict;
     
-    public JSONWriter(JsonGenerator gen, ElementDictionary dict) {
+    public JSONWriter(JsonGenerator gen, final ElementDictionary dict) {
         this(gen);        
         // branch in constructor once to save comparisons for each tag
         // used anonymous class instead of lambda for compat with older java  


### PR DESCRIPTION
Added a constructor to JSONWriter that takes a ElementDictionary as a second parameter.
If this constructor is used the JSONWriter will serialize the Tag names to human readable format using the given ElementDictionary. Can be used like:

`final StringWriter writer = new StringWriter();`
`JsonGenerator gen = Json.createGenerator(writer);`
`new JSONWriter(gen, ElementDictionary.getStandardElementDictionary()).write(attr);`
`gen.flush();`