### PR TITLE
fix StreamUtils.skipFully(InputStream in, long n )

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/util/StreamUtils.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/util/StreamUtils.java
@@ -74,11 +74,15 @@ public class StreamUtils {
             throw new EOFException();
     }
     
-    public static  void skipFully(InputStream in, long n) throws IOException {
+    public static void skipFully(InputStream in, long n) throws IOException {
         while (n > 0) {
             long count = in.skip(n);
-            if (count <= 0)
-                throw new EOFException();
+            if (count == 0) {
+                if (in.read() == -1) {
+                    throw new EOFException();
+                }
+                count = 1;
+            }
             n -= count;
         }
     }


### PR DESCRIPTION
The implementation of StreamUtils.skipFully(InputStream in, long n ) assumes that InputStream.skip(long n) will only return 0 at the EOF. But this is not the case. From the JavaDoc:
> The skip method may, for a variety of reasons, end up skipping over some smaller number of bytes, possibly 0. This may result from any of a number of conditions; reaching end of file before n bytes have been skipped is only one possibility. The actual number of bytes skipped is returned.