### PR TITLE
Revert changes made to DicomInputStream.readValues

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -782,7 +782,7 @@ public class DicomInputStream extends FilterInputStream
 
         } catch (IOException e) {
 
-            if ((Objects.isNull(e.getMessage()) || e.getMessage().equals("")) && Objects.nonNull(e.getCause())) {
+            if (Objects.isNull(e.getMessage()) && Objects.nonNull(e.getCause())) {
 
                     throw new IOException(String.format("IOException during read of %s #%d @ %d",
                             TagUtils.toString(tag), length, tagPos), e.getCause());

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -768,7 +768,7 @@ public class DicomInputStream extends FilterInputStream
                 throw new EOFException("DicomInputStream length is less than zero");
             }
 
-            if (allocateLimit > 0 && length > allocateLimit) {
+            if (length > allocateLimit) {
                 LOG.warn("Expected value length {} exceeds allocate limit {}", length, allocateLimit);
             }
 

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -782,7 +782,7 @@ public class DicomInputStream extends FilterInputStream
 
         } catch (IOException e) {
 
-            if ((Objects.isNull(e.getMessage()) || e.getMessage().trim().equals("")) && Objects.nonNull(e.getCause())) {
+            if ((Objects.isNull(e.getMessage()) || e.getMessage().equals("")) && Objects.nonNull(e.getCause())) {
 
                     throw new IOException(String.format("IOException during read of %s #%d @ %d",
                             TagUtils.toString(tag), length, tagPos), e.getCause());

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -163,6 +163,8 @@ public class DicomInputStream extends FilterInputStream
     }
 
     /** 
+     * Returns the limit of initial allocated memory for element values.
+     * 
      * By default, the limit is set to 67108864 (64 MiB).
      *
      * @return Limit of initial allocated memory for value or -1 for no limit
@@ -173,9 +175,22 @@ public class DicomInputStream extends FilterInputStream
     }
 
     /**
+     * Sets the limit of initial allocated memory for element values. If the
+     * value length exceeds the limit, a byte array with the specified size is
+     * allocated. If the array can filled with bytes read from this
+     * <code>DicomInputStream</code>, the byte array is reallocated with
+     * twice the previous length and filled again. That continues until
+     * the twice of the previous length exceeds the actual value length. Then
+     * the byte array is reallocated with actual value length and filled with
+     * the remaining bytes for the value from this <code>DicomInputStream</code>.
+     * 
+     * The rational of the incrementing allocation of byte arrays is to avoid
+     * OutOfMemoryErrors on parsing corrupted DICOM streams.
+     * 
      * By default, the limit is set to 67108864 (64 MiB).
      * 
      * @param allocateLimit limit of initial allocated memory or -1 for no limit
+     * 
      */
     public final void setAllocateLimit(int allocateLimit) {
         this.allocateLimit = allocateLimit;
@@ -761,30 +776,27 @@ public class DicomInputStream extends FilterInputStream
     }
 
     public byte[] readValue() throws IOException {
-
+        int valLen = length;
         try {
-
-            if (length < 0) {
-                throw new EOFException("DicomInputStream length is less than zero");
+            if (valLen < 0)
+                throw new EOFException(); // assume InputStream length < 2 GiB
+            int allocLen = allocateLimit >= 0
+                    ? Math.min(valLen, allocateLimit)
+                    : valLen;
+            byte[] value = new byte[allocLen];
+            readFully(value, 0, allocLen);
+            while (allocLen < valLen) {
+                int newLength = Math.min(valLen, allocLen << 1);
+                value = Arrays.copyOf(value, newLength);
+                readFully(value, allocLen, newLength - allocLen);
+                allocLen = newLength;
             }
-
-            if (length > allocateLimit) {
-                LOG.warn("Expected value length {} exceeds allocate limit {}", length, allocateLimit);
-            }
-
-            byte[] value = new byte[length];
-
-            readFully(value, 0, length);
-
             return value;
-
         } catch (IOException e) {
-
-            throw new IOException(String.format("IOException during read of %s #%d @ %d",
-                    TagUtils.toString(tag), length, tagPos), e);
-
+            LOG.warn("IOException during read of {} #{} @ {}",
+                    TagUtils.toString(tag), length, tagPos, e);
+            throw e;
         }
-
     }
 
     private void switchTransferSyntax(String tsuid) throws IOException {

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -781,7 +781,7 @@ public class DicomInputStream extends FilterInputStream
         } catch (IOException e) {
 
             throw new IOException(String.format("IOException during read of %s #%d @ %d",
-                    TagUtils.toString(tag), length, tagPos), e.getCause());
+                    TagUtils.toString(tag), length, tagPos), e);
 
         }
 

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -51,7 +51,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 
@@ -68,7 +67,6 @@ import org.dcm4che3.data.VR;
 import org.dcm4che3.util.ByteUtils;
 import org.dcm4che3.util.SafeClose;
 import org.dcm4che3.util.StreamUtils;
-import org.dcm4che3.util.StringUtils;
 import org.dcm4che3.util.TagUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -782,14 +780,8 @@ public class DicomInputStream extends FilterInputStream
 
         } catch (IOException e) {
 
-            if (Objects.isNull(e.getMessage()) && Objects.nonNull(e.getCause())) {
-
-                    throw new IOException(String.format("IOException during read of %s #%d @ %d",
-                            TagUtils.toString(tag), length, tagPos), e.getCause());
-
-            }
-
-            throw e;
+            throw new IOException(String.format("IOException during read of %s #%d @ %d",
+                    TagUtils.toString(tag), length, tagPos), e.getCause());
 
         }
 

--- a/dcm4che-core/src/test/java/org/dcm4che3/io/DicomInputStreamTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/io/DicomInputStreamTest.java
@@ -1,31 +1,20 @@
 package org.dcm4che3.io;
 
-import org.dcm4che3.data.Attributes;
-import org.dcm4che3.data.BulkData;
-import org.dcm4che3.data.Sequence;
-import org.dcm4che3.data.Tag;
-import org.dcm4che3.data.UID;
-import org.dcm4che3.data.VR;
-import org.dcm4che3.io.DicomInputStream.IncludeBulkData;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.FileInputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.dcm4che3.data.BulkData;
+import org.dcm4che3.data.Tag;
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.Sequence;
+import org.dcm4che3.io.DicomInputStream.IncludeBulkData;
+import org.junit.Test;
 
 /**
  * @author Gunter Zeilinger <gunterze@gmail.com>
  */
 public class DicomInputStreamTest {
-
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
     public void testPart10ExplicitVR() throws Exception {
@@ -62,7 +51,7 @@ public class DicomInputStreamTest {
         assertEquals(((BulkData) pixelData).uri, item.getString(Tag.RetrieveURL));
     }
 
-    private static Attributes readFromResource(String name,
+    private static Attributes readFromResource(String name, 
             IncludeBulkData includeBulkData)
             throws Exception {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
@@ -75,33 +64,6 @@ public class DicomInputStreamTest {
         } finally {
             in.close();
         }
-    }
-
-    @Test
-    public void readValueExplicitVR() throws Exception {
-
-        File smallBlob = temporaryFolder.newFile("smallBlob");
-
-        byte[] expectedBytes = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-
-        try (DicomOutputStream dicomOutputStream = new DicomOutputStream(smallBlob)) {
-
-            dicomOutputStream.writeAttribute(Tag.PixelData, VR.OB, expectedBytes);
-
-        }
-
-        try (FileInputStream fileInputStream = new FileInputStream(smallBlob)) {
-
-            DicomInputStream dicomInputStream = new DicomInputStream(fileInputStream, UID.ExplicitVRLittleEndian);
-
-            dicomInputStream.readHeader();
-
-            byte[] actualBytes = dicomInputStream.readValue();
-
-            Assert.assertArrayEquals(expectedBytes, actualBytes);
-
-        }
-
     }
 
 }


### PR DESCRIPTION
We are going to revert the changes to DicomInputStream.readValues in order to address the issue with spikes in Direct Memory Buffers and be more aligned with master.

This means we will be reintroducing the out of memory issue this issue solved. This is to be handled separately by using BuldDataDescriptorFactory.