### PR TITLE
[LIB-312] Do not apply time zone conversion to Patient Birth Date and Time, Context Group Version and Context Group Local Version

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -1706,6 +1706,7 @@ public class Attributes implements Serializable {
         TimeZone tz = DateUtils.timeZone(utcOffset);
         updateTimezone(getTimeZone(), tz);
         setString(Tag.TimezoneOffsetFromUTC, VR.SH, utcOffset);
+        this.tz = tz;
     }
 
     /**
@@ -1730,10 +1731,13 @@ public class Attributes implements Serializable {
             setString(Tag.TimezoneOffsetFromUTC, VR.SH,
                     DateUtils.formatTimezoneOffsetFromUTC(tz));
         }
-        this.tz=null;
+        this.tz = tz;
     }
 
     private void updateTimezone(TimeZone from, TimeZone to) {
+        if (from.hasSameRules(to))
+            return;
+
         for (int i = 0; i < size; i++) {
             Object val = values[i];
             if (val instanceof Sequence) {
@@ -1742,7 +1746,9 @@ public class Attributes implements Serializable {
                     item.updateTimezone(item.getTimeZone(), to);
                     item.remove(Tag.TimezoneOffsetFromUTC);
                 }
-            } else if (vrs[i] == VR.TM || vrs[i] == VR.DT)
+            } else if (vrs[i] == VR.TM && tags[i] != Tag.PatientBirthTime
+                    || vrs[i] == VR.DT && tags[i] != Tag.ContextGroupVersion
+                                       && tags[i] != Tag.ContextGroupLocalVersion)
                 updateTimezone(from, to, i);
         }
     }

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
@@ -290,14 +290,25 @@ public class AttributesTest {
             Attributes a = new Attributes();
             a.setDefaultTimeZone(DateUtils.timeZone("+0000"));
             a.setDate(Tag.StudyDateAndTime, new Date(0));
+            a.setString(Tag.PatientBirthDate, VR.DA, "19700101");
+            a.setString(Tag.PatientBirthTime, VR.TM, "000000.000");
+            a.setString(Tag.ContextGroupVersion, VR.DT, "19700101");
             assertEquals("19700101", a.getString(Tag.StudyDate));
             assertEquals("000000.000", a.getString(Tag.StudyTime));
+
             a.setTimezoneOffsetFromUTC("+0100");
             assertEquals("19700101", a.getString(Tag.StudyDate));
             assertEquals("010000.000", a.getString(Tag.StudyTime));
+            assertEquals("19700101", a.getString(Tag.PatientBirthDate));
+            assertEquals("000000.000", a.getString(Tag.PatientBirthTime));
+            assertEquals("19700101", a.getString(Tag.ContextGroupVersion));
+
             a.setTimezoneOffsetFromUTC("-0100");
             assertEquals("19691231", a.getString(Tag.StudyDate));
             assertEquals("230000.000", a.getString(Tag.StudyTime));
+            assertEquals("19700101", a.getString(Tag.PatientBirthDate));
+            assertEquals("000000.000", a.getString(Tag.PatientBirthTime));
+            assertEquals("19700101", a.getString(Tag.ContextGroupVersion));
         }
 
         @Test


### PR DESCRIPTION
@gunterze, this is another commit from you from generic-config, that you forgot (?) to take over to the master branch.