### PR TITLE
Fix copy and paste typo in ImageReaderParam.toString()

### DIFF
--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/ImageReaderFactory.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/ImageReaderFactory.java
@@ -123,7 +123,7 @@ public class ImageReaderFactory implements Serializable {
 
         @Override
         public String toString() {
-            return "ImageWriterParam{" +
+            return "ImageReaderParam{" +
                     "formatName='" + formatName + '\'' +
                     ", className='" + className + '\'' +
                     ", patchJPEGLS=" + patchJPEGLS +


### PR DESCRIPTION
`ImageReaderParam.toString()` uses the wrong class name (`ImageWriterParam`) for its output.