### PR TITLE
Reduce the logging by findCompatibelConnection in ApplicationEntity

### DIFF
--- a/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
+++ b/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
@@ -1218,7 +1218,8 @@ public class AuditLogger extends DeviceExtension {
                         return activeConnection;
                     }
         throw new IncompatibleConnectionException(
-                "No compatible connection to " + arr + " available on " + this);
+                "No compatible connection to AuditRecordRepository @ Device " + arr.getDevice().getDeviceName()
+                        + " available on AuditLogger @ Device " + getDevice().getDeviceName());
     }
 
 	public static String processID() {

--- a/dcm4che-net-hl7/src/main/java/org/dcm4che3/net/hl7/HL7Application.java
+++ b/dcm4che-net-hl7/src/main/java/org/dcm4che3/net/hl7/HL7Application.java
@@ -294,7 +294,7 @@ public class HL7Application implements Serializable {
                     if (conn.isInstalled() && conn.isCompatible(remoteConn))
                         return new CompatibleConnection(conn, remoteConn);
         throw new IncompatibleConnectionException(
-                "No compatible connection to " + remote + " available on " + this);
+                "No compatible connection to " + remote.getApplicationName() + " available on " + name);
     }
 
     public Connection findCompatibelConnection(Connection remoteConn)
@@ -303,7 +303,7 @@ public class HL7Application implements Serializable {
             if (conn.isInstalled() && conn.isCompatible(remoteConn))
                 return conn;
         throw new IncompatibleConnectionException(
-                "No compatible connection to " + remoteConn + " available on " + this);
+                "No compatible connection to " + remoteConn + " available on " + name);
     }
 
     private void checkInstalled() {

--- a/dcm4che-net-hl7/src/main/java/org/dcm4che3/net/hl7/HL7Application.java
+++ b/dcm4che-net-hl7/src/main/java/org/dcm4che3/net/hl7/HL7Application.java
@@ -294,7 +294,7 @@ public class HL7Application implements Serializable {
                     if (conn.isInstalled() && conn.isCompatible(remoteConn))
                         return new CompatibleConnection(conn, remoteConn);
         throw new IncompatibleConnectionException(
-                "No compatible connection to " + remote.getApplicationName() + " available on " + name);
+                "No compatible connection to " + remote.getApplicationName() + " available on " + this.getApplicationName());
     }
 
     public Connection findCompatibelConnection(Connection remoteConn)
@@ -303,7 +303,7 @@ public class HL7Application implements Serializable {
             if (conn.isInstalled() && conn.isCompatible(remoteConn))
                 return conn;
         throw new IncompatibleConnectionException(
-                "No compatible connection to " + remoteConn + " available on " + name);
+                "No compatible connection to " + remoteConn + " available on " + this.getApplicationName());
     }
 
     private void checkInstalled() {

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/ApplicationEntity.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/ApplicationEntity.java
@@ -702,7 +702,7 @@ public class ApplicationEntity implements Serializable {
             if (conn.isInstalled() && conn.isCompatible(remoteConn))
                 return conn;
         throw new IncompatibleConnectionException(
-                "No compatible connection to " + remoteConn + " available on " + this);
+                "No compatible connection to " + remoteConn.getHostname() + " available on " + this.getAETitle());
     }
 
     public CompatibleConnection findCompatibelConnection(ApplicationEntity remote)
@@ -719,7 +719,7 @@ public class ApplicationEntity implements Serializable {
                     }
         if (cc == null)
             throw new IncompatibleConnectionException(
-                    "No compatible connection to " + remote.getAETitle() + " available on " + this); 
+                    "No compatible connection to " + remote.getAETitle() + " available on " + this.getAETitle());
         return cc;
     }
 

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/ApplicationEntity.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/ApplicationEntity.java
@@ -702,7 +702,7 @@ public class ApplicationEntity implements Serializable {
             if (conn.isInstalled() && conn.isCompatible(remoteConn))
                 return conn;
         throw new IncompatibleConnectionException(
-                "No compatible connection to " + remoteConn.getHostname() + " available on " + this.getAETitle());
+                "No compatible connection to " + remoteConn + " available on " + this.getAETitle());
     }
 
     public CompatibleConnection findCompatibelConnection(ApplicationEntity remote)


### PR DESCRIPTION
This is a continuation of the change from pull request #980, to reduce unnecessary information when findCompatibelConnection in ApplicationEntity throws an exception.