### PR TITLE
Update to OpenCV 4.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <weasis.core.img.version>4.5.1</weasis.core.img.version>
-    <weasis.opencv.native.version>4.5.1-dcm</weasis.opencv.native.version>
+    <weasis.core.img.version>4.5.3</weasis.core.img.version>
+    <weasis.opencv.native.version>4.5.3-dcm</weasis.opencv.native.version>
     <keycloak.version>11.0.3</keycloak.version>
     <jbossws-cxf-client.version>5.4.3.Final</jbossws-cxf-client.version>
     <apache-cxf.version>3.3.10</apache-cxf.version>


### PR DESCRIPTION
- Update to OpenCV 4.5.3
- jpeg-ls decoder: fix get rendered image with non-rgb color model
- Fix the arm-32 folder detection for the native library
- New API for getting base Exif metadata of jpeg, tif and png
- Fix non-case sensitive extension on Windows