### PR TITLE
Fixed Creatorless private tag NPE

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/util/TagUtils.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/util/TagUtils.java
@@ -45,6 +45,13 @@ import org.dcm4che3.data.Tag;
  */
 public class TagUtils {
 
+    public enum Type {
+        STANDARD, PRIVATE, PRIVATE_CREATOR;
+        public static Type typeOf(int tag) {
+            return (tag & 0x00010000) != 0 ? (tag & 0x0000FF00) != 0 ? PRIVATE : PRIVATE_CREATOR : STANDARD;
+        }
+    }
+
     private static char[] HEX_DIGITS = {
         '0', '1', '2', '3', '4', '5', '6', '7',
         '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
@@ -165,6 +165,28 @@ public class AttributesTest {
         assertTrue(a1.equals(a2));
         assertTrue(a2.equals(a1));
     }
+    
+    @Test
+    public void testPrivateTagEqualsWithoutPrivateCreator() {
+        Attributes a1 = new Attributes();
+        a1.setString(0x00091010, VR.LO, "VALUE1");
+        Attributes a2 = new Attributes();
+        a2.setString(0x00091010, VR.LO, "VALUE1");
+        assertTrue(a1.equals(a2));
+        assertTrue(a2.equals(a1));
+    }
+
+    @Test
+    public void testPrivateTagNotEqualsWithoutPrivateCreator() {
+        Attributes a1 = new Attributes();
+        a1.setString(0x00090010, VR.LO, "CREATOR1");
+        a1.setString(0x00091010, VR.LO, "VALUE1");
+        Attributes a2 = new Attributes();
+        a2.setString(0x00090020, VR.LO, "CREATOR2");
+        a2.setString(0x00091010, VR.LO, "VALUE1");
+        assertFalse(a1.equals(a2));
+        assertFalse(a2.equals(a1));
+    }
 
     @Test
     public void testEqualsIS() {
@@ -653,4 +675,5 @@ public class AttributesTest {
         assertArrayEquals(MODALITIES_IN_STUDY, a.getStrings(Tag.ModalitiesInStudy));
         assertEquals(MODALITIES_IN_STUDY[0], a.getString(Tag.ModalitiesInStudy));
     }
+
 }


### PR DESCRIPTION
java.lang.ClassCastException on copy of data sets with empty PrivateCreator Data Elements fix #660
(cherry picked from commit 0f78d7dceb22b2bd834cc08cfd78a4a961a955f6)
Creator-less Private Tag cause equals() to throw Null Pointer Exception fix #900
(cherry picked from commit 3c60672781d458033f0c72c680a9dec33076db0a)
(cherry picked from commit c0c34a7c4926ca239bfbb7677beb331ac250ed45)
(cherry picked from commit [4c94e6647353ba7c4792d0c6f366da2fd0886f8f)]

Fix for #900 