### PR TITLE
[LIB-363] NullPointerException in Attributes.getModified()

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -3176,7 +3176,7 @@ public class Attributes implements Serializable {
             } else if (origValue instanceof Fragments) {
                 result.set(privateCreator, tag, (Fragments) origValue);
             } else {
-                result.set(privateCreator, tag, vrs[i], origValue);
+                result.set(privateCreator, tag, vrs[j], origValue);
             }
         }
         return result;

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
@@ -303,6 +303,26 @@ public class AttributesTest {
     }
 
     @Test
+    public void testGetModified_LIB_363()
+    {
+        // tests the fix for LIB-363
+
+        Attributes original = new Attributes();
+        original.setString(Tag.AccessionNumber, VR.SH, "AccessionNumber");
+        
+        Attributes other = new Attributes();
+        other.setString(Tag.SOPInstanceUID, VR.UI, "1.2.3.4");
+        other.setString(Tag.AccessionNumber, VR.SH, "AccessionNumber2");
+
+        Attributes modified = original.getModified(other, null);
+
+        Attributes expected = new Attributes();
+        expected.setString(Tag.AccessionNumber, VR.SH, "AccessionNumber");
+
+        assertEquals(expected, modified);
+    }
+
+    @Test
     public void testGetRemovedOrModified() {
         Attributes original = createOriginal();
         Attributes other = modify(original);


### PR DESCRIPTION
Cherry-picked from 10263e523a58e834bcff0d64fcf36e567aedc6fb
See https://dcm4che.atlassian.net/browse/LIB-363

@gunterze This is a very old fix from the generic-config branch.