### PR TITLE
Split switchTransferSyntax() to make boolean toggle work in writeFileMetaInformation() again

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomOutputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomOutputStream.java
@@ -77,7 +77,7 @@ public class DicomOutputStream extends FilterOutputStream {
             throws IOException {
         super(out);
         switchBigEndianAndExplicitVr(tsuid);
-		switchOutputStream(tsuid);
+        switchOutputStream(tsuid);
     }
 
     public DicomOutputStream(File file) throws IOException {
@@ -136,7 +136,7 @@ public class DicomOutputStream extends FilterOutputStream {
             throws IOException {
         if (fmi != null) {
             writeFileMetaInformation(fmi);
-			switchOutputStream(fmi.getString(Tag.TransferSyntaxUID, null));
+            switchOutputStream(fmi.getString(Tag.TransferSyntaxUID, null));
         }
         if (dataset.bigEndian() != bigEndian
                 || encOpts.groupLength
@@ -148,18 +148,18 @@ public class DicomOutputStream extends FilterOutputStream {
         dataset.writeTo(this);
     }
 
-	private void switchBigEndianAndExplicitVr(String tsuid) {
-		bigEndian = tsuid.equals(UID.ExplicitVRBigEndianRetired);
-		explicitVR = !tsuid.equals(UID.ImplicitVRLittleEndian);
-	}
+    private void switchBigEndianAndExplicitVr(String tsuid) {
+        bigEndian = tsuid.equals(UID.ExplicitVRBigEndianRetired);
+        explicitVR = !tsuid.equals(UID.ImplicitVRLittleEndian);
+    }
 
     private void switchOutputStream(String tsuid) {
-		if (tsuid.equals(UID.DeflatedExplicitVRLittleEndian)
+        if (tsuid.equals(UID.DeflatedExplicitVRLittleEndian)
                         || tsuid.equals(UID.JPIPReferencedDeflate)) {
                 super.out = new DeflaterOutputStream(super.out,
                         new Deflater(Deflater.DEFAULT_COMPRESSION, true));
         }
-	}
+    }
 
     public void writeHeader(int tag, VR vr, int len) throws IOException {
         byte[] b = buf;


### PR DESCRIPTION
The fix for issue #449 unfortunately breaks cases where the FMI is written separately from the dataset, and the transfer syntax is 1.2.840.10008.1.2 (Implicit VR) or 1.2.840.10008.1.2.2 (Big Endian). In these cases the corresponding booleans do not get switched any more and, as a consequence, the `DicomOutputStream` encodes all following data elements wrongly.

I am not 100% sure whether it is OK to split up `switchTransferSyntax()` for each and every use case, as I do not fully understand the motivation for issue #449. However, the proposed changes here do fix regressions on my end and maybe this is useful to you, too. In any case, please let me know if a more refined approach is required.
