### PR TITLE
Create directory if dest doesn't exist

### DIFF
--- a/dcm4che-tool/dcm4che-tool-dcm2jpg/src/main/java/org/dcm4che3/tool/dcm2jpg/Dcm2Jpg.java
+++ b/dcm4che-tool/dcm4che-tool-dcm2jpg/src/main/java/org/dcm4che3/tool/dcm2jpg/Dcm2Jpg.java
@@ -307,10 +307,13 @@ public class Dcm2Jpg {
             if (argc < 2)
                 throw new ParseException(rb.getString("missing"));
             File dest = new File(argList.get(argc-1));
-            if ((argc > 2 || new File(argList.get(0)).isDirectory())
-                    && !dest.isDirectory())
+            if (!dest.isFile() && !dest.exists()) {
+                dest.mkdirs();
+            }
+            if ((argc > 2 || new File(argList.get(0)).isDirectory()) && !dest.isDirectory()) {
                 throw new ParseException(
                         MessageFormat.format(rb.getString("nodestdir"), dest));
+            }
             for (String src : argList.subList(0, argc-1))
                 main.mconvert(new File(src), dest);
         } catch (ParseException e) {


### PR DESCRIPTION
This change fixes https://github.com/dcm4che/dcm4che/issues/387, create the directory to avoid exceptions thrown.
