### PR TITLE
Update native libraries for encoders and decoders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
   </organization>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <weasis.version>3.0.2-rc1</weasis.version>
-    <weasis.opencv.native.version>4.0.0-dcmR2</weasis.opencv.native.version>
+    <weasis.version>3.0.4</weasis.version>
+    <weasis.opencv.native.version>4.0.0-dcmR3</weasis.opencv.native.version>
     <keycloak.version>4.6.0.Final</keycloak.version>
     <jaxws-tools-maven-plugin.version>1.2.1.Final</jaxws-tools-maven-plugin.version>
     <jbossws-cxf-client.version>5.2.1.Final</jbossws-cxf-client.version>


### PR DESCRIPTION
- update to opencv 4.0 final
- update to charls 2.0.1
- update openjpeg
- fix result of jpeg-ls lossless compression is wrong #367