### PR TITLE
Bulk Data handling fixes.

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/stream/BulkURIImageInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/stream/BulkURIImageInputStream.java
@@ -43,6 +43,8 @@ import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageInputStreamImpl;
 import java.io.IOException;
 
+import static java.lang.String.format;
+
 /**
  * Return a subset of an image input stream.  The local variables track the location within the offset/length
  * bounds which are mapped onto the underlying full image input stream.
@@ -57,6 +59,16 @@ public class BulkURIImageInputStream extends ImageInputStreamImpl {
 
 
     public BulkURIImageInputStream(ImageInputStream iis, long offset, int length) throws IOException {
+        if(iis == null) {
+            throw new IllegalArgumentException("iis is null");
+        }
+        if(offset < 0) {
+            throw new IllegalArgumentException("Offset "+offset);
+        }
+        if(length < 0) {
+            throw new IllegalArgumentException("Length "+offset);
+        }
+
         this.iis = iis;
         this.offset = offset;
         this.length = length;
@@ -95,8 +107,13 @@ public class BulkURIImageInputStream extends ImageInputStreamImpl {
             }
             else if(bytesRead == -1) {
                 // EOF, but did we read everything?
-                if(this.streamPos < length()) {
-                    throw new TruncatedPixelDataException();
+                if(this.streamPos < this.length) {
+                    String message = format("Segment ended at %s of %s.  The segment is offset %s into a stream of length %s.",
+                            this.streamPos,
+                            this.length,
+                            this.offset,
+                            this.iis.length());
+                    throw new TruncatedPixelDataException(message);
                 }
             }
         }

--- a/dcm4che-core/src/test/java/org/dcm4che3/io/stream/BulkURIImageInputStreamTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/io/stream/BulkURIImageInputStreamTest.java
@@ -1,5 +1,6 @@
 package org.dcm4che3.io.stream;
 
+import org.dcm4che3.error.TruncatedPixelDataException;
 import org.junit.Test;
 
 import javax.imageio.stream.FileImageInputStream;
@@ -37,6 +38,40 @@ public class BulkURIImageInputStreamTest {
         }
     }
 
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_NegativeOffset_ThrowsIllegalArgumentException() throws IOException {
+        MockImageInputStream iis = new MockImageInputStream();
+        long offset = -5;
+        int length = 5;
+        new BulkURIImageInputStream(iis, offset, length);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_NegativeLength_ThrowsIllegalArgumentException() throws IOException {
+        MockImageInputStream iis = new MockImageInputStream();
+        long offset = 0;
+        int length = -1;
+        new BulkURIImageInputStream(iis, offset, length);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_StreamIsNull_ThrowsIllegalArgumentException() throws IOException {
+        long offset = 5;
+        int length = 50;
+        new BulkURIImageInputStream(null, offset, length);
+    }
+
+    @Test(expected = TruncatedPixelDataException.class)
+    public void read_EndsPrematurely_ThrowsTruncatedPixelDataException() throws IOException {
+        long offset = 0;
+        int length = 100;
+
+        try(ImageInputStream iis = new BulkURIImageInputStream( new MockImageInputStream(), offset, length);) {
+            byte[] buffer = new byte[30];
+            iis.read(buffer);
+        }
+    }
 
     private class MockImageInputStream extends ImageInputStreamImpl {
 

--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/metadata/BulkDataDicomImageAccessor.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/metadata/BulkDataDicomImageAccessor.java
@@ -192,7 +192,7 @@ public class BulkDataDicomImageAccessor implements DicomImageAccessor {
             }
 
             Fragments fragments = (Fragments) pixelData;
-            ImageInputStream iisOfFile = uriLoader.openStream(this.uri);
+            ImageInputStream iisOfFile = openStreamForFile();
             iisOfFrame = new SegmentedImageInputStream(iisOfFile,fragments, frameIndex);
         }
         else {
@@ -225,6 +225,18 @@ public class BulkDataDicomImageAccessor implements DicomImageAccessor {
                 : ByteOrder.LITTLE_ENDIAN);
 
         return iisOfFrame;
+    }
+
+    private ImageInputStream openStreamForFile() throws IOException {
+        ImageInputStream iisOfFile;
+        if(this.uri.getScheme().equals("java")) {
+            // If the protocol is java:iis then we now that we do not have a file to read from, so an empty IIS is returned
+            iisOfFile =  new ByteArrayImageInputStream(new byte[0]);
+        }
+        else {
+            iisOfFile = uriLoader.openStream(this.uri);
+        }
+        return iisOfFile;
     }
 
     protected  void checkFrameIndex(int frameIndex) throws IOException {

--- a/dcm4che-imageio/src/test/java/org/dcm4che3/imageio/plugins/dcm/BulkDataPixelDataTests.java
+++ b/dcm4che-imageio/src/test/java/org/dcm4che3/imageio/plugins/dcm/BulkDataPixelDataTests.java
@@ -1,0 +1,123 @@
+//
+///////////////////////////////////////////////////////////////
+//                C O P Y R I G H T  (c) 2020                //
+//        Agfa HealthCare N.V. and/or its affiliates         //
+//                    All Rights Reserved                    //
+///////////////////////////////////////////////////////////////
+//                                                           //
+//       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF      //
+//        Agfa HealthCare N.V. and/or its affiliates.        //
+//      The copyright notice above does not evidence any     //
+//     actual or intended publication of such source code.   //
+//                                                           //
+///////////////////////////////////////////////////////////////
+//
+
+
+package org.dcm4che3.imageio.plugins.dcm;
+
+import org.dcm4che3.data.*;
+import org.dcm4che3.image.PhotometricInterpretation;
+import org.dcm4che3.imageio.metadata.BulkDataDicomImageAccessor;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests to ensure that we properly handle pixel data in the BulkDataDicomImageAccessor.
+ */
+public class BulkDataPixelDataTests {
+
+    DatasetWithFMI datasetWithFMI;
+    @Before
+    public void setup() {
+        datasetWithFMI = new DatasetWithFMI(new Attributes(), new Attributes());
+    }
+
+    @Test
+    public void containsPixelData_NoPixelDataTag_ReturnsFalse() {
+        BulkDataDicomImageAccessor imageAccessor = new BulkDataDicomImageAccessor(null, datasetWithFMI);
+        assertFalse(imageAccessor.containsPixelData());
+    }
+
+    @Test
+    public void containsPixelData_EmptyFragments_ReturnsFalse() {
+        datasetWithFMI.getDataset().setValue(Tag.PixelData, VR.OB, new Fragments(VR.OB, false, 0));
+        BulkDataDicomImageAccessor imageAccessor = new BulkDataDicomImageAccessor(null, datasetWithFMI);
+        assertFalse(imageAccessor.containsPixelData());
+    }
+
+    @Test
+    public void containsPixelData_EmptyBytes_ReturnsFalse() {
+        datasetWithFMI.getDataset().setValue(Tag.PixelData, VR.OB, new byte[0]);
+        BulkDataDicomImageAccessor imageAccessor = new BulkDataDicomImageAccessor(null, datasetWithFMI);
+        assertFalse(imageAccessor.containsPixelData());
+    }
+
+    @Test
+    public void containsPixelData_FragmentsBulkData_ReturnsTrue() {
+        Fragments fragments = new Fragments(VR.OB, false, 1);
+        fragments.add(new BulkData("file:///c/file.dcm", 100, 10, false ));
+        datasetWithFMI.getDataset().setValue(Tag.PixelData, VR.OB, fragments);
+        BulkDataDicomImageAccessor imageAccessor = new BulkDataDicomImageAccessor(null, datasetWithFMI);
+        assertTrue(imageAccessor.containsPixelData());
+    }
+
+
+    @Test
+    public void containsPixelData_FragmentsBytes_ReturnsTrue() {
+        Fragments fragments = new Fragments(VR.OB, true, 1);
+        fragments.add(new byte[1]);
+        datasetWithFMI.getDataset().setValue(Tag.PixelData, VR.OB, fragments);
+        BulkDataDicomImageAccessor imageAccessor = new BulkDataDicomImageAccessor(null, datasetWithFMI);
+        assertTrue(imageAccessor.containsPixelData());
+    }
+
+    @Test
+    public void countFrames_UncompressedPadded_MustIgnorePadding() throws IOException {
+        int rows = 101;
+        int cols = 51;
+        int samples = 1;
+        int allocated = 8;
+
+        PhotometricInterpretation pmi = PhotometricInterpretation.MONOCHROME2;
+        int frameLength = pmi.frameLength(cols, rows, samples, allocated);
+        assertEquals("odd frame length", 1, frameLength % 2);
+
+        datasetWithFMI.getFileMetaInformation().setString(Tag.TransferSyntaxUID, VR.CS, UID.ExplicitVRLittleEndian);
+        datasetWithFMI.getDataset().setInt(Tag.Rows, VR.IS, rows);
+        datasetWithFMI.getDataset().setInt(Tag.Columns, VR.IS, cols);
+        datasetWithFMI.getDataset().setInt(Tag.BitsAllocated, VR.IS, allocated);
+        datasetWithFMI.getDataset().setInt(Tag.SamplesPerPixel, VR.IS, samples);
+        datasetWithFMI.getDataset().setString(Tag.PhotometricInterpretation, VR.CS, pmi.toString());
+
+        datasetWithFMI.getDataset().setValue(Tag.PixelData, VR.OB, new byte[15454]);// padded by one byte
+        BulkDataDicomImageAccessor imageAccessor = new BulkDataDicomImageAccessor(null, datasetWithFMI);
+        assertTrue(imageAccessor.containsPixelData());
+        assertEquals(3, imageAccessor.countFrames());
+    }
+
+
+    /**
+     * The number of frames cannot be calculated for a study that does not contain all the required attributes
+     */
+    @Test
+    public void countFrames_UncompressedMissingAttributes_ReturnsMinus1() throws IOException {
+        int samples = 1;
+        int allocated = 8;
+
+        PhotometricInterpretation pmi = PhotometricInterpretation.MONOCHROME2;
+        datasetWithFMI.getFileMetaInformation().setString(Tag.TransferSyntaxUID, VR.CS, UID.ExplicitVRLittleEndian);
+        datasetWithFMI.getDataset().setInt(Tag.BitsAllocated, VR.IS, allocated);
+        datasetWithFMI.getDataset().setInt(Tag.SamplesPerPixel, VR.IS, samples);
+        datasetWithFMI.getDataset().setString(Tag.PhotometricInterpretation, VR.CS, pmi.toString());
+
+        datasetWithFMI.getDataset().setValue(Tag.PixelData, VR.OB, new byte[15454]);// padded by one byte
+        BulkDataDicomImageAccessor imageAccessor = new BulkDataDicomImageAccessor(null, datasetWithFMI);
+        assertTrue(imageAccessor.containsPixelData());
+        assertEquals("Frame length is ambiguous without rows / cols", -1, imageAccessor.countFrames());
+    }
+}

--- a/dcm4che-imageio/src/test/java/org/dcm4che3/imageio/plugins/dcm/DicomMetaDataTest.java
+++ b/dcm4che-imageio/src/test/java/org/dcm4che3/imageio/plugins/dcm/DicomMetaDataTest.java
@@ -78,7 +78,7 @@ public abstract class DicomMetaDataTest {
         return createMetadata(new TestData(fileName));
     }
 
-    private DicomMetaData createMetadata(TestData data) throws IOException {
+    protected DicomMetaData createMetadata(TestData data) throws IOException {
         return this.createMetadataFactory().readMetaData(data.toFile());
     }
 


### PR DESCRIPTION
- TruncatedPixelDataException now contains a detailed message regarding the state of the stream.
- BulkURIImageInputStream now throws exceptions when invalid offset or length are passed in.
- BulkDataDicomImageAccessor.countFrames() now properly handles uncompressed pixel data of odd length.
- BulkDataDicomImageAccessor.containsPixelData() properly handles empty pixel data