### PR TITLE
Update to weasis.core.img 4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <weasis.core.img.version>4.3.0</weasis.core.img.version>
-    <weasis.opencv.native.version>4.3.0-dcm</weasis.opencv.native.version>
+    <weasis.core.img.version>4.4.0</weasis.core.img.version>
+    <weasis.opencv.native.version>4.4.0-dcm</weasis.opencv.native.version>
     <keycloak.version>10.0.2</keycloak.version>
     <jbossws-cxf-client.version>5.4.1.Final</jbossws-cxf-client.version>
     <apache-cxf.version>3.3.6</apache-cxf.version>


### PR DESCRIPTION
- Update to openCV 4.4.0
- Fix Memory leak with the jpeg-lossless encoder https://github.com/dcm4che/dcm4che/issues/757