### PR TITLE
skipFully in skipAttribute

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -653,7 +653,7 @@ public class DicomInputStream extends FilterInputStream
     private void skipAttribute(String message) throws IOException {
         LOG.warn(message,
                  new Object[] { TagUtils.toString(tag), length, tagPos });
-        skip(length);
+        skipFully(length);
     }
 
     private void readSequence(int len, Attributes attrs, int sqtag)


### PR DESCRIPTION
DicomInputStream.skipAttribute(String message) is expected to skip the whole attribute. The call to InputStream.skip(long n) is not guaranteed to skip the specified number of bytes, and can intermittently cause the DicomInputStream to lose its place depending on the number of bytes available in the stream. A call to SkipFully addresses this.