### PR TITLE
IEI-81066 Set specific version of maven-deploy-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,10 @@
           </configuration>
         </plugin>
         <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.0.0-M1</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <version>2.4.0</version>


### PR DESCRIPTION
Cherry-pick of 63af1976e5adf820dc02e56310b73dfa82727cd0

@craigtmoore: I realized that the altDeploymentRepository property only works with this new version of the deploy-plugin. Therefore I am fixing it to be on the safe side (sometimes the build slave is picking an older version of said plugin.)
We might have to backport this little change also to rc branches should we need to release them again and the release fails.