### PR TITLE
Fix classloader issue in OSGI environment

### DIFF
--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJ2kImageWriter.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJ2kImageWriter.java
@@ -56,11 +56,11 @@ import javax.imageio.stream.ImageOutputStream;
 
 import org.dcm4che3.imageio.codec.BytesWithImageImageDescriptor;
 import org.dcm4che3.imageio.codec.ImageDescriptor;
-import org.opencv.core.Core;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfInt;
 import org.opencv.imgcodecs.Imgcodecs;
+import org.opencv.osgi.OpenCVNativeLoader;
 import org.weasis.opencv.data.ImageCV;
 import org.weasis.opencv.op.ImageConversion;
 
@@ -70,7 +70,9 @@ import org.weasis.opencv.op.ImageConversion;
  */
 class NativeJ2kImageWriter extends ImageWriter {
     static {
-        System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+        // Load the native OpenCV library
+        OpenCVNativeLoader loader = new OpenCVNativeLoader();
+        loader.init();
     }
 
     NativeJ2kImageWriter(ImageWriterSpi originatingProvider) throws IOException {

--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJLSImageWriter.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJLSImageWriter.java
@@ -56,11 +56,11 @@ import javax.imageio.stream.ImageOutputStream;
 
 import org.dcm4che3.imageio.codec.BytesWithImageImageDescriptor;
 import org.dcm4che3.imageio.codec.ImageDescriptor;
-import org.opencv.core.Core;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfInt;
 import org.opencv.imgcodecs.Imgcodecs;
+import org.opencv.osgi.OpenCVNativeLoader;
 import org.weasis.opencv.data.ImageCV;
 import org.weasis.opencv.op.ImageConversion;
 
@@ -70,7 +70,9 @@ import org.weasis.opencv.op.ImageConversion;
  */
 class NativeJLSImageWriter extends ImageWriter {
     static {
-        System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+        // Load the native OpenCV library
+        OpenCVNativeLoader loader = new OpenCVNativeLoader();
+        loader.init();
     }
 
     NativeJLSImageWriter(ImageWriterSpi originatingProvider) throws IOException {

--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJPEGImageWriter.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJPEGImageWriter.java
@@ -57,11 +57,11 @@ import javax.imageio.stream.ImageOutputStream;
 import org.dcm4che3.image.PhotometricInterpretation;
 import org.dcm4che3.imageio.codec.BytesWithImageImageDescriptor;
 import org.dcm4che3.imageio.codec.ImageDescriptor;
-import org.opencv.core.Core;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfInt;
 import org.opencv.imgcodecs.Imgcodecs;
+import org.opencv.osgi.OpenCVNativeLoader;
 import org.weasis.opencv.data.ImageCV;
 import org.weasis.opencv.op.ImageConversion;
 
@@ -71,7 +71,9 @@ import org.weasis.opencv.op.ImageConversion;
  */
 class NativeJPEGImageWriter extends ImageWriter {
     static {
-        System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+        // Load the native OpenCV library
+        OpenCVNativeLoader loader = new OpenCVNativeLoader();
+        loader.init();
     }
 
     NativeJPEGImageWriter(ImageWriterSpi originatingProvider) throws IOException {

--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/StreamSegment.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/StreamSegment.java
@@ -59,7 +59,7 @@ import org.dcm4che3.data.BulkData;
 import org.dcm4che3.imageio.codec.BytesWithImageImageDescriptor;
 import org.dcm4che3.imageio.codec.ImageDescriptor;
 import org.dcm4che3.imageio.stream.SegmentedInputImageStream;
-import org.opencv.core.Core;
+import org.opencv.osgi.OpenCVNativeLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +71,9 @@ public abstract class StreamSegment {
     private static final Logger LOGGER = LoggerFactory.getLogger(StreamSegment.class);
 
     static {
-        System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+        // Load the native OpenCV library
+        OpenCVNativeLoader loader = new OpenCVNativeLoader();
+        loader.init();
     }
 
     private final long[] segPosition;


### PR DESCRIPTION
Avoid to get java.lang.UnsatisfiedLinkError: no opencv_java in java.library.path.
This happens when different classloaders try to load the native library.