### PR TITLE
IEI-133247 Large log message captured in failed jobs

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/ApplicationEntity.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/ApplicationEntity.java
@@ -719,7 +719,7 @@ public class ApplicationEntity implements Serializable {
                     }
         if (cc == null)
             throw new IncompatibleConnectionException(
-                    "No compatible connection to " + remote.getAETitle() + " available on " + this);
+                    "No compatible connection to " + remote.getAETitle() + " available on " + this); 
         return cc;
     }
 


### PR DESCRIPTION
The change is already in the dcm4che ei/master branch.
Sorry, I accidently committed the change to dcm4che generic-config branch. So I only add one space at the end here just for this pull request.
Original:  "No compatible connection to " + remote + " available on " + aet);
change:   "No compatible connection to " + remote.getAETitle() + " available on " + aet);