### PR TITLE
Fix #382 LOG.warn does not properly print integer value on failed VR

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/VR.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/VR.java
@@ -113,7 +113,7 @@ public enum VR {
             if (vr != null)
                 return vr;
         } catch (IndexOutOfBoundsException e) {}
-        LOG.warn("Unrecogniced VR code: {0}H - treat as UN",
+        LOG.warn("Unrecogniced VR code: 0x{} - treat as UN",
                 Integer.toHexString(code));
         return UN;
     }


### PR DESCRIPTION
Corrected log message. Used Java format (0xXXX) for hex value.