### PR TITLE
Issue 1003 - fix an out of memory exception when decoding a single frame compressed image

### DIFF
--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/StreamSegment.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/StreamSegment.java
@@ -116,14 +116,8 @@ public abstract class StreamSegment {
 
     private static StreamSegment getFileStreamSegment(SegmentedInputImageStream iis) {
         try {
-            Class<? extends ImageInputStream> clazz = iis.getClass();
-            Field fStream = clazz.getDeclaredField("stream");
-            Field fCurSegment = clazz.getDeclaredField("curSegment");
-            if (fCurSegment != null && fStream != null) {
-                fCurSegment.setAccessible(true);
-                fStream.setAccessible(true);
 
-                ImageInputStream fstream = (ImageInputStream) fStream.get(iis);
+                ImageInputStream fstream = iis.getStream();
                 Field fRaf = null;
                 if (fstream instanceof FileImageInputStream) {
                     fRaf = FileImageInputStream.class.getDeclaredField("raf");
@@ -133,7 +127,7 @@ public abstract class StreamSegment {
 
                 if (fRaf != null) {
                     fRaf.setAccessible(true);
-                    long[][] seg = getSegments(iis, clazz, fCurSegment);
+                    long[][] seg = getSegments(iis);
                     if (seg != null) {
                         RandomAccessFile raf = (RandomAccessFile) fRaf.get(fstream);
                         /*
@@ -147,7 +141,7 @@ public abstract class StreamSegment {
                     MemoryCacheImageInputStream mstream = (MemoryCacheImageInputStream) fstream;
                     byte[] b = MemoryStreamSegment.getByte(MemoryStreamSegment.getByteArrayInputStream(mstream));
                     if (b != null) {
-                        long[][] seg = getSegments(iis, clazz, fCurSegment);
+                        long[][] seg = getSegments(iis);
                         if (seg != null) {
                             int offset = (int) seg[0][0];
                             return new MemoryStreamSegment(
@@ -157,28 +151,22 @@ public abstract class StreamSegment {
                     }
                 }
                 LOGGER.error("Cannot read SegmentedInputImageStream with {} ", fstream.getClass());
-            }
         } catch (Exception e) {
             LOGGER.error("Building FileStreamSegment from SegmentedInputImageStream", e);
         }
         return null;
     }
 
-    private static long[][] getSegments(SegmentedInputImageStream iis, Class<? extends ImageInputStream> clazz, Field fCurSegment) throws Exception {
-        Integer curSegment = (Integer) fCurSegment.get(iis);
+    private static long[][] getSegments(SegmentedInputImageStream iis) throws Exception {
+        Integer curSegment = iis.getCurSegment();
         if (curSegment != null && curSegment >= 0) {
             ImageDescriptor desc = iis.getImageDescriptor();
-            Field ffragments = clazz.getDeclaredField("fragments");
-            Field flastSegment = clazz.getDeclaredField("lastSegment");
-            if (ffragments != null && flastSegment != null) {
-                ffragments.setAccessible(true);
-                flastSegment.setAccessible(true);
-                List<Object> fragments = (List<Object>) ffragments.get(iis);
-                Integer lastSegment = (Integer) flastSegment.get(iis);
+                List<Object> fragments = iis.getFragments();
+                Integer lastSegment = iis.getLastSegment();
                 if (!desc.isMultiframe() && lastSegment < fragments.size()) {
                     lastSegment = fragments.size();
                 }
-
+                System.out.println("lastSegment="+lastSegment+" curSegment="+curSegment);
                 long[] segPositions = new long[lastSegment - curSegment];
                 long[] segLength = new long[segPositions.length];
                 long beforePos = 0;
@@ -202,7 +190,6 @@ public abstract class StreamSegment {
                     }
                 }
                 return new long[][] { segPositions, segLength };
-            }
         }
         return null;
     }

--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/StreamSegment.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/StreamSegment.java
@@ -157,7 +157,7 @@ public abstract class StreamSegment {
         return null;
     }
 
-    private static long[][] getSegments(SegmentedInputImageStream iis) throws Exception {
+    private static long[][] getSegments(SegmentedInputImageStream iis) throws IOException {
         Integer curSegment = iis.getCurSegment();
         if (curSegment != null && curSegment >= 0) {
             ImageDescriptor desc = iis.getImageDescriptor();
@@ -166,7 +166,6 @@ public abstract class StreamSegment {
                 if (!desc.isMultiframe() && lastSegment < fragments.size()) {
                     lastSegment = fragments.size();
                 }
-                System.out.println("lastSegment="+lastSegment+" curSegment="+curSegment);
                 long[] segPositions = new long[lastSegment - curSegment];
                 long[] segLength = new long[segPositions.length];
                 long beforePos = 0;

--- a/dcm4che-imageio-test/pom.xml
+++ b/dcm4che-imageio-test/pom.xml
@@ -292,6 +292,11 @@
     </dependency>
     <dependency>
       <groupId>org.dcm4che</groupId>
+      <artifactId>dcm4che-imageio</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.dcm4che</groupId>
       <artifactId>dcm4che-imageio-opencv</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/dcm4che-imageio-test/src/test/java/org/dcm4che3/imageio/dcm/TestDicomImageReader.java
+++ b/dcm4che-imageio-test/src/test/java/org/dcm4che3/imageio/dcm/TestDicomImageReader.java
@@ -86,6 +86,7 @@ public class TestDicomImageReader {
     private static final String US_MF_RLE = "US-PAL-8-10x-echo";
     private static final String US_MF_RLE_CHECKSUM = "5F4909DEDD7D1E113CC69172C693B4705FEE5B46";
     private static final String REPORT_DFL = "report_dfl";
+    private static final String UNCOMPRESSED_SINGLEFRAME = "MR2_UNC";
 
     DicomImageReader reader;
     
@@ -136,7 +137,19 @@ public class TestDicomImageReader {
             testReadPostPixelData(is);
         }
     }
-    
+
+    /**
+     * This test previously throw an out of memory exception, shows that the changes work.
+     * @throws IOException
+     */
+    @Test
+    public void testReadUncompressedingleFrame_fromImageInputStream() throws IOException {
+        try(FileImageInputStream is = new FileImageInputStream(new File("target/test-data/" + UNCOMPRESSED_SINGLEFRAME))) {
+            reader.setInput(is);
+            reader.read(0);
+        }
+    }
+
     @Test 
     public void testReadCompressedPostPixelData_fromInputStream() throws IOException {
         try(FileInputStream is = new FileInputStream(new File("target/test-data/" + US_MF_RLE))) {

--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/stream/SegmentedInputImageStream.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/stream/SegmentedInputImageStream.java
@@ -76,7 +76,8 @@ public class SegmentedInputImageStream extends ImageInputStreamImpl {
     private byte[] byteFrag;
     private ImageDescriptor imageDescriptor;
 
-    /** Create a segmented input stream, that updates the bulk data entries as required, frameIndex
+    /**
+     * Create a segmented input stream, that updates the bulk data entries as required, frameIndex
      * of -1 means the entire object/value.
      */
     public SegmentedInputImageStream(ImageInputStream stream,
@@ -97,7 +98,7 @@ public class SegmentedInputImageStream extends ImageInputStreamImpl {
         fragments = new Fragments(VR.OB, false, 16);
         if( !singleFrame ) {
             lastSegment = 2;
-        } 
+        }
         fragments.add(new byte[0]);
         fragments.add(new BulkData("pixelData://",  streamPosition, length, false));
         stream = iis;
@@ -338,5 +339,22 @@ public class SegmentedInputImageStream extends ImageInputStreamImpl {
             LOG.debug("Stack trace",e);
             return -1;
         }
+    }
+
+    public ImageInputStream getStream() {
+        return stream;
+    }
+
+    public int getCurSegment() {
+        return curSegment;
+    }
+
+    public List<Object> getFragments() {
+        return fragments;
+    }
+
+    public Integer getLastSegment() throws IOException {
+        seek(Long.MAX_VALUE);
+        return lastSegment;
     }
 }


### PR DESCRIPTION
The problem occurs because of an assumption about the segmented image input stream being used already having been fully initialized.  That isn't true because the stream was designed to be lazy loaded, which means it contains an end of fragments of MAX_INT.  That caused an int buffer of size MAX_INT to be allocated, which fails all the time.