### PR TITLE
Compression of JPEG Lossless images corrupts pixel data when bits allocated is 16 and bits stored is 8 #813

### DIFF
--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJLSImageWriter.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJLSImageWriter.java
@@ -125,6 +125,10 @@ class NativeJLSImageWriter extends ImageWriter {
                     jpeglsNLE = 0;
                     bitCompressed = 16; // Extend to bit allocated to avoid exception as negative values are treated as large positive values
                 }
+                // Specific case not well supported by jpeg and jpeg-ls encoder that reduce the stream to 8-bit
+                if(bitCompressed == 8 && desc.getBitsAllocated() == 16){
+                  bitCompressed = 12;
+                }
 
                 int[] params = new int[15];
                 params[Imgcodecs.DICOM_PARAM_IMREAD] = Imgcodecs.IMREAD_UNCHANGED; // Image flags

--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJPEGImageWriter.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJPEGImageWriter.java
@@ -127,7 +127,12 @@ class NativeJPEGImageWriter extends ImageWriter {
                 int channels = CvType.channels(cvType);
                 boolean signed = desc.isSigned();
                 int dcmFlags = signed ? Imgcodecs.DICOM_FLAG_SIGNED : Imgcodecs.DICOM_FLAG_UNSIGNED;
-
+                // Specific case not well supported by jpeg and jpeg-ls encoder that reduce the stream to 8-bit
+                int bitCompressed = desc.getBitsCompressed();
+                if(bitCompressed == 8 && desc.getBitsAllocated() == 16){
+                  bitCompressed = 12;
+                }
+                
                 int[] params = new int[15];
                 params[Imgcodecs.DICOM_PARAM_IMREAD] = Imgcodecs.IMREAD_UNCHANGED; // Image flags
                 params[Imgcodecs.DICOM_PARAM_DCM_IMREAD] = dcmFlags; // DICOM flags
@@ -135,7 +140,7 @@ class NativeJPEGImageWriter extends ImageWriter {
                 params[Imgcodecs.DICOM_PARAM_HEIGHT] = mat.height(); // Image height
                 params[Imgcodecs.DICOM_PARAM_COMPRESSION] = Imgcodecs.DICOM_CP_JPG; // Type of compression
                 params[Imgcodecs.DICOM_PARAM_COMPONENTS] = channels; // Number of components
-                params[Imgcodecs.DICOM_PARAM_BITS_PER_SAMPLE] = desc.getBitsCompressed(); // Bits per sample
+                params[Imgcodecs.DICOM_PARAM_BITS_PER_SAMPLE] = bitCompressed; // Bits per sample
                 params[Imgcodecs.DICOM_PARAM_INTERLEAVE_MODE] = Imgcodecs.ILV_SAMPLE; // Interleave mode
                 params[Imgcodecs.DICOM_PARAM_COLOR_MODEL] = epi; // Photometric interpretation
                 params[Imgcodecs.DICOM_PARAM_JPEG_MODE] = jpegParams.getMode(); // JPEG Codec mode


### PR DESCRIPTION
I had already seen a similar image produced by Philips with BitStored at 8 and BitAllocated at 16. It seems strange to use twice as much space as necessary.

The jpeg and jpeg-ls encoders don't handle 8-bit encoding well with a 16-bit image. The jpeg-2000 encoder handles this correctly.

The fix is to force as if the encoding is 12-bit even if the values will be in the 8-bit range at the end.