### PR TITLE
IEI-118580 correct encoding with value length < 64 Kib.  Bring fix from master into generic-config branch.

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomOutputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomOutputStream.java
@@ -170,6 +170,8 @@ public class DicomOutputStream extends FilterOutputStream {
         ByteUtils.tagToBytes(tag, b, 0, bigEndian);
         int headerLen;
         if (!TagUtils.isItem(tag) && explicitVR) {
+            // Check to see if the size of the value to see if it is greater than 64Kib (8th bit is needed).
+            // If so, change the VR tag to unsigned before encoding the value.
             if ((len & 0xffff0000) != 0 && vr.headerLength() == 8)
                 vr = VR.UN;
             ByteUtils.shortToBytesBE(vr.code(), b, 4);

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomOutputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomOutputStream.java
@@ -170,6 +170,8 @@ public class DicomOutputStream extends FilterOutputStream {
         ByteUtils.tagToBytes(tag, b, 0, bigEndian);
         int headerLen;
         if (!TagUtils.isItem(tag) && explicitVR) {
+            if ((len & 0xffff0000) != 0 && vr.headerLength() == 8)
+                vr = VR.UN;
             ByteUtils.shortToBytesBE(vr.code(), b, 4);
             if ((headerLen = vr.headerLength()) == 8) {
                 ByteUtils.shortToBytes(len, b, 6, bigEndian);


### PR DESCRIPTION
There is an issue with the generic-config branch handling large tags.  