### PR TITLE
*ImageReaderSpi classes report ability to decode ImageInputStreams which the actual Readers fail to decode

### DIFF
--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJ2kImageReaderSpi.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJ2kImageReaderSpi.java
@@ -80,7 +80,14 @@ public class NativeJ2kImageReaderSpi extends ImageReaderSpi {
         if (!(source instanceof ImageInputStream)) {
             return false;
         }
+
         ImageInputStream iis = (ImageInputStream) source;
+        // NativeImageReader.read() eventually instantiates a StreamSegment, 
+        // which does not support all ImageInputStreams
+        if (!StreamSegment.supportsInputStream(iis)) {
+        	return false;
+        }
+
         iis.mark();
         try {
             int marker = (iis.read() << 8) | iis.read();

--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJLSImageReaderSpi.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJLSImageReaderSpi.java
@@ -80,7 +80,14 @@ public class NativeJLSImageReaderSpi extends ImageReaderSpi {
         if (!(source instanceof ImageInputStream)) {
             return false;
         }
+
         ImageInputStream iis = (ImageInputStream) source;
+        // NativeImageReader.read() eventually instantiates a StreamSegment, 
+        // which does not support all ImageInputStreams
+        if (!StreamSegment.supportsInputStream(iis)) {
+        	return false;
+        }
+
         iis.mark();
         int byte1 = iis.read();
         int byte2 = iis.read();

--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJPEGImageReaderSpi.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJPEGImageReaderSpi.java
@@ -90,7 +90,14 @@ public class NativeJPEGImageReaderSpi extends ImageReaderSpi {
         if (!(source instanceof ImageInputStream)) {
             return false;
         }
+
         ImageInputStream iis = (ImageInputStream) source;
+        // NativeImageReader.read() eventually instantiates a StreamSegment, 
+        // which does not support all ImageInputStreams
+        if (!StreamSegment.supportsInputStream(iis)) {
+        	return false;
+        }
+
         iis.mark();
         try {
             int byte1 = iis.read();

--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/StreamSegment.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/StreamSegment.java
@@ -104,6 +104,15 @@ public abstract class StreamSegment {
         }
         throw new IllegalArgumentException("No stream adaptor found for " + iis.getClass().getName() + "!");
     }
+    
+    public static boolean supportsInputStream(ImageInputStream iis) {
+        // This list must reflect getStreamSegment()'s implementation
+        return
+            (iis instanceof ExtendSegmentedInputImageStream) ||
+            (iis instanceof SegmentedInputImageStream) ||
+            (iis instanceof BytesWithImageImageDescriptor)
+        ;
+    }
 
     private static StreamSegment getFileStreamSegment(SegmentedInputImageStream iis) {
         try {


### PR DESCRIPTION
The various `ImageReaderSpi`s solely checked that the given Object to read from is an ImageInputStream. The `NativeReader` provided by the SPIs, however, eventually tries to create a StreamSegment, which imposes more restrictions on the actual subtype of ImageInputStream in `org.dcm4che3.opencv.StreamSegment.getStreamSegment(ImageInputStream, ImageReadParam)`.

When the SPIs, provided by dcm4che, are on the classpath, they will be considered by Java's ImageIO framwork, for example when using `javax.imageio.ImageIO.read(File)`. In these cases the SPI reports, that the corresponding Reader can decode the stream, when in reality it can not handle the `FileImageInputStream` which was created by ImageIO.
This issue can cause errors in completely unrelated parts of the code.

I fixed this by making the SPIs aware of `StreamSegment`'s limitations.


P.S.: When more than on SPI claims that its Readers can handle the input, I found that ImageIO chooses an SPI/Reader at random. If you want to reproduce this issue, I suggest to run your test code multiple times, until it fails, or deregister competing SPIs with `javax.imageio.spi.ServiceRegistry.deregisterServiceProvider(Object)`