### PR TITLE
Fix Private tag without privateCreator cause equals method to throw NullPointerException #900

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -501,7 +501,7 @@ public class Attributes implements Serializable {
             creatorTag = tags[index];
             if (vrs[index].isStringType()) {
                 Object creatorID = decodeStringValue(index);
-                if (privateCreator.equals(creatorID))
+                if (privateCreator != null && privateCreator.equals(creatorID))
                     return creatorTag;
             }
             index++;
@@ -2666,9 +2666,14 @@ public class Attributes implements Serializable {
                 int tmp = TagUtils.creatorTagOf(tag);
                 if (creatorTag != tmp) {
                     creatorTag = tmp;
-                    otherCreatorTag = other.creatorTagOf(privateCreatorAt(indexOf(creatorTag)), tag, false);
-                    if (otherCreatorTag == -1)
-                        return false;
+                    String privateCreator = privateCreatorAt(indexOf(creatorTag));
+                    if (privateCreator != null) {
+                    	otherCreatorTag = other.creatorTagOf(privateCreator, tag, false);
+                        if (otherCreatorTag == -1)
+                            return false;
+                    }
+                    else
+                    	otherCreatorTag = creatorTag;
                 }
                 int j = other.indexOf(TagUtils.toPrivateTag(otherCreatorTag, tag));
                 if (j < 0 || !equalValues(other, i, j))

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
@@ -163,6 +163,18 @@ public class AttributesTest {
         assertTrue(a1.equals(a2));
         assertTrue(a2.equals(a1));
     }
+    
+    @Test
+    public void testPrivateTagEqualsWithoutPrivateCreator() {
+    	Attributes a1 = new Attributes();
+    	a1.setString(0x55330010, VR.LO, "CREATOR1");
+    	a1.setString(0x55331134, VR.LO, "VALUE1");
+    	Attributes a2 = new Attributes();
+    	a2.setString(0x55330010, VR.LO, "CREATOR1");
+    	a2.setString(0x55331134, VR.LO, "VALUE1");
+    	assertTrue(a1.equals(a2));
+    	assertTrue(a2.equals(a1));
+    }
 
     @Test
     public void testEqualValues() {


### PR DESCRIPTION
Fix for #900 