### PR TITLE
Set specific version of maven-deploy-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,10 @@
           <version>3.1.1</version>
         </plugin>
         <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.0.0-M1</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>3.1.1</version>
         </plugin>


### PR DESCRIPTION
Reasoning: Without setting a specific version, the results of our deployments are unpredictable.