### PR TITLE
Minor fixes for metadata refactoring of DCM4CHE3

### DIFF
--- a/dcm4che-all/pom.xml
+++ b/dcm4che-all/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-parent</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>dcm4che-all</artifactId>

--- a/dcm4che-assembly/pom.xml
+++ b/dcm4che-assembly/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-parent</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>dcm4che-assembly</artifactId>

--- a/dcm4che-audit/pom.xml
+++ b/dcm4che-audit/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-parent</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-audit</artifactId>
   <packaging>bundle</packaging>

--- a/dcm4che-camel/pom.xml
+++ b/dcm4che-camel/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-camel</artifactId>
   <packaging>bundle</packaging>

--- a/dcm4che-cdi/dcm4che-cdi-device/pom.xml
+++ b/dcm4che-cdi/dcm4che-cdi-device/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-cdi-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-cdi-device</artifactId>
   <dependencies>

--- a/dcm4che-cdi/dcm4che-cdi-ear/pom.xml
+++ b/dcm4che-cdi/dcm4che-cdi-ear/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-cdi-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-cdi-ear</artifactId>
   <packaging>ear</packaging>

--- a/dcm4che-cdi/dcm4che-cdi-echo/pom.xml
+++ b/dcm4che-cdi/dcm4che-cdi-echo/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-cdi-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-cdi-echo</artifactId>
   <dependencies>

--- a/dcm4che-cdi/dcm4che-cdi-rest/pom.xml
+++ b/dcm4che-cdi/dcm4che-cdi-rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-cdi-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-cdi-rest</artifactId>
   <dependencies>

--- a/dcm4che-cdi/dcm4che-cdi-war/pom.xml
+++ b/dcm4che-cdi/dcm4che-cdi-war/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-cdi-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-cdi-war</artifactId>
   <packaging>war</packaging>

--- a/dcm4che-cdi/pom.xml
+++ b/dcm4che-cdi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-cdi-parent</artifactId>
   <packaging>pom</packaging>

--- a/dcm4che-conf/dcm4che-conf-api-hl7/pom.xml
+++ b/dcm4che-conf/dcm4che-conf-api-hl7/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dcm4che-conf</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-conf-api-hl7</artifactId>

--- a/dcm4che-conf/dcm4che-conf-api/pom.xml
+++ b/dcm4che-conf/dcm4che-conf-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>dcm4che-conf</artifactId>
         <groupId>org.dcm4che</groupId>
-        <version>3.3.9-METADATA-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>dcm4che-conf-api</artifactId>
     <name>dcm4che-conf-api</name>

--- a/dcm4che-conf/dcm4che-conf-core-api/pom.xml
+++ b/dcm4che-conf/dcm4che-conf-core-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>dcm4che-conf</artifactId>
         <groupId>org.dcm4che</groupId>
-        <version>3.3.9-METADATA-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>dcm4che-conf-core-api</artifactId>
     <name>dcm4che-conf-core-api</name>

--- a/dcm4che-conf/dcm4che-conf-core/pom.xml
+++ b/dcm4che-conf/dcm4che-conf-core/pom.xml
@@ -45,7 +45,7 @@
   <parent>
     <artifactId>dcm4che-conf</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-conf-core</artifactId>
   <name>dcm4che-conf-core</name>

--- a/dcm4che-conf/dcm4che-conf-dicom/pom.xml
+++ b/dcm4che-conf/dcm4che-conf-dicom/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <artifactId>dcm4che-conf</artifactId>
         <groupId>org.dcm4che</groupId>
-        <version>3.3.9-METADATA-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>dcm4che-conf-dicom</artifactId>
     <packaging>jar</packaging>

--- a/dcm4che-conf/dcm4che-conf-ldap/pom.xml
+++ b/dcm4che-conf/dcm4che-conf-ldap/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dcm4che-conf</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-conf-ldap</artifactId>
   <name>dcm4che-conf-ldap</name>

