### PR TITLE
Proposal: use MappedByteBuffer to read file instead of a giant byte array

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomOutputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomOutputStream.java
@@ -113,6 +113,10 @@ public class DicomOutputStream extends FilterOutputStream {
     public void write(byte[] b, int off, int len) throws IOException {
         out.write(b, off, len);
     }
+    
+    public void write(byte b) throws IOException {
+        out.write(b);
+    }
 
     public void writeCommand(Attributes cmd) throws IOException {
         if (explicitVR || bigEndian)


### PR DESCRIPTION
Hi, 

We are embedding videos inside DICOM files using jpg2dcm, and we noticed that this tool requires to allocate the entire byte array to store the video in memory which can stress our host a bit too much. 

This small patch just use a MappedByteBuffer to allow access to video data without having to allocate anything by ourselves.

The speed should be equivalent (maybe even faster), but the memory requirement should be far smaller.

For sure there is still a limitation with the size of a video that could not be bigger than 2GB, although 
 the standard allows 4GB file, but this could be done in another pull request, as it requires modifications in the MPEG parser.

Just tell us if it is acceptable or if some change are required to be accepted.

Regards,
Didier Weckmann
IRCAD / IHU Strasbourg - France