### PR TITLE
Make read images streams public

### DIFF
--- a/dcm4che-tool/dcm4che-tool-dcm2jpg/src/main/java/org/dcm4che3/tool/dcm2jpg/Dcm2Jpg.java
+++ b/dcm4che-tool/dcm4che-tool-dcm2jpg/src/main/java/org/dcm4che3/tool/dcm2jpg/Dcm2Jpg.java
@@ -425,14 +425,14 @@ public class Dcm2Jpg {
         writeImage(dest, iccProfile.adjust(readImage.apply(src)));
     }
 
-    private BufferedImage readImageFromImageInputStream(File file) throws IOException {
+    public BufferedImage readImageFromImageInputStream(File file) throws IOException {
         try (ImageInputStream iis = new FileImageInputStream(file)) {
             imageReader.setInput(iis);
             return imageReader.read(frame - 1, readParam());
         }
     }
 
-    private BufferedImage readImageFromDicomInputStream(File file) throws IOException {
+    public BufferedImage readImageFromDicomInputStream(File file) throws IOException {
         try (DicomInputStream dis = new DicomInputStream(file)) {
             imageReader.setInput(dis);
             return imageReader.read(frame - 1, readParam());


### PR DESCRIPTION
Back in February two InputStreams readers methods were introduced: `readImageFromImageInputStream` and `readImageFromDicomInputStream`. 
First, they were made **private**, and second, the default image reading action was omitted. So basically one MUST call one of these methods to instantiate [readImage](https://github.com/dcm4che/dcm4che/blob/7a49871e63c900ec63addf7fee9210b7fe4464f8/dcm4che-tool/dcm4che-tool-dcm2jpg/src/main/java/org/dcm4che3/tool/dcm2jpg/Dcm2Jpg.java#L73) so that we wont get NPE.

Making them public will allow (at least us in the team) use Dcm2Jpg methods directly to convert images, not using static call of `main`

Yes, one can use `main`, but then we see unnecessary annoying messages in stdout. One does not need this. (Maybe "silent" option could be introduced as well)