### PR TITLE
Added quotation marks around JAVA_LIBRARY_PATH in tools executables

### DIFF
--- a/dcm4che-assembly/src/bin/dcm2dcm
+++ b/dcm4che-assembly/src/bin/dcm2dcm
@@ -74,7 +74,7 @@ if $cygwin; then
     JAVA_LIBRARY_PATH=`cygpath --path --windows "$JAVA_LIBRARY_PATH"`
 fi
 
-JAVA_OPTS="$JAVA_OPTS -Djava.library.path=${JAVA_LIBRARY_PATH}"
+JAVA_OPTS="$JAVA_OPTS -Djava.library.path=\"${JAVA_LIBRARY_PATH}\""
 
 if [ -n "$IMAGE_READER_FACTORY" ]; then
     JAVA_OPTS="$JAVA_OPTS -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=$IMAGE_READER_FACTORY"

--- a/dcm4che-assembly/src/bin/dcm2dcm.bat
+++ b/dcm4che-assembly/src/bin/dcm2dcm.bat
@@ -61,7 +61,7 @@ rem Setup the native library path
 "%JAVA%" -d64 -version >nul 2>&1 && set OS=win-x86_64 || set OS=win-i686
 set JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%
 
-set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path=%JAVA_LIBRARY_PATH%
+set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path="%JAVA_LIBRARY_PATH%"
 
 if not "%IMAGE_READER_FACTORY%" == "" ^
  set JAVA_OPTS=%JAVA_OPTS% -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=%IMAGE_READER_FACTORY%

--- a/dcm4che-assembly/src/bin/dcm2jpg
+++ b/dcm4che-assembly/src/bin/dcm2jpg
@@ -74,7 +74,7 @@ if $cygwin; then
     JAVA_LIBRARY_PATH=`cygpath --path --windows "$JAVA_LIBRARY_PATH"`
 fi
 
-JAVA_OPTS="$JAVA_OPTS -Djava.library.path=${JAVA_LIBRARY_PATH}"
+JAVA_OPTS="$JAVA_OPTS -Djava.library.path=\"${JAVA_LIBRARY_PATH}\""
 
 if [ -n "$IMAGE_READER_FACTORY" ]; then
     JAVA_OPTS="$JAVA_OPTS -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=$IMAGE_READER_FACTORY"

--- a/dcm4che-assembly/src/bin/dcm2jpg.bat
+++ b/dcm4che-assembly/src/bin/dcm2jpg.bat
@@ -61,7 +61,7 @@ rem Setup the native library path
 "%JAVA%" -d64 -version >nul 2>&1 && set OS=win-x86_64 || set OS=win-i686
 set JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%
 
-set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path=%JAVA_LIBRARY_PATH%
+set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path="%JAVA_LIBRARY_PATH%"
 
 if not "%IMAGE_READER_FACTORY%" == "" ^
  set JAVA_OPTS=%JAVA_OPTS% -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=%IMAGE_READER_FACTORY%

--- a/dcm4che-assembly/src/bin/storescu
+++ b/dcm4che-assembly/src/bin/storescu
@@ -75,7 +75,7 @@ if $cygwin; then
     JAVA_LIBRARY_PATH=`cygpath --path --windows "$JAVA_LIBRARY_PATH"`
 fi
 
-JAVA_OPTS="$JAVA_OPTS -Djava.library.path=${JAVA_LIBRARY_PATH}"
+JAVA_OPTS="$JAVA_OPTS -Djava.library.path=\"${JAVA_LIBRARY_PATH}\""
 
 if [ -n "$IMAGE_READER_FACTORY" ]; then
     JAVA_OPTS="$JAVA_OPTS -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=$IMAGE_READER_FACTORY"

--- a/dcm4che-assembly/src/bin/storescu.bat
+++ b/dcm4che-assembly/src/bin/storescu.bat
@@ -62,7 +62,7 @@ rem Setup native library path
 "%JAVA%" -d64 -version >nul 2>&1 && set OS=win-x86_64 || set OS=win-i686
 set JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%
 
-set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path=%JAVA_LIBRARY_PATH%
+set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path="%JAVA_LIBRARY_PATH%"
 
 if not "%IMAGE_READER_FACTORY%" == "" ^
  set JAVA_OPTS=%JAVA_OPTS% -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=%IMAGE_READER_FACTORY%


### PR DESCRIPTION
Without the quotation marks the command will fail to execute if the path contains spaces.