### PR TITLE
hl7rcv: Wrong port number in help text

### DIFF
--- a/dcm4che-tool/dcm4che-tool-hl7rcv/README.md
+++ b/dcm4che-tool/dcm4che-tool-hl7rcv/README.md
@@ -107,5 +107,5 @@ Options:
                                      default
 -
 Example: hl7rcv -b 2575
-=> Starts receiver listening on port 11112.
+=> Starts receiver listening on port 2575.
 ```


### PR DESCRIPTION
The port is 2575 Instead of 11112, this according to what the documentation indicates.