### PR TITLE
[IEI-96376] Fixed CStoreSCUResp so it won't forget the last error

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/service/BasicCStoreSCUResp.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/service/BasicCStoreSCUResp.java
@@ -43,6 +43,7 @@ import org.dcm4che3.net.Status;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Umberto Cappellini <umberto.cappellini@agfa.com>
@@ -109,7 +110,10 @@ public class BasicCStoreSCUResp {
 
         setCompleted(getCompleted() + addendumResponse.getCompleted());
         setFailed(getFailed() + addendumResponse.getFailed());
-		setLastError(addendumResponse.getLastError());
+        // Do not forget the last error
+        if (Objects.nonNull(addendumResponse.getLastError())) {
+            setLastError(addendumResponse.getLastError());
+        }
         setWarning(getWarning() + addendumResponse.getWarning());
 
         String[] currentCompletedUIDs = getCompletedUIDs();


### PR DESCRIPTION
EI failed to provide an accurate description of the error while storing instances because the extendResponse method did not check if the addendum response's lastError field is ````null````. If this field was previously set in the current object, the error information for the previous transfers is lost forever. 