### PR TITLE
[IEI-96376] Fix CStoreSCUResp when extending response

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/service/BasicCStoreSCUResp.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/service/BasicCStoreSCUResp.java
@@ -43,6 +43,7 @@ import org.dcm4che3.net.Status;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Umberto Cappellini <umberto.cappellini@agfa.com>
@@ -109,7 +110,10 @@ public class BasicCStoreSCUResp {
 
         setCompleted(getCompleted() + addendumResponse.getCompleted());
         setFailed(getFailed() + addendumResponse.getFailed());
-		setLastError(addendumResponse.getLastError());
+        // Do not forget the last error
+        if (Objects.nonNull(addendumResponse.getLastError())) {
+            setLastError(addendumResponse.getLastError());
+        }
         setWarning(getWarning() + addendumResponse.getWarning());
 
         String[] currentCompletedUIDs = getCompletedUIDs();

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/service/BasicCStoreSCUResp.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/service/BasicCStoreSCUResp.java
@@ -40,10 +40,13 @@ package org.dcm4che3.net.service;
 
 import org.dcm4che3.net.Status;
 
-import java.util.stream.Stream;
-
-import static java.util.Objects.nonNull;
-import static java.util.Objects.isNull;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Umberto Cappellini <umberto.cappellini@agfa.com>
@@ -52,12 +55,25 @@ import static java.util.Objects.isNull;
 public class BasicCStoreSCUResp {
 
     private int status;
-    private int completed;
-    private int failed;
     private int warning;
-    private String[] completedUIDs;
-    private String[] failedUIDs;
-	private Throwable lastError;
+    private Set<String> completedUIDs = new HashSet<>();
+    private Set<String> failedUIDs = new HashSet<>();
+    private List<Exception> errors = new ArrayList<>();
+
+    public BasicCStoreSCUResp() { }
+
+    /**
+     * This creates a shallow copy of the BasicCStoreSCUResp referenced by
+     * other.
+     * @param other The BasicCStoreSCUResp to be copied.
+     */
+    protected BasicCStoreSCUResp(BasicCStoreSCUResp other) {
+        this.status = other.status;
+        this.warning = other.warning;
+        this.completedUIDs = other.completedUIDs;
+        this.failedUIDs = other.failedUIDs;
+        this.errors = other.errors;
+    }
    
     public int getStatus() {
         return status;
@@ -66,16 +82,10 @@ public class BasicCStoreSCUResp {
         this.status = status;
     }
     public int getCompleted() {
-        return completed;
-    }
-    public void setCompleted(int completed) {
-        this.completed = completed;
+        return completedUIDs.size();
     }
     public int getFailed() {
-        return failed;
-    }
-    public void setFailed(int failed) {
-        this.failed = failed;
+        return failedUIDs.size();
     }
     public int getWarning() {
         return warning;
@@ -83,51 +93,40 @@ public class BasicCStoreSCUResp {
     public void setWarning(int warning) {
         this.warning = warning;
     }
-    public String[] getCompletedUIDs() {
-        return completedUIDs;
+    public Set<String> getCompletedUIDs() {
+        return Collections.unmodifiableSet(this.completedUIDs);
     }
-    public void setCompletedUIDs(String[] completedUIDs) {
-        this.completedUIDs = completedUIDs;
+    public void addCompletedUIDs(Collection<String> completedUIDs) {
+        this.completedUIDs.addAll(completedUIDs);
     }
-    public String[] getFailedUIDs() {
-        return failedUIDs;
+    public Set<String> getFailedUIDs() {
+        return Collections.unmodifiableSet(this.failedUIDs);
     }
-    public void setFailedUIDs(String[] failedUIDs) {
-        this.failedUIDs = failedUIDs;
+    public void addFailedUIDs(Collection<String> failedUIDs) {
+        this.failedUIDs.addAll(failedUIDs);
     }
-	public Throwable getLastError() {
-        return lastError;
+    public List<Exception> getErrors() {
+        return Collections.unmodifiableList(errors);
     }
-    public void setLastError(Throwable lastError) {
-        this.lastError = lastError;
+    public Optional<Exception> getLastError() {
+        return errors.stream().skip(Math.max(0, errors.size() - 1)).findFirst();
+    }
+    public void addError(Exception error) {
+        this.errors.add(error);
     }
 
+    /**
+     * Extends the current response object with the results from the
+     * addendumResponse.
+     * @param addendumResponse the response object to use for extension.
+     */
     public void extendResponse(BasicCStoreSCUResp addendumResponse) {
-
         if (getStatus() != addendumResponse.getStatus()) {
             setStatus(Status.OneOrMoreFailures);
         }
-
-        setCompleted(getCompleted() + addendumResponse.getCompleted());
-        setFailed(getFailed() + addendumResponse.getFailed());
-
-        // Do not forget the last error
-        if (nonNull(addendumResponse.getLastError())) {
-            setLastError(addendumResponse.getLastError());
-        }
-
+        errors.addAll(addendumResponse.getErrors());
         setWarning(getWarning() + addendumResponse.getWarning());
-        setCompletedUIDs(unionOf(getCompletedUIDs(), addendumResponse.getCompletedUIDs()));
-        setFailedUIDs(unionOf(getFailedUIDs(), addendumResponse.getFailedUIDs()));
-    }
-
-    private static String[] unionOf(String[] first, String[] second) {
-        if (isNull(first)) {
-            return second;
-        }
-        if (isNull(second)) {
-            return first;
-        }
-        return Stream.concat(Stream.of(first), Stream.of(second)).toArray(String[]::new);
+        addCompletedUIDs(addendumResponse.getCompletedUIDs());
+        addFailedUIDs(addendumResponse.getFailedUIDs());
     }
 }

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/service/BasicCStoreSCUResp.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/service/BasicCStoreSCUResp.java
@@ -40,10 +40,10 @@ package org.dcm4che3.net.service;
 
 import org.dcm4che3.net.Status;
 
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.stream.Stream;
+
+import static java.util.Objects.nonNull;
+import static java.util.Objects.isNull;
 
 /**
  * @author Umberto Cappellini <umberto.cappellini@agfa.com>
@@ -110,30 +110,24 @@ public class BasicCStoreSCUResp {
 
         setCompleted(getCompleted() + addendumResponse.getCompleted());
         setFailed(getFailed() + addendumResponse.getFailed());
+
         // Do not forget the last error
-        if (Objects.nonNull(addendumResponse.getLastError())) {
+        if (nonNull(addendumResponse.getLastError())) {
             setLastError(addendumResponse.getLastError());
         }
-        setWarning(getWarning() + addendumResponse.getWarning());
 
-        String[] currentCompletedUIDs = getCompletedUIDs();
-        String[] newCompletedUIDs = addendumResponse.getCompletedUIDs();
-        if (currentCompletedUIDs == null) {
-            setCompletedUIDs(newCompletedUIDs);
-        } else if (newCompletedUIDs != null) {
-            String[] completedUIDs = Arrays.copyOf(currentCompletedUIDs, currentCompletedUIDs.length + newCompletedUIDs.length);
-            System.arraycopy(newCompletedUIDs, 0, completedUIDs, currentCompletedUIDs.length, newCompletedUIDs.length);
-            setCompletedUIDs(completedUIDs);
+        setWarning(getWarning() + addendumResponse.getWarning());
+        setCompletedUIDs(unionOf(getCompletedUIDs(), addendumResponse.getCompletedUIDs()));
+        setFailedUIDs(unionOf(getFailedUIDs(), addendumResponse.getFailedUIDs()));
+    }
+
+    private static String[] unionOf(String[] first, String[] second) {
+        if (isNull(first)) {
+            return second;
         }
-		
-        String[] currentFailedUIDs = getFailedUIDs();
-        String[] newFailedUIDs = addendumResponse.getFailedUIDs();
-        if (currentFailedUIDs == null) {
-            setFailedUIDs(newFailedUIDs);
-        } else if (newFailedUIDs != null) {
-            String[] failedUIDs = Arrays.copyOf(currentFailedUIDs, currentFailedUIDs.length + newFailedUIDs.length);
-            System.arraycopy(newFailedUIDs, 0, failedUIDs, currentFailedUIDs.length, newFailedUIDs.length);
-            setFailedUIDs(failedUIDs);
+        if (isNull(second)) {
+            return first;
         }
+        return Stream.concat(Stream.of(first), Stream.of(second)).toArray(String[]::new);
     }
 }


### PR DESCRIPTION
Error information was lost in IEI-96376 because BasicCStoreSCUResp removes the Last Error when the addendum response doesn't have any errors. The correct behavior should be replacing it only if a new one arises.