### PR TITLE
Reduce the logging for unsupportedOperationException to trace to avoi…

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -678,7 +678,7 @@ public class Attributes implements Serializable {
             
             return vr.toBytes(value, getSpecificCharacterSet(vr));
         } catch (UnsupportedOperationException e) {
-            LOG.info("Attempt to access {} {} as bytes", TagUtils.toString(tag), vr);
+            LOG.trace("Attempt to access {} {} as bytes", TagUtils.toString(tag), vr, e);
             return null;
         }
     }
@@ -763,7 +763,7 @@ public class Attributes implements Serializable {
         try {
             return vr.toString(value, bigEndian, valueIndex, defVal);
         } catch (UnsupportedOperationException e) {
-            LOG.info("Attempt to access {} {} as string", TagUtils.toString(tag), vr);
+            LOG.trace("Attempt to access {} {} as string", TagUtils.toString(tag), vr, e);
             return defVal;
         }
     }
@@ -798,7 +798,7 @@ public class Attributes implements Serializable {
             return toStrings(vr.toStrings(value, bigEndian,
                     getSpecificCharacterSet(vr)));
         } catch (UnsupportedOperationException e) {
-            LOG.info("Attempt to access {} {} as string", TagUtils.toString(tag), vr);
+            LOG.trace("Attempt to access {} {} as string", TagUtils.toString(tag), vr, e);
             return null;
         }
     }
@@ -849,7 +849,7 @@ public class Attributes implements Serializable {
 
             return vr.toInt(value, bigEndian, valueIndex, defVal);
         } catch (UnsupportedOperationException e) {
-            LOG.info("Attempt to access {} {} as int", TagUtils.toString(tag), vr);
+            LOG.trace("Attempt to access {} {} as int", TagUtils.toString(tag), vr, e);
             return defVal;
         } catch (IllegalArgumentException e) {
             LOG.info("Invalid value of {} {}", TagUtils.toString(tag), vr);
@@ -885,7 +885,7 @@ public class Attributes implements Serializable {
 
             return vr.toInts(value, bigEndian);
         } catch (UnsupportedOperationException e) {
-            LOG.info("Attempt to access {} {} as int", TagUtils.toString(tag), vr);
+            LOG.trace("Attempt to access {} {} as int", TagUtils.toString(tag), vr, e);
             return null;
         } catch (IllegalArgumentException e) {
             LOG.info("Invalid value of {} {}", TagUtils.toString(tag), vr);
@@ -933,7 +933,7 @@ public class Attributes implements Serializable {
 
             return vr.toFloat(value, bigEndian, valueIndex, defVal);
         } catch (UnsupportedOperationException e) {
-            LOG.info("Attempt to access {} {} as float", TagUtils.toString(tag), vr);
+            LOG.trace("Attempt to access {} {} as float", TagUtils.toString(tag), vr, e);
             return defVal;
         } catch (IllegalArgumentException e) {
             LOG.info("Invalid value of {} {}", TagUtils.toString(tag), vr);
@@ -969,7 +969,7 @@ public class Attributes implements Serializable {
 
             return vr.toFloats(value, bigEndian);
         } catch (UnsupportedOperationException e) {
-            LOG.info("Attempt to access {} {} as float", TagUtils.toString(tag), vr);
+            LOG.trace("Attempt to access {} {} as float", TagUtils.toString(tag), vr, e);
             return null;
         } catch (IllegalArgumentException e) {
             LOG.info("Invalid value of {} {}", TagUtils.toString(tag), vr);
@@ -1017,7 +1017,7 @@ public class Attributes implements Serializable {
 
             return vr.toDouble(value, bigEndian, valueIndex, defVal);
         } catch (UnsupportedOperationException e) {
-            LOG.info("Attempt to access {} {} as double", TagUtils.toString(tag), vr);
+            LOG.trace("Attempt to access {} {} as double", TagUtils.toString(tag), vr, e);
            return defVal;
         } catch (IllegalArgumentException e) {
             LOG.info("Invalid value of {} {}", TagUtils.toString(tag), vr);
@@ -1053,7 +1053,7 @@ public class Attributes implements Serializable {
 
             return vr.toDoubles(value, bigEndian);
         } catch (UnsupportedOperationException e) {
-            LOG.info("Attempt to access {} {} as double", TagUtils.toString(tag), vr);
+            LOG.trace("Attempt to access {} {} as double", TagUtils.toString(tag), vr, e);
             return null;
         } catch (IllegalArgumentException e) {
             LOG.info("Invalid value of {} {}", TagUtils.toString(tag), vr);


### PR DESCRIPTION
The logging in the attributes class in the unsupportedOperationException is causing the server logs to fill up.