### PR TITLE
[IEI-87704] AuditLogger.isInstalled assumes null = true for Boolean v…

### DIFF
--- a/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
+++ b/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
@@ -334,11 +334,11 @@ public class AuditLogger extends DeviceExtension {
     @ConfigurableProperty(name = "dcmAuditMessageSupplement95Schema", defaultValue = "false")
     private boolean supplement95;
 
-    @ConfigurableProperty(name = "dicomInstalled")
-    private Boolean auditLoggerInstalled;
+    @ConfigurableProperty(name = "dicomInstalled", defaultValue = "false")
+    private boolean auditLoggerInstalled = false;
 
     @ConfigurableProperty(name = "dcmAuditIncludeInstanceUID")
-    private Boolean doIncludeInstanceUID = false;
+    private boolean doIncludeInstanceUID = false;
 
     @ConfigurableProperty(name = "dcmAuditLoggerSpoolDirectoryURI")
     private String spoolDirectoryURI;
@@ -637,30 +637,29 @@ public class AuditLogger extends DeviceExtension {
 
     public boolean isInstalled() {
         return device != null && device.isInstalled()
-                && (auditLoggerInstalled == null || auditLoggerInstalled.booleanValue());
+                && auditLoggerInstalled;
     }
 
-    public final Boolean getAuditLoggerInstalled() {
+    public final boolean getAuditLoggerInstalled() {
         return auditLoggerInstalled;
     }
 
-    public void setAuditLoggerInstalled(Boolean installed) {
-        if (installed != null && installed.booleanValue()
-                && device != null && !device.isInstalled())
+    public void setAuditLoggerInstalled(boolean installed) {
+        if (installed && device != null && !device.isInstalled())
             throw new IllegalStateException("owning device not installed");
         this.auditLoggerInstalled = installed;
     }
 
 
-    public Boolean isIncludeInstanceUID() {
+    public boolean isIncludeInstanceUID() {
         return doIncludeInstanceUID;
     }
 
-    public Boolean getDoIncludeInstanceUID() {
+    public boolean getDoIncludeInstanceUID() {
         return doIncludeInstanceUID;
     }
 
-    public void setDoIncludeInstanceUID(Boolean doIncludeInstanceUID) {
+    public void setDoIncludeInstanceUID(boolean doIncludeInstanceUID) {
         this.doIncludeInstanceUID = doIncludeInstanceUID;
     }
 


### PR DESCRIPTION
When an AuditLogger extension exists in the configuration if the 'dicom installed' value has never been set or modified it will be null in the actual configuration.

This will result in audit messages still being created and put into memory even if there is no place for them to be sent or saved to with auditing disabled completely.