### PR TITLE
Update Attributes.java

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -91,7 +91,7 @@ public class Attributes implements Serializable {
 
     private static final int INIT_CAPACITY = 16;
     private static final int TO_STRING_LIMIT = 50;
-    private static final int TO_STRING_WIDTH = 78;
+    private static final int TO_STRING_WIDTH = 120;
     private transient Attributes parent;
     private transient int[] tags;
     private transient VR[] vrs;


### PR DESCRIPTION
Increasing length of STRING_WIDTH as the DICOM tag names at the end of the command line output are getting stripped, when the StudyInstanceUID is longer.