### PR TITLE
Fix compression/decompression of images with bitstored is 8 and bitsallocated is 16 in legacy compressor/decompressor

### DIFF
--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Compressor.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Compressor.java
@@ -62,12 +62,13 @@ import javax.imageio.stream.FileImageInputStream;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
 
-import org.dcm4che3.data.Tag;
 import org.dcm4che3.data.Attributes;
 import org.dcm4che3.data.BulkData;
 import org.dcm4che3.data.Fragments;
+import org.dcm4che3.data.Tag;
 import org.dcm4che3.data.VR;
 import org.dcm4che3.data.Value;
+import org.dcm4che3.image.BufferedImageUtils;
 import org.dcm4che3.image.Overlays;
 import org.dcm4che3.imageio.codec.jpeg.PatchJPEGLS;
 import org.dcm4che3.imageio.codec.jpeg.PatchJPEGLSImageOutputStream;
@@ -302,6 +303,9 @@ public class Compressor extends Decompressor implements Closeable {
                 Compressor.this.extractEmbeddedOverlays(frameIndex, bi);
                 if (bitsStored < bitsAllocated)
                     Compressor.this.nullifyUnusedBits(bitsStored, bi);
+                if (imageDescriptor.is16BitsAllocated8BitsStored()) {
+                	bi = BufferedImageUtils.convertShortsToBytes(bi, null);
+                }
                 cache = new FlushlessMemoryCacheImageOutputStream(cacheout, imageDescriptor);
                 compressor.setOutput(patchJPEGLS != null
                         ? new PatchJPEGLSImageOutputStream(cache, patchJPEGLS)


### PR DESCRIPTION
As suggested in conversation https://groups.google.com/u/1/g/dcm4che/c/xi0S-BtO_lY, made the change in legacy compressor/decompressor on issue when bitstored is 8 and bitsallocated is 16