### PR TITLE
Image rendering  improve handling of empty images / overlays

### DIFF
--- a/dcm4che-image/src/main/java/org/dcm4che3/image/LookupTableFactory.java
+++ b/dcm4che-image/src/main/java/org/dcm4che3/image/LookupTableFactory.java
@@ -289,6 +289,8 @@ public class LookupTableFactory {
             return false;
 
         int[] min_max = calcMinMax(raster);
+        if (min_max[0] == min_max[1])
+        	return false;
         windowCenter = (min_max[0] + min_max[1] + 1) / 2 * rescaleSlope + rescaleIntercept;
         windowWidth = Math.abs((min_max[1] + 1 - min_max[0]) * rescaleSlope);
         if (addAutoWindow) {

--- a/dcm4che-image/src/main/java/org/dcm4che3/image/Overlays.java
+++ b/dcm4che-image/src/main/java/org/dcm4che3/image/Overlays.java
@@ -261,8 +261,12 @@ public class Overlays {
 
         int ovlyLen = ovlyRows * ovlyColumns;
         int ovlyOff = ovlyLen * ovlyFrameIndex;
-        for (int i = ovlyOff >>> 3,
-               end = (ovlyOff + ovlyLen + 7) >>> 3; i < end; i++) {
+        int end = (ovlyOff + ovlyLen + 7) >>> 3;
+        if (end > ovlyData.length) {
+        	LOG.warn("OverlayData to small ({} vs. {})! Skip this overlay:{}", ovlyData.length, end, TagUtils.toString(tagOverlayData));
+        	return;
+        }
+        for (int i = ovlyOff >>> 3; i < end; i++) {
             int ovlyBits = ovlyData[i] & 0xff;
             for (int j = 0; (ovlyBits>>>j) != 0; j++) {
                 if ((ovlyBits & (1<<j)) == 0)


### PR DESCRIPTION
1) An empty image (all pixels are equal) are rendered white because of the auto-windowing (center=0, width=1)
2) If the size of the OverlayData (60xx,3000) is to small, rendering will fail with IndexOutOfBoundsException