--- a/dcm4che-conf/dcm4che-conf-test/pom.xml
+++ b/dcm4che-conf/dcm4che-conf-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dcm4che-conf</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-conf-test</artifactId>
   <name>dcm4che-conf-test</name>

--- a/dcm4che-conf/pom.xml
+++ b/dcm4che-conf/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>dcm4che-parent</artifactId>
         <groupId>org.dcm4che</groupId>
-        <version>3.3.9-METADATA-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>dcm4che-conf</artifactId>
     <packaging>pom</packaging>

--- a/dcm4che-core/pom.xml
+++ b/dcm4che-core/pom.xml
@@ -41,7 +41,7 @@
   <parent>
     <artifactId>dcm4che-parent</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>dcm4che-core</artifactId>

--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -387,6 +387,9 @@ public class Attributes implements Serializable {
         return sq.get(itemIndex);
     }
 
+    /**
+     * Get the nested dataset relative to the current level.
+     */
     public Attributes getNestedDataset(ItemPointer... itemPointers) {
         Attributes item = this;
         for (ItemPointer ip : itemPointers) {

--- a/dcm4che-core/src/main/java/org/dcm4che3/data/ItemPointer.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/ItemPointer.java
@@ -38,6 +38,8 @@
 
 package org.dcm4che3.data;
 
+import org.dcm4che3.util.TagUtils;
+
 import java.io.Serializable;
 
 /**
@@ -90,5 +92,19 @@ public class ItemPointer implements Serializable {
         result = 31 * result + (privateCreator != null ? privateCreator.hashCode() : 0);
         result = 31 * result + itemIndex;
         return result;
+    }
+
+
+    @Override
+    public String toString() {
+        StringBuilder str = new StringBuilder();
+
+        str.append("/").append(TagUtils.toString(sequenceTag));
+        if(privateCreator!=null) {
+            str.append(":").append(privateCreator);
+        }
+        str.append("[").append(itemIndex).append("]");
+
+        return str.toString();
     }
 }

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -128,6 +128,7 @@ public class DicomInputStream extends FilterInputStream
     private BulkDataDescriptor bulkDataDescriptor = BulkDataDescriptor.DEFAULT;
     private final byte[] buffer = new byte[12];
     private List<ItemPointer> itemPointers = new ArrayList<ItemPointer>(4);
+    private List<ItemPointer> immutableItemPointers;
     private boolean decodeUNWithIVRLE = true;
     private boolean addBulkDataReferences;
 
@@ -286,8 +287,23 @@ public class DicomInputStream extends FilterInputStream
         return fileMetaInformation;
     }
 
+    /**
+     * Level of sequence depth of the Attributes instance currently being populated
+     * by the DicomInputStream.  0 indicates the root level.
+     */
     public final int level() {
         return itemPointers.size();
+    }
+
+    /**
+     * Pointers from the root of the instance to the current Attributes instance being
+     * popluated by the DicomInputStream.  An empty list indicates the root level.
+     */
+    public final List<ItemPointer> itemPointers() {
+        if(this.immutableItemPointers == null) {
+            this.immutableItemPointers = Collections.unmodifiableList(itemPointers);
+        }
+        return this.immutableItemPointers;
     }
 
     public final int tag() {

--- a/dcm4che-dcmr/pom.xml
+++ b/dcm4che-dcmr/pom.xml
@@ -43,7 +43,7 @@
   <parent>
     <artifactId>dcm4che-parent</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dcm4che-dict-private/pom.xml
+++ b/dcm4che-dict-private/pom.xml
@@ -42,7 +42,7 @@
     <parent>
         <artifactId>dcm4che-parent</artifactId>
         <groupId>org.dcm4che</groupId>
-        <version>3.3.9-METADATA-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dcm4che-dict/pom.xml
+++ b/dcm4che-dict/pom.xml
@@ -41,7 +41,7 @@
   <parent>
     <artifactId>dcm4che-parent</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-dict</artifactId>

--- a/dcm4che-emf/pom.xml
+++ b/dcm4che-emf/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-emf</artifactId>
   <packaging>bundle</packaging>

--- a/dcm4che-filecache/pom.xml
+++ b/dcm4che-filecache/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-filecache</artifactId>
   <packaging>bundle</packaging>

--- a/dcm4che-hl7/pom.xml
+++ b/dcm4che-hl7/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-parent</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-hl7</artifactId>

--- a/dcm4che-image/pom.xml
+++ b/dcm4che-image/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-image</artifactId>
   <packaging>bundle</packaging>

--- a/dcm4che-imageio-rle/pom.xml
+++ b/dcm4che-imageio-rle/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-imageio-rle</artifactId>
   <packaging>bundle</packaging>

--- a/dcm4che-imageio/pom.xml
+++ b/dcm4che-imageio/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-imageio</artifactId>
   <packaging>bundle</packaging>

--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/metadata/BulkDataDicomImageAccessor.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/metadata/BulkDataDicomImageAccessor.java
@@ -138,7 +138,8 @@ public class BulkDataDicomImageAccessor implements DicomImageAccessor {
         else {
             int frameLength = calculateFrameLength();
             long pixelDataLength = Fragments.length(getPixelDataValue());
-            if(pixelDataLength % frameLength == 0) {
+            if(pixelDataLength % frameLength <= 1) {
+                // Must be within 1 bytes to account for padding
                 frames = (int) pixelDataLength / frameLength;
             }
             else {

--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/plugins/dcm/DicomImageReader.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/plugins/dcm/DicomImageReader.java
@@ -332,6 +332,14 @@ public class DicomImageReader extends ImageReader implements CloneIt<DicomImageR
         return updatedReadParam;
     }
 
+    /**
+     * Read the buffered image from the underlying data source.  Presentation state, Window Level and LUTs will be
+     * applied to the instance according to the configuration of the param argument.
+     * @param frameIndex 0 based index of the frame to read.
+     * @param param parameters to read the instance with.
+     * @return buffered image that contains the rendering DICOM frame
+     * @throws IOException Thrown when the image cannot be read from the underlying data source.
+     */
     @Override
     public BufferedImage read(int frameIndex, ImageReadParam param)
             throws IOException {
@@ -357,8 +365,9 @@ public class DicomImageReader extends ImageReader implements CloneIt<DicomImageR
             raster = (WritableRaster) readRaster(frameIndex, param);
         }
 
+
         ColorModel cm;
-        if (getAccessor().getPhotometricInterpretation().isMonochrome()) {
+        if (getAccessor().isMonochrome()) {
             int[] overlayGroupOffsets = getActiveOverlayGroupOffsets(param);
             byte[][] overlayData = new byte[overlayGroupOffsets.length][];
             for (int i = 0; i < overlayGroupOffsets.length; i++) {

--- a/dcm4che-jboss-modules/pom.xml
+++ b/dcm4che-jboss-modules/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-jboss-modules</artifactId>
   <packaging>pom</packaging>

--- a/dcm4che-js-dict/pom.xml
+++ b/dcm4che-js-dict/pom.xml
@@ -41,7 +41,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-js-dict</artifactId>
   <name>dcm4che-js-dict</name>

--- a/dcm4che-json/pom.xml
+++ b/dcm4che-json/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-json</artifactId>
   <packaging>bundle</packaging>

--- a/dcm4che-karaf/pom.xml
+++ b/dcm4che-karaf/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
   <artifactId>dcm4che-karaf</artifactId>

--- a/dcm4che-mime/pom.xml
+++ b/dcm4che-mime/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-mime</artifactId>
   <name>dcm4che-mime</name>

--- a/dcm4che-net-audit/pom.xml
+++ b/dcm4che-net-audit/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-net-audit</artifactId>
   <name>dcm4che-net-audit</name>

--- a/dcm4che-net-hl7/pom.xml
+++ b/dcm4che-net-hl7/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-parent</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-net-hl7</artifactId>

--- a/dcm4che-net-imageio/pom.xml
+++ b/dcm4che-net-imageio/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-net-imageio</artifactId>
   <name>dcm4che-net-imageio</name>

--- a/dcm4che-net/pom.xml
+++ b/dcm4che-net/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-parent</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-net</artifactId>
   <packaging>bundle</packaging>

--- a/dcm4che-osgi/dcm4che-osgi-device/pom.xml
+++ b/dcm4che-osgi/dcm4che-osgi-device/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.dcm4che</groupId>
         <artifactId>dcm4che-osgi-parent</artifactId>
-        <version>3.3.9-METADATA-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>dcm4che-osgi-device</artifactId>
     <packaging>bundle</packaging>

--- a/dcm4che-osgi/dcm4che-osgi-echo/pom.xml
+++ b/dcm4che-osgi/dcm4che-osgi-echo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.dcm4che</groupId>
         <artifactId>dcm4che-osgi-parent</artifactId>
-        <version>3.3.9-METADATA-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>dcm4che-osgi-echo</artifactId>
     <packaging>bundle</packaging>

--- a/dcm4che-osgi/dcm4che-osgi-rest/pom.xml
+++ b/dcm4che-osgi/dcm4che-osgi-rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-osgi-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-osgi-rest</artifactId>
   <packaging>bundle</packaging>

--- a/dcm4che-osgi/pom.xml
+++ b/dcm4che-osgi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-osgi-parent</artifactId>
   <packaging>pom</packaging>

--- a/dcm4che-servlet/pom.xml
+++ b/dcm4che-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-servlet</artifactId>
   <packaging>war</packaging>

--- a/dcm4che-soundex/pom.xml
+++ b/dcm4che-soundex/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-parent</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-soundex</artifactId>
   <name>dcm4che-soundex</name>

--- a/dcm4che-test-data/pom.xml
+++ b/dcm4che-test-data/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <artifactId>dcm4che-parent</artifactId>
         <groupId>org.dcm4che</groupId>
-        <version>3.3.9-METADATA-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dcm4che-tool/dcm4che-tool-all/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-all/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-all</artifactId>
   <name>dcm4che-tool-all</name>

--- a/dcm4che-tool/dcm4che-tool-common/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-common/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-common</artifactId>
   <name>dcm4che-tool-common</name>

--- a/dcm4che-tool/dcm4che-tool-dcm2dcm/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-dcm2dcm/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che.tool</groupId>
     <artifactId>dcm4che-tool</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-dcm2dcm</artifactId>
   <name>dcm4che-tool-dcm2dcm</name>

--- a/dcm4che-tool/dcm4che-tool-dcm2jpg/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-dcm2jpg/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che.tool</groupId>
     <artifactId>dcm4che-tool</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-dcm2jpg</artifactId>
   <name>dcm4che-tool-dcm2jpg</name>

--- a/dcm4che-tool/dcm4che-tool-dcm2json/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-dcm2json/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <groupId>org.dcm4che.tool</groupId>
     <artifactId>dcm4che-tool</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-dcm2json</artifactId>
   <description>Convert DICOM file to JSON</description>

--- a/dcm4che-tool/dcm4che-tool-dcm2xml/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-dcm2xml/pom.xml
@@ -41,7 +41,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>dcm4che-tool-dcm2xml</artifactId>

--- a/dcm4che-tool/dcm4che-tool-dcmdict/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-dcmdict/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-dcmdict</artifactId>
   <name>dcm4che-tool-dcmdict</name>

--- a/dcm4che-tool/dcm4che-tool-dcmdir/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-dcmdir/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-dcmdir</artifactId>
   <name>dcm4che-tool-dcmdir</name>

--- a/dcm4che-tool/dcm4che-tool-dcmdump/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-dcmdump/pom.xml
@@ -41,7 +41,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>dcm4che-tool-dcmdump</artifactId>

--- a/dcm4che-tool/dcm4che-tool-dcmgen/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-dcmgen/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-dcmgen</artifactId>
   <name>dcm4che-tool-dcmgen</name>

--- a/dcm4che-tool/dcm4che-tool-dcmqrscp/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-dcmqrscp/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-dcmqrscp</artifactId>
   <name>dcm4che-tool-dcmqrscp</name>

--- a/dcm4che-tool/dcm4che-tool-dcmvalidate/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-dcmvalidate/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che.tool</groupId>
     <artifactId>dcm4che-tool</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-dcmvalidate</artifactId>
   <name>dcm4che-tool-dcmvalidate</name>

--- a/dcm4che-tool/dcm4che-tool-emf2sf/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-emf2sf/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che.tool</groupId>
     <artifactId>dcm4che-tool</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-emf2sf</artifactId>
   <name>dcm4che-tool-emf2sf</name>

--- a/dcm4che-tool/dcm4che-tool-findscu/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-findscu/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-findscu</artifactId>
   <name>dcm4che-tool-findscu</name>

--- a/dcm4che-tool/dcm4che-tool-getscu/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-getscu/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-getscu</artifactId>
   <name>dcm4che-tool-getscu</name>

--- a/dcm4che-tool/dcm4che-tool-hl72xml/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-hl72xml/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-hl72xml</artifactId>

--- a/dcm4che-tool/dcm4che-tool-hl7pix/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-hl7pix/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-hl7pix</artifactId>

--- a/dcm4che-tool/dcm4che-tool-hl7rcv/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-hl7rcv/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-hl7rcv</artifactId>

--- a/dcm4che-tool/dcm4che-tool-hl7snd/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-hl7snd/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-hl7snd</artifactId>

--- a/dcm4che-tool/dcm4che-tool-ianscp/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-ianscp/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-ianscp</artifactId>

--- a/dcm4che-tool/dcm4che-tool-ianscu/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-ianscu/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-ianscu</artifactId>

--- a/dcm4che-tool/dcm4che-tool-ihe/dcm4che-tool-ihe-modality/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-ihe/dcm4che-tool-ihe-modality/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool-ihe</artifactId>
     <groupId>org.dcm4che.tool.ihe</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-ihe-modality</artifactId>
   <name>dcm4che-tool-ihe-modality</name>

--- a/dcm4che-tool/dcm4che-tool-ihe/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-ihe/pom.xml
@@ -43,7 +43,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <groupId>org.dcm4che.tool.ihe</groupId>
   <artifactId>dcm4che-tool-ihe</artifactId>

--- a/dcm4che-tool/dcm4che-tool-jpg2dcm/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-jpg2dcm/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-jpg2dcm</artifactId>

--- a/dcm4che-tool/dcm4che-tool-json2dcm/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-json2dcm/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <groupId>org.dcm4che.tool</groupId>
     <artifactId>dcm4che-tool</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-json2dcm</artifactId>
   <description>Convert JSON to DICOM file</description>

--- a/dcm4che-tool/dcm4che-tool-mkkos/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-mkkos/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-mkkos</artifactId>

--- a/dcm4che-tool/dcm4che-tool-movescu/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-movescu/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-movescu</artifactId>
   <name>dcm4che-tool-movescu</name>

--- a/dcm4che-tool/dcm4che-tool-mppsscp/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-mppsscp/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-mppsscp</artifactId>

--- a/dcm4che-tool/dcm4che-tool-mppsscu/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-mppsscu/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-mppsscu</artifactId>

--- a/dcm4che-tool/dcm4che-tool-prefs2xml/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-prefs2xml/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che.tool</groupId>
     <artifactId>dcm4che-tool</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-prefs2xml</artifactId>
   <name>dcm4che-tool-prefs2xml</name>

--- a/dcm4che-tool/dcm4che-tool-qc/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-qc/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-qc</artifactId>
   <name>dcm4che-tool-qc</name>

--- a/dcm4che-tool/dcm4che-tool-qidors/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-qidors/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-qidors</artifactId>
   <name>dcm4che-tool-qido</name>

--- a/dcm4che-tool/dcm4che-tool-stgcmtscu/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-stgcmtscu/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-stgcmtscu</artifactId>
   <name>dcm4che-tool-stgcmtscu</name>

--- a/dcm4che-tool/dcm4che-tool-storescp/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-storescp/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-storescp</artifactId>
   <name>dcm4che-tool-storescp</name>

--- a/dcm4che-tool/dcm4che-tool-storescu/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-storescu/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-storescu</artifactId>
   <name>dcm4che-tool-storescu</name>

--- a/dcm4che-tool/dcm4che-tool-stowrs/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-stowrs/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-stowrs</artifactId>

--- a/dcm4che-tool/dcm4che-tool-swappxdata/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-swappxdata/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <artifactId>dcm4che-tool</artifactId>
         <groupId>org.dcm4che.tool</groupId>
-        <version>3.3.9-METADATA-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dcm4che-tool/dcm4che-tool-syslog/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-syslog/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che.tool</groupId>
     <artifactId>dcm4che-tool</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-syslog</artifactId>
   <dependencies>

--- a/dcm4che-tool/dcm4che-tool-syslogd/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-syslogd/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che.tool</groupId>
     <artifactId>dcm4che-tool</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-syslogd</artifactId>
   <dependencies>

--- a/dcm4che-tool/dcm4che-tool-wadors/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-wadors/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-wadors</artifactId>
   <name>dcm4che-tool-wadors</name>

--- a/dcm4che-tool/dcm4che-tool-wadouri/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-wadouri/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-wadouri</artifactId>
   <name>dcm4che-tool-wadouri</name>

--- a/dcm4che-tool/dcm4che-tool-xml2dcm/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-xml2dcm/pom.xml
@@ -41,7 +41,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>dcm4che-tool-xml2dcm</artifactId>

--- a/dcm4che-tool/dcm4che-tool-xml2hl7/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-xml2hl7/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dcm4che-tool-xml2hl7</artifactId>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.dcm4che</groupId>
       <artifactId>dcm4che-hl7</artifactId>
-      <version>3.3.9-METADATA-SNAPSHOT</version>
+      <version>3.4.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 </project>

--- a/dcm4che-tool/dcm4che-tool-xml2prefs/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-xml2prefs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dcm4che-tool</artifactId>
     <groupId>org.dcm4che.tool</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-tool-xml2prefs</artifactId>
   <name>dcm4che-tool-xml2prefs</name>

--- a/dcm4che-tool/pom.xml
+++ b/dcm4che-tool/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <artifactId>dcm4che-parent</artifactId>
     <groupId>org.dcm4che</groupId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.dcm4che.tool</groupId>

--- a/dcm4che-ws-rs/pom.xml
+++ b/dcm4che-ws-rs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dcm4che</groupId>
     <artifactId>dcm4che-parent</artifactId>
-    <version>3.3.9-METADATA-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>dcm4che-ws-rs</artifactId>
   <packaging>bundle</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.dcm4che</groupId>
   <artifactId>dcm4che-parent</artifactId>
-  <version>3.3.9-METADATA-SNAPSHOT</version>
+  <version>3.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>dcm4che DICOM toolkit and utilities</name>
   <description>dcm4che DICOM toolkit and utilities</description>


### PR DESCRIPTION
- Rolled the version upto 3.4.0-SNAPSHOT
- BulkDataDicomImageAccessor now accounts for pixel padding when
  counting frames.
- Tweaked DicomImageReader and added javadocs to read()
- DicomInputStream now exposes an immutable List of ItemPointers.
- ItemPointers now include a meaningful toString()