### PR TITLE
Merge Handle escaped HL7 Separator characters by constructor of Issuer and IDWithIssuer #674 add missing method

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Issuer.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Issuer.java
@@ -142,6 +142,10 @@ public class Issuer implements Serializable {
         }
     }
 
+    public String parseAndUnescape(){
+        return parseAndDeescapeDelimiters(toString());
+    }
+
     private String parseAndDeescapeDelimiters(String s) {
         String value = emptyToNull(s);
         if (value != null && value.contains(escapedDelimiter)) {


### PR DESCRIPTION
Forgot to commit the method for accessing the String representation using unescaped characters