### PR TITLE
Update to OpenCV 4.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <weasis.core.img.version>4.5.0</weasis.core.img.version>
-    <weasis.opencv.native.version>4.5.0-dcm</weasis.opencv.native.version>
+    <weasis.core.img.version>4.5.1</weasis.core.img.version>
+    <weasis.opencv.native.version>4.5.1-dcm</weasis.opencv.native.version>
     <keycloak.version>11.0.3</keycloak.version>
     <jbossws-cxf-client.version>5.4.1.Final</jbossws-cxf-client.version>
     <apache-cxf.version>3.3.7</apache-cxf.version>


### PR DESCRIPTION
- Update to OpenCV 4.5.1
- Update charls to[ 2.2.0](https://github.com/team-charls/charls/releases/tag/2.2.0)
- Update OpenJPEG to [2.4.0](https://github.com/uclouvain/openjpeg/blob/v2.4.0/CHANGELOG.md#v240-2020-12-28)
- Fix reading binary image