### PR TITLE
Avoid IndexOutOfBounds exception in case of wrongly encoded ISO 2022 string.

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/SpecificCharacterSet.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/SpecificCharacterSet.java
@@ -424,29 +424,39 @@ public class SpecificCharacterSet {
             int cur = 0;
             StringBuilder sb = new StringBuilder(b.length);
             while (cur < b.length) {
-                if (b[cur] == 0x1b) { // ESC
+                if ( b[ cur ] == 0x1b && cur + 2 < b.length ) { // ESC
                     if (off < cur) {
                         sb.append(codec[g].decode(b, off, cur - off));
                     }
                     cur += 3;
                     switch (((b[cur - 2] & 255) << 8) + (b[cur - 1] & 255)) {
                         case 0x2428:
-                            if (b[cur++] == 0x44) {
-                                codec[0] = Codec.JIS_X_212;
-                            } else { // decode invalid ESC sequence as chars
-                                sb.append(codec[0].decode(b, cur - 4, 4));
+                            if (cur < b.length ) {
+                                if (b[cur++] == 0x44) {
+                                    codec[0] = Codec.JIS_X_212;
+                                } else { // decode invalid ESC sequence as chars
+                                    sb.append(codec[0].decode(b, cur - 4, 4));
+                                }
+                            }
+                            else { // decode invalid ESC sequence as chars
+                                sb.append(codec[0].decode(b, cur - 3, 3));
                             }
                             break;
                         case 0x2429:
-                            switch (b[cur++]) {
-                                case 0x41:
-                                    switchCodec(codec, 1, Codec.GB2312);
-                                    break;
-                                case 0x43:
-                                    switchCodec(codec, 1, Codec.KS_X_1001);
-                                    break;
-                                default: // decode invalid ESC sequence as chars
-                                    sb.append(codec[0].decode(b, cur - 4, 4));
+                            if (cur < b.length ) {
+                                switch (b[cur++]) {
+                                    case 0x41:
+                                        switchCodec(codec, 1, Codec.GB2312);
+                                        break;
+                                    case 0x43:
+                                        switchCodec(codec, 1, Codec.KS_X_1001);
+                                        break;
+                                    default: // decode invalid ESC sequence as chars
+                                        sb.append(codec[0].decode(b, cur - 4, 4));
+                                }
+                            }
+                            else { // decode invalid ESC sequence as chars
+                                sb.append(codec[0].decode(b, cur - 3, 3));
                             }
                             break;
                         case 0x2442:
@@ -510,7 +520,7 @@ public class SpecificCharacterSet {
                 }
             }
             if (off < cur) {
-                sb.append(codec[g].decode(b, off, cur - off));
+                sb.append(codec[g].decode(b, off, Math.min( cur, b.length) - off ));
             }
             return sb.toString();
         }

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/SpecificCharacterSetTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/SpecificCharacterSetTest.java
@@ -432,5 +432,52 @@ public class SpecificCharacterSetTest {
         assertEquals(CHINESE_PERSON_NAME_GB18030,
                 gbk().decode(CHINESE_PERSON_NAME_GB18030_BYTES));
     }
-
+    
+    @Test
+    public void testDecodeJISX0201EdgeCases() {
+        // Cover some illegal/undefined cases to verify that they do not result in exceptions. 
+        // Some of the resulting strings are not meaningful.
+        byte[][] edgeCases = new byte[][] {
+                {},
+                { 0x33, 0x43 },
+                { 0x33, 0x1b },
+                { 0x1b, 0x24, 0x28 },
+                { 0x1b, 0x24, 0x28, 0x55 },
+                { 0x1b, 0x24, 0x28, 0x44 },
+                { 0x1b, 0x24, 0x28, 0x44, 0x55 },
+                { 0x1b, 0x24, 0x29 },
+                { 0x1b, 0x24, 0x29, 0x41 },
+                { 0x1b, 0x24, 0x29, 0x41, 0x55 },
+                { 0x1b, 0x24, 0x29, 0x43 },
+                { 0x1b, 0x24, 0x29, 0x43, 0x55 },
+                { 0x1b, 0x24, 0x29, 0x55 },
+                { 0x1b, 0x24, 0x42 },
+                { 0x1b, 0x24, 0x42, 0x31 },
+                { 0x1b, 0x33 },
+                { 0x1b, 0x33, 0x43 } };
+        final String[] expectedStrings = new String[] {
+                "",
+                "3C",
+                "3\u001b",
+                "\u001b$(",
+                "\u001b$(U",
+                "",
+                "\ufffd",
+                "\u001b$)",
+                "",
+                "U",
+                "",
+                "U",
+                "\u001b$)U",
+                "",
+                "\ufffd",
+                "\u001b3",
+                "\u001b3C" };
+        assertEquals( "There must be the same number of expected results and edge cases.", edgeCases.length,
+                      expectedStrings.length );
+        for ( int i = 0; i < edgeCases.length; ++i ) {
+            assertEquals( "Unexpected value for the sequence with the index " + i, expectedStrings[ i ],
+                          jisX0201().decode( edgeCases[ i ] ) );
+        }
+    }
 }


### PR DESCRIPTION
Fix dcm4che/dcm4che#450