### PR TITLE
Allow spaces in DCM4CHE_HOME under windows again. Fix #628

### DIFF
--- a/dcm4che-assembly/src/bin/dcm2dcm.bat
+++ b/dcm4che-assembly/src/bin/dcm2dcm.bat
@@ -59,9 +59,9 @@ set CP=%CP%;%DCM4CHE_HOME%\lib\commons-cli-${commons-cli.version}.jar
 
 rem Setup the native library path
 "%JAVA%" -version 2>&1 | findstr 64-Bit >nul && set "OS=win-x86_64" || set "OS=win-i686"
-set "JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%"
+set JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%
 
-set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path=%JAVA_LIBRARY_PATH%
+set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path="%JAVA_LIBRARY_PATH%"
 
 if not "%IMAGE_READER_FACTORY%" == "" ^
  set JAVA_OPTS=%JAVA_OPTS% -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=%IMAGE_READER_FACTORY%

--- a/dcm4che-assembly/src/bin/dcm2jpg.bat
+++ b/dcm4che-assembly/src/bin/dcm2jpg.bat
@@ -59,9 +59,9 @@ set CP=%CP%;%DCM4CHE_HOME%\lib\commons-cli-${commons-cli.version}.jar
 
 rem Setup the native library path
 "%JAVA%" -version 2>&1 | findstr 64-Bit >nul && set "OS=win-x86_64" || set "OS=win-i686"
-set "JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%"
+set JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%
 
-set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path=%JAVA_LIBRARY_PATH%
+set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path="%JAVA_LIBRARY_PATH%"
 
 if not "%IMAGE_READER_FACTORY%" == "" ^
  set JAVA_OPTS=%JAVA_OPTS% -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=%IMAGE_READER_FACTORY%

--- a/dcm4che-assembly/src/bin/storescu.bat
+++ b/dcm4che-assembly/src/bin/storescu.bat
@@ -60,9 +60,9 @@ set CP=%CP%;%DCM4CHE_HOME%\lib\commons-cli-${commons-cli.version}.jar
 
 rem Setup native library path
 "%JAVA%" -version 2>&1 | findstr 64-Bit >nul && set "OS=win-x86_64" || set "OS=win-i686"
-set "JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%"
+set JAVA_LIBRARY_PATH=%DCM4CHE_HOME%\lib\%OS%
 
-set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path=%JAVA_LIBRARY_PATH%
+set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path="%JAVA_LIBRARY_PATH%"
 
 if not "%IMAGE_READER_FACTORY%" == "" ^
  set JAVA_OPTS=%JAVA_OPTS% -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=%IMAGE_READER_FACTORY%


### PR DESCRIPTION
Fixes a regression with spaces in the `%DCM4CHE_HOME%` path, introduced in #629.

Tested successfully using:
- Windows 10
- OpenJDK 8 and 11 (both 64 and 32 bit)
- with and without spaces in the execution path
- `dcm2jpg.bat` with compressed image