### PR TITLE
[IEI-102318] Checking Internal Auditing checkbox is not logging ARR m…

### DIFF
--- a/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
+++ b/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
@@ -334,8 +334,8 @@ public class AuditLogger extends DeviceExtension {
     @ConfigurableProperty(name = "dcmAuditMessageSupplement95Schema", defaultValue = "false")
     private boolean supplement95;
 
-    @ConfigurableProperty(name = "dicomInstalled", defaultValue = "true")
-    private boolean auditLoggerInstalled = true;
+    @ConfigurableProperty(name = "dicomInstalled", defaultValue = "false")
+    private boolean auditLoggerInstalled = false;
 
     @ConfigurableProperty(name = "dcmAuditIncludeInstanceUID")
     private boolean doIncludeInstanceUID = false;


### PR DESCRIPTION
…essages
Change the default value of AuditLogger.dicomInstalled to false, so when no ARRs are configured it's not generating audit messages.