### PR TITLE
DicomInputStream#readValue(): remove code that creates multiple arrays

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 
@@ -67,6 +68,7 @@ import org.dcm4che3.data.VR;
 import org.dcm4che3.util.ByteUtils;
 import org.dcm4che3.util.SafeClose;
 import org.dcm4che3.util.StreamUtils;
+import org.dcm4che3.util.StringUtils;
 import org.dcm4che3.util.TagUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -162,8 +164,6 @@ public class DicomInputStream extends FilterInputStream
     }
 
     /** 
-     * Returns the limit of initial allocated memory for element values.
-     * 
      * By default, the limit is set to 67108864 (64 MiB).
      *
      * @return Limit of initial allocated memory for value or -1 for no limit
@@ -174,22 +174,9 @@ public class DicomInputStream extends FilterInputStream
     }
 
     /**
-     * Sets the limit of initial allocated memory for element values. If the
-     * value length exceeds the limit, a byte array with the specified size is
-     * allocated. If the array can filled with bytes read from this
-     * <code>DicomInputStream</code>, the byte array is reallocated with
-     * twice the previous length and filled again. That continues until
-     * the twice of the previous length exceeds the actual value length. Then
-     * the byte array is reallocated with actual value length and filled with
-     * the remaining bytes for the value from this <code>DicomInputStream</code>.
-     * 
-     * The rational of the incrementing allocation of byte arrays is to avoid
-     * OutOfMemoryErrors on parsing corrupted DICOM streams.
-     * 
      * By default, the limit is set to 67108864 (64 MiB).
      * 
      * @param allocateLimit limit of initial allocated memory or -1 for no limit
-     * 
      */
     public final void setAllocateLimit(int allocateLimit) {
         this.allocateLimit = allocateLimit;
@@ -761,27 +748,36 @@ public class DicomInputStream extends FilterInputStream
     }
 
     public byte[] readValue() throws IOException {
-        int valLen = length;
+
         try {
-            if (valLen < 0)
-                throw new EOFException(); // assume InputStream length < 2 GiB
-            int allocLen = allocateLimit >= 0
-                    ? Math.min(valLen, allocateLimit)
-                    : valLen;
-            byte[] value = new byte[allocLen];
-            readFully(value, 0, allocLen);
-            while (allocLen < valLen) {
-                int newLength = Math.min(valLen, allocLen << 1);
-                value = Arrays.copyOf(value, newLength);
-                readFully(value, allocLen, newLength - allocLen);
-                allocLen = newLength;
+
+            if (length < 0) {
+                throw new EOFException("DicomInputStream length is less than zero");
             }
+
+            if (allocateLimit > 0 && length > allocateLimit) {
+                LOG.warn("Expected value length {} exceeds allocate limit {}", length, allocateLimit);
+            }
+
+            byte[] value = new byte[length];
+
+            readFully(value, 0, length);
+
             return value;
+
         } catch (IOException e) {
-            LOG.warn("IOException during read of {} #{} @ {}",
-                    TagUtils.toString(tag), length, tagPos, e);
+
+            if ((Objects.isNull(e.getMessage()) || e.getMessage().trim().equals("")) && Objects.nonNull(e.getCause())) {
+
+                    throw new IOException(String.format("IOException during read of %s #%d @ %d",
+                            TagUtils.toString(tag), length, tagPos), e.getCause());
+
+            }
+
             throw e;
+
         }
+
     }
 
     private void switchTransferSyntax(String tsuid) throws IOException {

--- a/dcm4che-core/src/test/java/org/dcm4che3/io/DicomInputStreamTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/io/DicomInputStreamTest.java
@@ -1,20 +1,31 @@
 package org.dcm4che3.io;
 
-import static org.junit.Assert.*;
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.BulkData;
+import org.dcm4che3.data.Sequence;
+import org.dcm4che3.data.Tag;
+import org.dcm4che3.data.UID;
+import org.dcm4che3.data.VR;
+import org.dcm4che3.io.DicomInputStream.IncludeBulkData;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.FileInputStream;
 
-import org.dcm4che3.data.BulkData;
-import org.dcm4che3.data.Tag;
-import org.dcm4che3.data.Attributes;
-import org.dcm4che3.data.Sequence;
-import org.dcm4che3.io.DicomInputStream.IncludeBulkData;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Gunter Zeilinger <gunterze@gmail.com>
  */
 public class DicomInputStreamTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
     public void testPart10ExplicitVR() throws Exception {
@@ -51,7 +62,7 @@ public class DicomInputStreamTest {
         assertEquals(((BulkData) pixelData).uri, item.getString(Tag.RetrieveURL));
     }
 
-    private static Attributes readFromResource(String name, 
+    private static Attributes readFromResource(String name,
             IncludeBulkData includeBulkData)
             throws Exception {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
@@ -64,6 +75,33 @@ public class DicomInputStreamTest {
         } finally {
             in.close();
         }
+    }
+
+    @Test
+    public void readValueExplicitVR() throws Exception {
+
+        File smallBlob = temporaryFolder.newFile("smallBlob");
+
+        byte[] expectedBytes = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+        try (DicomOutputStream dicomOutputStream = new DicomOutputStream(smallBlob)) {
+
+            dicomOutputStream.writeAttribute(Tag.PixelData, VR.OB, expectedBytes);
+
+        }
+
+        try (FileInputStream fileInputStream = new FileInputStream(smallBlob)) {
+
+            DicomInputStream dicomInputStream = new DicomInputStream(fileInputStream, UID.ExplicitVRLittleEndian);
+
+            dicomInputStream.readHeader();
+
+            byte[] actualBytes = dicomInputStream.readValue();
+
+            Assert.assertArrayEquals(expectedBytes, actualBytes);
+
+        }
+
     }
 
 }


### PR DESCRIPTION
This is the same change that was made to the generic-config branch, see [pr #689](https://github.com/dcm4che/dcm4che/pull/689)