### PR TITLE
dcm4che-tool-stgcmtscu: fix keys 'one-per-study', 'one-per-series'

### DIFF
--- a/dcm4che-tool/dcm4che-tool-stgcmtscu/src/main/java/org/dcm4che3/tool/stgcmtscu/StgCmtSCU.java
+++ b/dcm4che-tool/dcm4che-tool-stgcmtscu/src/main/java/org/dcm4che3/tool/stgcmtscu/StgCmtSCU.java
@@ -250,9 +250,9 @@ public class StgCmtSCU {
     }
 
     public static int getSplitTag(CommandLine cl) {
-        return cl.hasOption("one-by-study") 
+        return cl.hasOption("one-per-study") 
                 ? Tag.StudyInstanceUID
-                : cl.hasOption("one-by-series")
+                : cl.hasOption("one-per-series")
                         ? Tag.SeriesInstanceUID
                         : 0;
     }


### PR DESCRIPTION
When stgcmtscu run with key '--one-per-study' or '--one-per-series', it sends one StorageCommitmentRequest instead severals.
This change fixes that.