### PR TITLE
Synchronizing DimseRSPHandler.onClose() to work around timeout issues

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/DimseRSPHandler.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/DimseRSPHandler.java
@@ -88,14 +88,14 @@ public class DimseRSPHandler {
 
     public void onDimseRSP(Association as, Attributes cmd, Attributes data) {
         if (stopOnPending || !Status.isPending(cmd.getInt(Tag.Status, -1)))
-            stopTimeout(as);
+            stopTimeout();
     }
 
     public void onClose(Association as) {
-        stopTimeout(as);
+        stopTimeout();
     }
 
-    private void stopTimeout(Association as) {
+    private synchronized void stopTimeout() {
         if (timeout != null) {
             timeout.stop();
             timeout = null;


### PR DESCRIPTION
I experienced strange and random tiemout issues when sending images with Association.cstore(). Sometimes timeouts would occur after the association was released:
```
2020-11-04 13:49:30.798 I org.dcm4che3.net.Dimse    :: AIM->STORE_SCP(73) << 1046:C-STORE-RQ...
2020-11-04 13:49:30.838 I org.dcm4che3.net.Dimse    :: AIM->STORE_SCP(73) >> 1046:C-STORE-RSP...
2020-11-04 13:49:30.891 I org.dcm4che3.net.Association :: AIM->STORE_SCP(73) << A-RELEASE-RQ
2020-11-04 13:49:30.895 I org.dcm4che3.net.Association :: AIM->STORE_SCP(73) >> A-RELEASE-RP
...
2020-11-04 13:49:58.170 I org.dcm4che3.net.Timeout  :: AIM->STORE_SCP(73): 905:DIMSE-RSP timeout expired
```

Sometimes the timeouts would occur while the association is still open and would cause a premature abort:
```
2020-09-14 09:18:48.956 I org.dcm4che3.net.Dimse    :: AIM->STORE_SCP(8650) << 910:C-STORE-RQ...
2020-09-14 09:18:48.972 I org.dcm4che3.net.Dimse    :: AIM->STORE_SCP(8650) >> 910:C-STORE-RSP...
...
2020-09-14 09:19:18.972 I org.dcm4che3.net.Timeout  :: AIM->STORE_SCP(8650): 910:DIMSE-RSP timeout expired
   2020-09-14 09:19:18.973 I org.dcm4che3.net.Association :: AIM->STORE_SCP(8650) << {}
   org.dcm4che3.net.pdu.AAbort
       A-ABORT[source: 0 - service-user, reason: 0]
       org.dcm4che3.net.Association.abort(Association.java:315)
       org.dcm4che3.net.Timeout.run(Timeout.java:83)
       java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
       java.util.concurrent.FutureTask.run(FutureTask.java:266)
       java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
       java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
       java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
       java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
       java.lang.Thread.run(Thread.java:748)
   2020-09-14 09:19:19.024 I org.dcm4che3.net.Association :: AIM->STORE_SCP(8650): close Socket[addr=chrzapp2109/10.16.4.81,port=1200,localport=30875]
```

I found the cause in the handling of Timeouts in Association and DimseRSPHandler. In `Association.invoke()` `startTimeout()` is called after the actual request was sent. Thus `DimseRSPHandler.onDimseRSP()` might be called after `DimseRSPHandler.setTimeout()` when the network is fast and the machine is slow. This opens the possibility for a timeout to never be stopped, resulting in the observed behavior.

For our product it should suffice to call `DimseRSPHandler.onClose()` after I am done with the handler in my code. However, I do not want to compete with calls to `DimseRSPHandler.onDimseRSP()`, potentially raising NullpointerExceptions. Thus this pull request.

I tried to solve this issue more profoundly by correctly synchronizing calls to `DimseRSPHandler.setTimeout()` and `DimseRSPHandler.onDimseRSP()`, however the way DimseRSPHandler is used makes this not very easy. What I could derive from the code is that `DimseRSPHandler.setTimeout()` can be called multiple times (in `Association.onDimseRSP()`), or not at all (should there be an Exception in `Association.invoke()`), and the solutions I could come up with broke at least one case each. @gunterze what are your thoughts on this?