### PR TITLE
IEI-122301 Create DicomConfiguration#listDevices for faster bulk searches

### DIFF
--- a/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/DicomConfiguration.java
+++ b/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/DicomConfiguration.java
@@ -123,12 +123,12 @@ public interface DicomConfiguration {
     List<String> listAllAETitles() throws ConfigurationException;
 
     /**
-     * Returns all {@link Device} objects containing a specific {@link DeviceType} from the configuration backend
-     * @param primaryDeviceType
+     * Returns all {@link Device} objects containing specific {@link DeviceType}s from the configuration backend
+     * @param primaryDeviceTypes Can be optionally included. If not, all the {@link Device}s will be retrieved
      * @return {@link Device} array
      * @throws org.dcm4che3.conf.core.api.ConfigurationException
      */
-    Device[] listDevices(DeviceType primaryDeviceType) throws ConfigurationException;
+    Device[] listDevices(DeviceType... primaryDeviceTypes) throws ConfigurationException;
 
     /**
      * Invalidates any present cached state for the configuration storage view of the client.

--- a/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/DicomConfiguration.java
+++ b/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/DicomConfiguration.java
@@ -123,12 +123,27 @@ public interface DicomConfiguration {
     List<String> listAllAETitles() throws ConfigurationException;
 
     /**
-     * Returns all {@link Device} objects containing specific {@link DeviceType}s from the configuration backend
-     * @param primaryDeviceTypes Can be optionally included. If not, all the {@link Device}s will be retrieved
+     * Returns all {@link Device} objects from the configuration backend
      * @return {@link Device} array
      * @throws org.dcm4che3.conf.core.api.ConfigurationException
      */
-    Device[] listDevices(DeviceType... primaryDeviceTypes) throws ConfigurationException;
+    Device[] listAllDevices() throws ConfigurationException;
+
+    /**
+     * Returns all {@link Device} objects containing a specific {@link DeviceType} from the configuration backend
+     * @param primaryDeviceType {@link DeviceType} to be used as filter
+     * @return {@link Device} array
+     * @throws org.dcm4che3.conf.core.api.ConfigurationException
+     */
+    Device[] listDevices(DeviceType primaryDeviceType) throws ConfigurationException;
+
+    /**
+     * Returns all {@link Device} objects containing specific {@link DeviceType}s from the configuration backend
+     * @param primaryDeviceTypes {@link DeviceType}s to be used as filter
+     * @return {@link Device} array
+     * @throws org.dcm4che3.conf.core.api.ConfigurationException
+     */
+    Device[] listDevices(DeviceType[] primaryDeviceTypes) throws ConfigurationException;
 
     /**
      * Invalidates any present cached state for the configuration storage view of the client.

--- a/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/DicomConfiguration.java
+++ b/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/DicomConfiguration.java
@@ -40,6 +40,7 @@ package org.dcm4che3.conf.api;
 import org.dcm4che3.conf.core.api.ConfigurationException;
 import org.dcm4che3.net.ApplicationEntity;
 import org.dcm4che3.net.Device;
+import org.dcm4che3.net.DeviceType;
 
 import java.util.List;
 
@@ -122,6 +123,14 @@ public interface DicomConfiguration {
     List<String> listAllAETitles() throws ConfigurationException;
 
     /**
+     * Returns all {@link Device} objects containing a specific {@link DeviceType} from the configuration backend
+     * @param primaryDeviceType
+     * @return {@link Device} array
+     * @throws org.dcm4che3.conf.core.api.ConfigurationException
+     */
+    Device[] listDevices(DeviceType primaryDeviceType) throws ConfigurationException;
+
+    /**
      * Invalidates any present cached state for the configuration storage view of the client.
      * There is no guarantee whether the devices accessed afterwards will be re-loaded lazily or eagerly.
      *
@@ -152,7 +161,7 @@ public interface DicomConfiguration {
      * @param dicomConfigBatch Configuration batch to execute
      */
     void runBatch(DicomConfigBatch dicomConfigBatch);
-    
+
     /**
      * Defines a configuration batch that allows to execute configuration changes in a bulk-type manner.
      * 

--- a/dcm4che-conf/dcm4che-conf-core-api/src/main/java/org/dcm4che3/conf/core/api/Configuration.java
+++ b/dcm4che-conf/dcm4che-conf-core-api/src/main/java/org/dcm4che3/conf/core/api/Configuration.java
@@ -40,6 +40,7 @@
 package org.dcm4che3.conf.core.api;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -109,6 +110,16 @@ public interface Configuration extends BatchRunner {
      * @throws ConfigurationException
      */
     Object getConfigurationNode(Path path, Class configurableClass) throws ConfigurationException;
+
+    /**
+     * Loads configuration nodes for each specified path.
+     *
+     * @param configurableClass
+     * @param paths              References to multiple nodes
+     * @return configuration nodes or an empty {@link List}, if not found
+     * @throws ConfigurationException
+     */
+    List<Object> getConfigurationNodes(Class configurableClass, Path[] paths) throws ConfigurationException;
 
     /**
      * Tests if a node under the specified path exists.

--- a/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/DelegatingConfiguration.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/DelegatingConfiguration.java
@@ -44,6 +44,7 @@ import org.dcm4che3.conf.core.api.ConfigurationException;
 import org.dcm4che3.conf.core.api.Path;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -68,6 +69,11 @@ public class DelegatingConfiguration implements Configuration {
     @Override
     public Object getConfigurationNode(Path path, Class configurableClass) throws ConfigurationException {
         return delegate.getConfigurationNode(path, configurableClass);
+    }
+
+    @Override
+    public List<Object> getConfigurationNodes(Class configurableClass, Path[] paths) throws ConfigurationException {
+        return delegate.getConfigurationNodes(configurableClass, paths);
     }
 
     @Override

--- a/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/storage/InMemoryConfiguration.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/storage/InMemoryConfiguration.java
@@ -45,9 +45,8 @@ import org.dcm4che3.conf.core.api.ConfigurationException;
 import org.dcm4che3.conf.core.Nodes;
 import org.dcm4che3.conf.core.api.Path;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Roman K
@@ -72,6 +71,13 @@ public class InMemoryConfiguration implements Configuration {
     @Override
     public Object getConfigurationNode(Path path, Class configurableClass) throws ConfigurationException {
         return Nodes.deepCloneNode(Nodes.getNode(root, path.getPathItems()));
+    }
+
+    @Override
+    public List<Object> getConfigurationNodes(Class configurableClass, Path... paths) throws ConfigurationException {
+        return Arrays.stream(paths)
+                .map(path -> getConfigurationNode(path, configurableClass))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/storage/InMemoryReadOnlyConfiguration.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/storage/InMemoryReadOnlyConfiguration.java
@@ -45,8 +45,8 @@ import org.dcm4che3.conf.core.api.ConfigurationException;
 import org.dcm4che3.conf.core.Nodes;
 import org.dcm4che3.conf.core.api.Path;
 
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Roman K
@@ -67,6 +67,13 @@ public class InMemoryReadOnlyConfiguration implements Configuration {
     @Override
     public Object getConfigurationNode(Path path, Class configurableClass) throws ConfigurationException {
         return Nodes.getNode(root, path.getPathItems());
+    }
+
+    @Override
+    public List<Object> getConfigurationNodes(Class configurableClass, Path... paths) throws ConfigurationException {
+        return Arrays.stream(paths)
+                .map(path -> getConfigurationNode(path, configurableClass))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/storage/InMemoryReadOnlyConfiguration.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/storage/InMemoryReadOnlyConfiguration.java
@@ -42,47 +42,44 @@ package org.dcm4che3.conf.core.storage;
 
 import org.dcm4che3.conf.core.api.Configuration;
 import org.dcm4che3.conf.core.api.ConfigurationException;
-import org.dcm4che3.conf.core.Nodes;
 import org.dcm4che3.conf.core.api.Path;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * @author Roman K
  */
 public class InMemoryReadOnlyConfiguration implements Configuration {
 
-    private final Map<String, Object> root;
+    private final InMemoryConfiguration delegate;
 
     public InMemoryReadOnlyConfiguration(Map<String, Object> root) {
-        this.root = root;
+        this.delegate = new InMemoryConfiguration(root);
     }
 
     @Override
     public Map<String, Object> getConfigurationRoot() throws ConfigurationException {
-        return root;
+        return delegate.getConfigurationRoot();
     }
 
     @Override
     public Object getConfigurationNode(Path path, Class configurableClass) throws ConfigurationException {
-        return Nodes.getNode(root, path.getPathItems());
+        return delegate.getConfigurationNode(path, configurableClass);
     }
 
     @Override
     public List<Object> getConfigurationNodes(Class configurableClass, Path... paths) throws ConfigurationException {
-        return Arrays.stream(paths)
-                .map(path -> getConfigurationNode(path, configurableClass))
-                .collect(Collectors.toList());
+        return delegate.getConfigurationNodes(configurableClass, paths);
     }
 
     @Override
     public boolean nodeExists(Path path) throws ConfigurationException {
-        return Nodes.nodeExists(root, path.getPathItems());
+        return delegate.nodeExists(path);
     }
 
     @Override
     public void refreshNode(Path path) throws ConfigurationException {
+        delegate.refreshNode(path);
     }
 
     @Override
@@ -97,12 +94,12 @@ public class InMemoryReadOnlyConfiguration implements Configuration {
 
     @Override
     public Path getPathByUUID(String uuid) {
-        throw new ConfigurationException("Unexpected error - uuid index is missing");
+        return delegate.getPathByUUID(uuid);
     }
 
     @Override
     public Iterator search(String liteXPathExpression) throws IllegalArgumentException, ConfigurationException {
-        return Nodes.search(root, liteXPathExpression);
+        return delegate.search(liteXPathExpression);
     }
 
     @Override
@@ -111,6 +108,6 @@ public class InMemoryReadOnlyConfiguration implements Configuration {
 
     @Override
     public void runBatch(Batch batch) {
-        batch.run();
+        delegate.runBatch(batch);
     }
 }

--- a/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/storage/SingleJsonFileConfigurationStorage.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/storage/SingleJsonFileConfigurationStorage.java
@@ -52,10 +52,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Roman K
@@ -126,6 +124,15 @@ public class SingleJsonFileConfigurationStorage implements Configuration {
     public synchronized Object getConfigurationNode(Path path, Class configurableClass) throws ConfigurationException {
         Object node = Nodes.getNode(getConfigurationRoot(), path.getPathItems());
         return node;
+    }
+
+    @Override
+    public synchronized List<Object> getConfigurationNodes(Class configurableClass, Path... paths) throws ConfigurationException {
+        Object configurationRoot = getConfigurationRoot();
+
+        return Arrays.stream(paths)
+                .map(path -> Nodes.getNode(configurationRoot, path.getPathItems()))
+                .collect(Collectors.toList());
     }
 
 

--- a/dcm4che-conf/dcm4che-conf-dicom/src/main/java/org/dcm4che3/conf/dicom/AlternativeTCLoader.java
+++ b/dcm4che-conf/dcm4che-conf-dicom/src/main/java/org/dcm4che3/conf/dicom/AlternativeTCLoader.java
@@ -92,27 +92,29 @@ public class AlternativeTCLoader {
         return this.tcGroups = config.getDicomConfigurationExtension(TransferCapabilityConfigExtension.class).getTransferCapabilityConfig();
     }
 
-
-    void initGroupBasedTCs(Device d) throws ConfigurationException {
-
+    void initGroupBasedTCs(Device... devices) throws ConfigurationException {
         TCConfiguration tcConfig = getTCConfig();
 
-        for (ApplicationEntity applicationEntity : d.getApplicationEntities()) {
-            TCGroupConfigAEExtension tcGroupConfigAEExtension = applicationEntity.getAEExtension(TCGroupConfigAEExtension.class);
-            if (tcGroupConfigAEExtension != null) {
+        for (Device device : devices) {
+            for (ApplicationEntity applicationEntity : device.getApplicationEntities()) {
+                TCGroupConfigAEExtension tcGroupConfigAEExtension = applicationEntity.getAEExtension(TCGroupConfigAEExtension.class);
+                if (tcGroupConfigAEExtension == null) {
+                    continue;
+                }
 
                 // override any entries that might have been added before
-                applicationEntity.setTransferCapabilities(new ArrayList<TransferCapability>());
+                applicationEntity.setTransferCapabilities(new ArrayList<>());
 
                 // Always add CEcho SCP
                 applicationEntity.addTransferCapability(new TransferCapability("CEcho SCP", UID.VerificationSOPClass, TransferCapability.Role.SCP, UID.ImplicitVRLittleEndian));
 
                 // add processed TCs from pre-configured groups to this ae
-                for (Map.Entry<String, TCGroupConfigAEExtension.TCGroupDetails> tcGroupRefEntry : tcGroupConfigAEExtension.getScpTCs().entrySet())
+                for (Map.Entry<String, TCGroupConfigAEExtension.TCGroupDetails> tcGroupRefEntry : tcGroupConfigAEExtension.getScpTCs().entrySet()) {
                     addTC(applicationEntity, tcConfig, tcGroupRefEntry, TransferCapability.Role.SCP);
-                for (Map.Entry<String, TCGroupConfigAEExtension.TCGroupDetails> tcGroupRefEntry : tcGroupConfigAEExtension.getScuTCs().entrySet())
+                }
+                for (Map.Entry<String, TCGroupConfigAEExtension.TCGroupDetails> tcGroupRefEntry : tcGroupConfigAEExtension.getScuTCs().entrySet()) {
                     addTC(applicationEntity, tcConfig, tcGroupRefEntry, TransferCapability.Role.SCU);
-
+                }
             }
         }
     }

--- a/dcm4che-conf/dcm4che-conf-dicom/src/main/java/org/dcm4che3/conf/dicom/DicomPath.java
+++ b/dcm4che-conf/dcm4che-conf-dicom/src/main/java/org/dcm4che3/conf/dicom/DicomPath.java
@@ -66,7 +66,8 @@ public enum DicomPath {
     DeviceUUIDByAnyUUID,
     DeviceByNameForWrite,
     DeviceByNameForRead,
-    AETransferCapabilities;
+    AETransferCapabilities,
+    AllDeviceNamesByPrimaryDeviceType;
 
     public static final Path TC_GROUPS_PATH = new Path("dicomConfigurationRoot","globalConfiguration","dcmTransferCapabilities");
     public static final Path CONFIG_ROOT_PATH = new Path("dicomConfigurationRoot");
@@ -78,6 +79,7 @@ public enum DicomPath {
     static {
         // search
         PATHS.put(/**************/AllAETitles, "/dicomConfigurationRoot/dicomDevicesRoot/*/dicomNetworkAE/*/dicomAETitle | /dicomConfigurationRoot/dicomDevicesRoot/*/dicomNetworkAE/*/dcmAETitleAliases");
+        PATHS.put(AllDeviceNamesByPrimaryDeviceType, "/dicomConfigurationRoot/dicomDevicesRoot/*[dicomPrimaryDeviceType='{primaryDeviceType}']/dicomDeviceName");
 
         PATHS.put(/*******/DeviceNameByAEName, "/dicomConfigurationRoot/dicomDevicesRoot/*[dicomNetworkAE[@name='{aeName}']]/dicomDeviceName");
         PATHS.put(/**/DeviceNameByAENameAlias, "/dicomConfigurationRoot/dicomDevicesRoot/*[dicomNetworkAE[*/dcmAETitleAliases='{aeNameAlias}']]/dicomDeviceName");

--- a/dcm4che-conf/dcm4che-conf-dicom/src/test/java/org/dcm4che3/conf/dicom/SimpleStorageTest.java
+++ b/dcm4che-conf/dcm4che-conf-dicom/src/test/java/org/dcm4che3/conf/dicom/SimpleStorageTest.java
@@ -47,6 +47,7 @@ import org.dcm4che3.conf.core.storage.SimpleCachingConfigurationDecorator;
 import org.dcm4che3.conf.core.storage.SingleJsonFileConfigurationStorage;
 import org.dcm4che3.conf.dicom.configclasses.SomeDeviceExtension;
 import org.dcm4che3.conf.dicom.misc.DeepEqualsDiffer;
+import org.dcm4che3.net.ExternalArchiveAEExtension;
 import org.dcm4che3.net.TCGroupConfigAEExtension;
 import org.dcm4che3.net.hl7.HL7DeviceExtension;
 import org.junit.Assert;
@@ -98,6 +99,7 @@ public class SimpleStorageTest {
         DicomConfigurationBuilder builder = DicomConfigurationBuilder.newConfigurationBuilder(System.getProperties());
         builder.registerDeviceExtension(HL7DeviceExtension.class);
         builder.registerAEExtension(TCGroupConfigAEExtension.class);
+        builder.registerAEExtension(ExternalArchiveAEExtension.class);
         builder.registerDeviceExtension(SomeDeviceExtension.class);
         builder.uuidIndexing();
         builder.extensionMerge(true);


### PR DESCRIPTION
Create DicomConfiguration#listDevices for faster bulk searches

- Introduce DicomConfiguration#listDevices for bulk device searches
- Introduce Configuration#getConfigurationNodes for bulk node searches

I am attaching below a few examples of performance improvement using 10, 100 and 1000 devices. The performance will progressively increase given the amount of devices to be listed:

#### 10 devices (listDevices vs findDevice)
![IEI-122301 - dcm4che 10](https://user-images.githubusercontent.com/20360212/98407826-4bff0f00-203e-11eb-9217-d55d1953db66.png)

#### 100 devices (listDevices vs findDevice)
![IEI-122301 - dcm4che 100](https://user-images.githubusercontent.com/20360212/98407824-4b667880-203e-11eb-8801-b613e58cd040.png)

#### 1000 devices (listDevices vs findDevice)
![IEI-122301 - dcm4che 1000](https://user-images.githubusercontent.com/20360212/98407825-4bff0f00-203e-11eb-9578-ad31c2a686af.png)

