### PR TITLE
build of dcm4che-imageio-test fails on Java 16.0.1 with NPE #1031

### DIFF
--- a/dcm4che-imageio-test/pom.xml
+++ b/dcm4che-imageio-test/pom.xml
@@ -267,7 +267,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} -Djava.library.path=${project.build.directory}/lib/${os-name}-${cpu-name}</argLine>
+          <argLine>@{argLine} -Djava.library.path=${project.build.directory}/lib/${os-name}-${cpu-name} -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED</argLine>
           <skipTests>${skipTests}</skipTests>
         </configuration>
       </plugin>


### PR DESCRIPTION
Add JVM parameters for runtime (from java 8 to 17)

It is required from JDK 16 with legacy API (Decompressor, get Raster) but not with Transcode of dcm2dcm.

As dcm4che3 does not use Java modules, it is necessary to add these options to the boot to allow the use of JDK 17.
```
# Ignore by Java 8
-XX:+IgnoreUnrecognizedVMOptions
# Required from Java 9
--add-opens=java.desktop/javax.imageio.stream=ALL-UNNAMED
--add-opens=java.base/java.io=ALL-UNNAMED
```

Note that JDK 17 does not allow to bypass these options anymore, see this [announcement](https://blogs.oracle.com/javamagazine/java-runtime-encapsulation-internals).