### PR TITLE
Detect 64-bit VM in tool launchers under Windows for Java 10+

### DIFF
--- a/dcm4che-assembly/src/bin/dcm2dcm.bat
+++ b/dcm4che-assembly/src/bin/dcm2dcm.bat
@@ -58,7 +58,7 @@ set CP=%CP%;%DCM4CHE_HOME%\lib\log4j-${log4j.version}.jar
 set CP=%CP%;%DCM4CHE_HOME%\lib\commons-cli-${commons-cli.version}.jar
 
 rem Setup the native library path
-"%JAVA%" -d64 -version >nul 2>&1 && set OS=win-x86_64 || set OS=win-i686
+"%JAVA%" -version 2>&1 | findstr 64-Bit >nul && set "OS=win-x86_64" || set "OS=win-i686"
 set "JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%"
 
 set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path=%JAVA_LIBRARY_PATH%

--- a/dcm4che-assembly/src/bin/dcm2jpg.bat
+++ b/dcm4che-assembly/src/bin/dcm2jpg.bat
@@ -58,7 +58,7 @@ set CP=%CP%;%DCM4CHE_HOME%\lib\log4j-${log4j.version}.jar
 set CP=%CP%;%DCM4CHE_HOME%\lib\commons-cli-${commons-cli.version}.jar
 
 rem Setup the native library path
-"%JAVA%" -d64 -version >nul 2>&1 && set OS=win-x86_64 || set OS=win-i686
+"%JAVA%" -version 2>&1 | findstr 64-Bit >nul && set "OS=win-x86_64" || set "OS=win-i686"
 set "JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%"
 
 set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path=%JAVA_LIBRARY_PATH%

--- a/dcm4che-assembly/src/bin/storescu.bat
+++ b/dcm4che-assembly/src/bin/storescu.bat
@@ -59,7 +59,7 @@ set CP=%CP%;%DCM4CHE_HOME%\lib\log4j-${log4j.version}.jar
 set CP=%CP%;%DCM4CHE_HOME%\lib\commons-cli-${commons-cli.version}.jar
 
 rem Setup native library path
-"%JAVA%" -d64 -version >nul 2>&1 && set OS=win-x86_64 || set OS=win-i686
+"%JAVA%" -version 2>&1 | findstr 64-Bit >nul && set "OS=win-x86_64" || set "OS=win-i686"
 set "JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%"
 
 set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path=%JAVA_LIBRARY_PATH%


### PR DESCRIPTION
The launch option `-d64`, that some of the tool batch scripts used to detect the VM's architecture, has been removed since Java 10 (https://bugs.openjdk.java.net/browse/JDK-8169646). This has already been addressed for the affected shell scripts with #442. 

I used a similar way to fix the windows batch scripts and tested it successfully with OpenJDK 8 and 11, using 32-bit and 64-bit runtime environments for both of them.

**EDIT:**
This also fixes problems with invalid library paths, as mentioned in #628
