### PR TITLE
Do not run sonar analysis for external pull requests

### DIFF
--- a/.github/workflows/build-with-sonar.sh
+++ b/.github/workflows/build-with-sonar.sh
@@ -3,4 +3,12 @@
 set -e
 
 mvn -B -P test-coverage verify
-mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.coverage.jacoco.xmlReportPaths=$(find "$(pwd)" -path '*/target/site/*/jacoco.xml' | tr '\n' ',')
+
+if [ -z "$SONAR_TOKEN" ]
+then
+  echo "Cannot run sonar analysis as there is no SONAR_TOKEN. \
+  This happens for external pull requests (from forks). See https://jira.sonarsource.com/browse/MMF-1371"
+else
+  mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+  -Dsonar.coverage.jacoco.xmlReportPaths=$(find "$(pwd)" -path '*/target/site/*/jacoco.xml' | tr '\n' ',')
+fi


### PR DESCRIPTION
... as they do not have a SONAR_TOKEN (for security reasons) and would therefore fail anyways.