### PR TITLE
default return value for TransferSyntaxType.forUID() => null

### DIFF
--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/TransferSyntaxType.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/TransferSyntaxType.java
@@ -109,11 +109,11 @@ public enum TransferSyntaxType {
 
     public static TransferSyntaxType forUID(String uid) {
         switch(uid) {
-        	case UID.ImplicitVRLittleEndian:
-        	case UID.ExplicitVRLittleEndian:
-        	case UID.ExplicitVRBigEndianRetired:
-        	case UID.DeflatedExplicitVRLittleEndian:
-        		return NATIVE;
+        case UID.ImplicitVRLittleEndian:
+            case UID.ExplicitVRLittleEndian:
+            case UID.ExplicitVRBigEndianRetired:
+            case UID.DeflatedExplicitVRLittleEndian:
+                return NATIVE;
             case UID.JPEGBaseline1:
                 return JPEG_BASELINE;
             case UID.JPEGExtended24:
@@ -149,7 +149,7 @@ public enum TransferSyntaxType {
             case UID.RLELossless:
                 return RLE;
             default:
-            	return null;
+                return null;
         }
     }
 

--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/TransferSyntaxType.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/TransferSyntaxType.java
@@ -109,6 +109,11 @@ public enum TransferSyntaxType {
 
     public static TransferSyntaxType forUID(String uid) {
         switch(uid) {
+        	case UID.ImplicitVRLittleEndian:
+        	case UID.ExplicitVRLittleEndian:
+        	case UID.ExplicitVRBigEndianRetired:
+        	case UID.DeflatedExplicitVRLittleEndian:
+        		return NATIVE;
             case UID.JPEGBaseline1:
                 return JPEG_BASELINE;
             case UID.JPEGExtended24:
@@ -143,8 +148,9 @@ public enum TransferSyntaxType {
                 return MPEG;
             case UID.RLELossless:
                 return RLE;
+            default:
+            	return null;
         }
-        return NATIVE;
     }
 
     public static boolean isLossyCompression(String uid) {


### PR DESCRIPTION
I restored the old behaviour of `TransferSyntaxType.forUID()` to return `null` on unknown transfer syntax UIDs. At a certain point in my code I need the `TransferSyntaxType` to go on, but would rather stop processing with an error, instead of assuming a NATIVE format for unknown transfer syntaxes. The new implementation made this distinction impossible.

It seems to me, that this was quite likely a deliberate choice of yours, and that some of your code might depend on `TransferSyntaxType.forUID()` to never return `null`. I am proposing this pull request anyway, should this have been an oversight after all.