### PR TITLE
Added startSequence() and endSequence() methods to SequenceVisitor

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -65,6 +65,8 @@ public class Attributes implements Serializable {
     }
 
     public interface SequenceVisitor extends Visitor {
+    	default void startSequence(int sqTag) {};
+    	default void endSequence() {};
         void startItem(int sqTag, int itemIndex);
         void endItem();
     }
@@ -3017,6 +3019,8 @@ public class Attributes implements Serializable {
             if (!visitor.visit(this, tags[i], vrs[i], values[i]))
                 return false;
             if (visitNestedDatasets && (values[i] instanceof Sequence)) {
+                if (visitor instanceof SequenceVisitor)
+                    ((SequenceVisitor) visitor).startSequence(tags[i]);
                 int itemIndex = 0;
                 for (Attributes item : (Sequence) values[i]) {
                     if (visitor instanceof SequenceVisitor)
@@ -3027,6 +3031,8 @@ public class Attributes implements Serializable {
                         ((SequenceVisitor) visitor).endItem();
                     itemIndex++;
                 }
+                if (visitor instanceof SequenceVisitor)
+                    ((SequenceVisitor) visitor).endSequence();
             }
         }
         return true;

--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -65,10 +65,10 @@ public class Attributes implements Serializable {
     }
 
     public interface SequenceVisitor extends Visitor {
-    	default void startSequence(int sqTag) {};
-    	default void endSequence() {};
         void startItem(int sqTag, int itemIndex);
         void endItem();
+        default void startSequence(int sqTag) {};
+        default void endSequence() {};
     }
 
     public static abstract class ItemPointerVisitor implements SequenceVisitor {


### PR DESCRIPTION
I extended the SequenceVisitor to include the start and end of sequences. This allowed me to significantly simplify my code, and I think this could generally be useful. I marked the new methods as `default` with an empty implementation for backwards compatibility.