### PR TITLE
Use DicomInputStream to allow for deflated transfer syntaxes to work in dcm2jpg tool

### DIFF
--- a/dcm4che-tool/dcm4che-tool-dcm2jpg/README.md
+++ b/dcm4che-tool/dcm4che-tool-dcm2jpg/README.md
@@ -50,6 +50,12 @@ Options:
     --suffix <suffix>         file extension used with destination
                               directory argument,lower case format name by
                               default
+    --usedis                  use DicomInputStream for reading the DICOM
+                              image. Supports deflated transfer syntaxes
+                              (default, without option --frame <number>)
+    --useiis                  use ImageInputStream for reading the DICOM
+                              image (default, with option --frame
+                              <number>)
     --uselut                  use explicit VOI LUT in image, even if the
                               image also specifies Window Center/Width;
                               prefer applying Window Center/Width over

--- a/dcm4che-tool/dcm4che-tool-dcm2jpg/src/main/java/org/dcm4che3/tool/dcm2jpg/Dcm2Jpg.java
+++ b/dcm4che-tool/dcm4che-tool-dcm2jpg/src/main/java/org/dcm4che3/tool/dcm2jpg/Dcm2Jpg.java
@@ -40,23 +40,15 @@ package org.dcm4che3.tool.dcm2jpg;
 
 import org.apache.commons.cli.*;
 import org.dcm4che3.data.Attributes;
-import org.dcm4che3.image.BufferedImageUtils;
 import org.dcm4che3.image.ICCProfile;
-import org.dcm4che3.image.PaletteColorModel;
 import org.dcm4che3.imageio.plugins.dcm.DicomImageReadParam;
 import org.dcm4che3.io.DicomInputStream;
 import org.dcm4che3.tool.common.CLIUtils;
 import org.dcm4che3.util.SafeClose;
 
 import javax.imageio.*;
-import javax.imageio.metadata.IIOMetadata;
-import javax.imageio.stream.FileImageInputStream;
 import javax.imageio.stream.FileImageOutputStream;
-import javax.imageio.stream.ImageInputStream;
-import javax.imageio.stream.ImageOutputStream;
-import java.awt.color.ColorSpace;
 import java.awt.image.BufferedImage;
-import java.awt.image.ColorModel;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -396,8 +388,8 @@ public class Dcm2Jpg {
     }
 
     private BufferedImage readImage(File file) throws IOException {
-        try (ImageInputStream iis = new FileImageInputStream(file)) {
-            imageReader.setInput(iis);
+        try (DicomInputStream dis = new DicomInputStream(file)) {
+            imageReader.setInput(dis);
             return imageReader.read(frame - 1, readParam());
         }
     }

--- a/dcm4che-tool/dcm4che-tool-dcm2jpg/src/main/resources/org/dcm4che3/tool/dcm2jpg/messages.properties
+++ b/dcm4che-tool/dcm4che-tool-dcm2jpg/src/main/resources/org/dcm4che3/tool/dcm2jpg/messages.properties
@@ -52,3 +52,5 @@ formatNotSupported=output image format: {0} not supported
 noSuchImageWriter=no Image Writer: {0} for format {1} found
 converted={0} -> {1}
 failed=Failed to convert {0}: {1}
+usedis=use DicomInputStream for reading the DICOM image. Supports deflated transfer syntaxes (default, without option --frame <number>)
+useiis=use ImageInputStream for reading the DICOM image (default, with option --frame <number>)


### PR DESCRIPTION
Currently, the dcm2jpg tool will throw an EOFException #42 when trying to convert a DICOM file to JPEG that is encoded with a deflated ts.

Per [DicomImageReader](https://github.com/dcm4che/dcm4che/blob/master/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/plugins/dcm/DicomImageReader.java) we can provide an ImageInputStream, DicomMetaData or InputStream. Using an ImageInputStream as the tool currently does, does not support deflated files. Simply swapping this to a DicomInputStream allows for the same functionality and works for deflated input streams also. 

If this isn't acceptable it would be possible to check if the file is deflated in the tool and select either an ImageInputStream or DicomInputStream at that time.