### PR TITLE
#445 Java Crash when reading, writing or transcoding several images in multi-threaded context

### DIFF
--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJ2kImageWriter.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJ2kImageWriter.java
@@ -102,35 +102,43 @@ class NativeJ2kImageWriter extends ImageWriter {
         ImageDescriptor desc = ((BytesWithImageImageDescriptor) stream).getImageDescriptor();
 
         RenderedImage renderedImage = image.getRenderedImage();
-
+        Mat buf = null;
+        MatOfInt dicomParams = null;
         try {
-            // Band interleaved mode (PlanarConfiguration = 1) is converted to pixel interleaved
-            // So the input image has always a pixel interleaved mode mode((PlanarConfiguration = 0)
-            ImageCV mat = ImageConversion.toMat(renderedImage, param.getSourceRegion(), false);
+            ImageCV mat = null;
+            try {
+                // Band interleaved mode (PlanarConfiguration = 1) is converted to pixel interleaved
+                // So the input image has always a pixel interleaved mode mode((PlanarConfiguration = 0)
+                mat = ImageConversion.toMat(renderedImage, param.getSourceRegion(), false);
 
-            int cvType = mat.type();
-            int elemSize = (int) mat.elemSize1();
-            int channels = CvType.channels(cvType);
-            int dcmFlags =
-                CvType.depth(cvType) == CvType.CV_16S ? Imgcodecs.DICOM_IMREAD_SIGNED : Imgcodecs.DICOM_IMREAD_UNSIGNED;
+                int cvType = mat.type();
+                int elemSize = (int) mat.elemSize1();
+                int channels = CvType.channels(cvType);
+                int dcmFlags = CvType.depth(cvType) == CvType.CV_16S ? Imgcodecs.DICOM_IMREAD_SIGNED
+                    : Imgcodecs.DICOM_IMREAD_UNSIGNED;
 
-            int[] params = new int[15];
-            params[Imgcodecs.DICOM_PARAM_IMREAD] = Imgcodecs.IMREAD_UNCHANGED; // Image flags
-            params[Imgcodecs.DICOM_PARAM_DCM_IMREAD] = dcmFlags; // DICOM flags
-            params[Imgcodecs.DICOM_PARAM_WIDTH] = mat.width(); // Image width
-            params[Imgcodecs.DICOM_PARAM_HEIGHT] = mat.height(); // Image height
-            params[Imgcodecs.DICOM_PARAM_COMPRESSION] = Imgcodecs.DICOM_CP_J2K; // Type of compression
-            params[Imgcodecs.DICOM_PARAM_COMPONENTS] = channels; // Number of components
-            params[Imgcodecs.DICOM_PARAM_BITS_PER_SAMPLE] = desc.getBitsStored(); // Bits per sample
-            params[Imgcodecs.DICOM_PARAM_INTERLEAVE_MODE] = Imgcodecs.ILV_SAMPLE; // Interleave mode
-            params[Imgcodecs.DICOM_PARAM_BYTES_PER_LINE] = mat.width() * elemSize; // Bytes per line
-            params[Imgcodecs.DICOM_PARAM_ALLOWED_LOSSY_ERROR] = j2kParams.isCompressionLossless() ? 0 : 1;
-            params[Imgcodecs.DICOM_PARAM_JPEG_QUALITY] = (int) (j2kParams.getCompressionQuality() * 100); // JPEG lossy quality
+                int[] params = new int[15];
+                params[Imgcodecs.DICOM_PARAM_IMREAD] = Imgcodecs.IMREAD_UNCHANGED; // Image flags
+                params[Imgcodecs.DICOM_PARAM_DCM_IMREAD] = dcmFlags; // DICOM flags
+                params[Imgcodecs.DICOM_PARAM_WIDTH] = mat.width(); // Image width
+                params[Imgcodecs.DICOM_PARAM_HEIGHT] = mat.height(); // Image height
+                params[Imgcodecs.DICOM_PARAM_COMPRESSION] = Imgcodecs.DICOM_CP_J2K; // Type of compression
+                params[Imgcodecs.DICOM_PARAM_COMPONENTS] = channels; // Number of components
+                params[Imgcodecs.DICOM_PARAM_BITS_PER_SAMPLE] = desc.getBitsStored(); // Bits per sample
+                params[Imgcodecs.DICOM_PARAM_INTERLEAVE_MODE] = Imgcodecs.ILV_SAMPLE; // Interleave mode
+                params[Imgcodecs.DICOM_PARAM_BYTES_PER_LINE] = mat.width() * elemSize; // Bytes per line
+                params[Imgcodecs.DICOM_PARAM_ALLOWED_LOSSY_ERROR] = j2kParams.isCompressionLossless() ? 0 : 1;
+                params[Imgcodecs.DICOM_PARAM_JPEG_QUALITY] = (int) (j2kParams.getCompressionQuality() * 100); // JPEG lossy  quality
 
-            MatOfInt dicomParams = new MatOfInt(params);
-            Mat buf = Imgcodecs.dicomJpgWrite(mat, dicomParams, "");
-            if (buf.empty()) {
-                throw new IIOException("Native JPEG2000 encoding error: null image");
+                dicomParams = new MatOfInt(params);
+                buf = Imgcodecs.dicomJpgWrite(mat, dicomParams, "");
+                if (buf.empty()) {
+                    throw new IIOException("Native JPEG2000 encoding error: null image");
+                }
+            } finally {
+                if (mat != null) {
+                    mat.release();
+                }
             }
 
             byte[] bSrcData = new byte[buf.width() * buf.height() * (int) buf.elemSize()];
@@ -138,6 +146,9 @@ class NativeJ2kImageWriter extends ImageWriter {
             stream.write(bSrcData);
         } catch (Throwable t) {
             throw new IIOException("Native JPEG2000 encoding error", t);
+        } finally {
+            NativeImageReader.closeMat(dicomParams);
+            NativeImageReader.closeMat(buf);
         }
     }
 

--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJLSImageWriter.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJLSImageWriter.java
@@ -100,45 +100,55 @@ class NativeJLSImageWriter extends ImageWriter {
         ImageDescriptor desc = ((BytesWithImageImageDescriptor) stream).getImageDescriptor();
 
         RenderedImage renderedImage = image.getRenderedImage();
-        
+        Mat buf = null;
+        MatOfInt dicomParams = null;
         try {
-            // Band interleaved mode (PlanarConfiguration = 1) is converted to pixel interleaved
-            // So the input image has always a pixel interleaved mode mode((PlanarConfiguration = 0)
-            ImageCV mat = ImageConversion.toMat(renderedImage, param.getSourceRegion(), false);
+            ImageCV mat = null;
+            try {
+                // Band interleaved mode (PlanarConfiguration = 1) is converted to pixel interleaved
+                // So the input image has always a pixel interleaved mode mode((PlanarConfiguration = 0)
+                mat = ImageConversion.toMat(renderedImage, param.getSourceRegion(), false);
 
-            int cvType = mat.type();
-            int elemSize = (int) mat.elemSize1();
-            int channels = CvType.channels(cvType);
-            int dcmFlags =
-                CvType.depth(cvType) == CvType.CV_16S ? Imgcodecs.DICOM_IMREAD_SIGNED : Imgcodecs.DICOM_IMREAD_UNSIGNED;
+                int cvType = mat.type();
+                int elemSize = (int) mat.elemSize1();
+                int channels = CvType.channels(cvType);
+                int dcmFlags = CvType.depth(cvType) == CvType.CV_16S ? Imgcodecs.DICOM_IMREAD_SIGNED
+                    : Imgcodecs.DICOM_IMREAD_UNSIGNED;
 
-            int[] params = new int[15];
-            params[Imgcodecs.DICOM_PARAM_IMREAD] = Imgcodecs.IMREAD_UNCHANGED; // Image flags
-            params[Imgcodecs.DICOM_PARAM_DCM_IMREAD] = dcmFlags; // DICOM flags
-            params[Imgcodecs.DICOM_PARAM_WIDTH] = mat.width(); // Image width
-            params[Imgcodecs.DICOM_PARAM_HEIGHT] = mat.height(); // Image height
-            params[Imgcodecs.DICOM_PARAM_COMPRESSION] = Imgcodecs.DICOM_CP_JPLS; // Type of compression
-            params[Imgcodecs.DICOM_PARAM_COMPONENTS] = channels; // Number of components
-            params[Imgcodecs.DICOM_PARAM_BITS_PER_SAMPLE] = desc.getBitsStored(); // Bits per sample
-            params[Imgcodecs.DICOM_PARAM_INTERLEAVE_MODE] = Imgcodecs.ILV_SAMPLE; // Interleave mode
-            params[Imgcodecs.DICOM_PARAM_BYTES_PER_LINE] = mat.width() * elemSize; // Bytes per line
-            params[Imgcodecs.DICOM_PARAM_ALLOWED_LOSSY_ERROR] =
-                // Allowed lossy error for jpeg-ls
-                param instanceof JPEGLSImageWriteParam ? ((JPEGLSImageWriteParam) param).getNearLossless() : 0;
+                int[] params = new int[15];
+                params[Imgcodecs.DICOM_PARAM_IMREAD] = Imgcodecs.IMREAD_UNCHANGED; // Image flags
+                params[Imgcodecs.DICOM_PARAM_DCM_IMREAD] = dcmFlags; // DICOM flags
+                params[Imgcodecs.DICOM_PARAM_WIDTH] = mat.width(); // Image width
+                params[Imgcodecs.DICOM_PARAM_HEIGHT] = mat.height(); // Image height
+                params[Imgcodecs.DICOM_PARAM_COMPRESSION] = Imgcodecs.DICOM_CP_JPLS; // Type of compression
+                params[Imgcodecs.DICOM_PARAM_COMPONENTS] = channels; // Number of components
+                params[Imgcodecs.DICOM_PARAM_BITS_PER_SAMPLE] = desc.getBitsStored(); // Bits per sample
+                params[Imgcodecs.DICOM_PARAM_INTERLEAVE_MODE] = Imgcodecs.ILV_SAMPLE; // Interleave mode
+                params[Imgcodecs.DICOM_PARAM_BYTES_PER_LINE] = mat.width() * elemSize; // Bytes per line
+                params[Imgcodecs.DICOM_PARAM_ALLOWED_LOSSY_ERROR] =
+                    // Allowed lossy error for jpeg-ls
+                    param instanceof JPEGLSImageWriteParam ? ((JPEGLSImageWriteParam) param).getNearLossless() : 0;
 
-            MatOfInt dicomParams = new MatOfInt(params);
-            Mat buf = Imgcodecs.dicomJpgWrite(mat, dicomParams, "");
-            if (buf.empty()) {
-                throw new IIOException("Native JPEG-LS encoding error: null image");
+                dicomParams = new MatOfInt(params);
+                buf = Imgcodecs.dicomJpgWrite(mat, dicomParams, "");
+                if (buf.empty()) {
+                    throw new IIOException("Native JPEG-LS encoding error: null image");
+                }
+            } finally {
+                if (mat != null) {
+                    mat.release();
+                }
             }
-
             byte[] bSrcData = new byte[buf.width() * buf.height() * (int) buf.elemSize()];
             buf.get(0, 0, bSrcData);
             stream.write(bSrcData);
         } catch (Throwable t) {
             throw new IIOException("Native JPEG-LS encoding error", t);
+        } finally {
+            NativeImageReader.closeMat(dicomParams);
+            NativeImageReader.closeMat(buf);
         }
-    }   
+    }
 
     @Override
     public IIOMetadata getDefaultStreamMetadata(ImageWriteParam param) {


### PR DESCRIPTION
This fix has been tested to transcode simultaneously 50 images (in 50 threads) from jpeg-ls to jpeg2000 with 128MB (xmx). No crash after more than 10'000 conversions.