### PR TITLE
dcm4che#532 fix timeouts for outgoing requests

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
@@ -1238,8 +1238,8 @@ public class Association {
         checkException();
         rspHandler.setPC(pc);
         addDimseRSPHandler(rspHandler);
-        encoder.writeDIMSE(pc, cmd, data);
         startTimeout(rspHandler.getMessageID(), rspTimeout, stopOnPending);
+        encoder.writeDIMSE(pc, cmd, data);
     }
 
     static int minZeroAsMax(int i1, int i2) {


### PR DESCRIPTION
Before commit 6b2dbf6 the response timeout applied to both sending out a
request and waiting for a response for it. After the change it is impossible
to set a timeout for sending the request.