### PR TITLE
[IEI-103029] Fixing thread leak when writing a dimse response fails

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
@@ -1211,7 +1211,15 @@ public class Association {
         rspHandler.setPC(pc);
         addDimseRSPHandler(rspHandler);
         startTimeout(rspHandler.getMessageID(), rspTimeout);
-        encoder.writeDIMSE(pc, cmd, data);
+        try {
+            encoder.writeDIMSE(pc, cmd, data);
+        } catch (IOException | RuntimeException e) {
+            // In some scenarios, there might be a zombie thread
+            // waiting forever for a spot to write into the queue
+            // if we don't handle an exception here.
+            removeDimseRSPHandler(rspHandler.getMessageID());
+            throw e;
+        }
     }
 
     static int minZeroAsMax(int i1, int i2) {


### PR DESCRIPTION
When a device does not respect the DICOM standard and sends messages asynchronously even though we told them to behave synchronously, there might be a thread leak when writing the response fails and there are other threads waiting for a spot to add a message to the response queue.

Removing the message from the queue when an exception is thrown fixes the issue.