### PR TITLE
Make legacy image APIs compatible with JDK 17

### DIFF
--- a/dcm4che-assembly/src/bin/dcm2dcm
+++ b/dcm4che-assembly/src/bin/dcm2dcm
@@ -99,5 +99,8 @@ if [ -n "$IMAGE_WRITER_FACTORY" ]; then
     JAVA_OPTS="$JAVA_OPTS -Dorg.dcm4che3.imageio.codec.ImageWriterFactory=$IMAGE_WRITER_FACTORY"
 fi
 
+# Required from JDK 16 with legacy image API (Decompressor and Compressor)
+JAVA_OPTS="$JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED"
+
 # Execute the JVM
 exec "$JAVA" $JAVA_OPTS -Djava.library.path="$JAVA_LIBRARY_PATH" -cp "$CP" $MAIN_CLASS "$@"

--- a/dcm4che-assembly/src/bin/dcm2dcm.bat
+++ b/dcm4che-assembly/src/bin/dcm2dcm.bat
@@ -69,4 +69,7 @@ if not "%IMAGE_READER_FACTORY%" == "" ^
 if not "%IMAGE_WRITER_FACTORY%" == "" ^
  set JAVA_OPTS=%JAVA_OPTS% -Dorg.dcm4che3.imageio.codec.ImageWriterFactory=%IMAGE_WRITER_FACTORY%
 
+rem Required from JDK 16 with legacy image API (Decompressor and Compressor)
+set JAVA_OPTS=%JAVA_OPTS% -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED
+
 "%JAVA%" %JAVA_OPTS% -cp "%CP%" %MAIN_CLASS% %ARGS%

--- a/dcm4che-assembly/src/bin/dcm2jpg
+++ b/dcm4che-assembly/src/bin/dcm2jpg
@@ -95,5 +95,8 @@ if [ -n "$IMAGE_READER_FACTORY" ]; then
     JAVA_OPTS="$JAVA_OPTS -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=$IMAGE_READER_FACTORY"
 fi
 
+# Required from JDK 16 with legacy image API (Decompressor and Compressor)
+JAVA_OPTS="$JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED"
+
 # Execute the JVM
 exec "$JAVA" $JAVA_OPTS -Djava.library.path="$JAVA_LIBRARY_PATH" -cp "$CP" $MAIN_CLASS "$@"

--- a/dcm4che-assembly/src/bin/dcm2jpg.bat
+++ b/dcm4che-assembly/src/bin/dcm2jpg.bat
@@ -66,4 +66,7 @@ set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path="%JAVA_LIBRARY_PATH%"
 if not "%IMAGE_READER_FACTORY%" == "" ^
  set JAVA_OPTS=%JAVA_OPTS% -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=%IMAGE_READER_FACTORY%
 
+rem Required from JDK 16 with legacy image API (Decompressor and Compressor)
+set JAVA_OPTS=%JAVA_OPTS% -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED
+
 "%JAVA%" %JAVA_OPTS% -cp "%CP%" %MAIN_CLASS% %ARGS%

--- a/dcm4che-assembly/src/bin/storescu
+++ b/dcm4che-assembly/src/bin/storescu
@@ -100,6 +100,8 @@ if [ -n "$IMAGE_WRITER_FACTORY" ]; then
     JAVA_OPTS="$JAVA_OPTS -Dorg.dcm4che3.imageio.codec.ImageWriterFactory=$IMAGE_WRITER_FACTORY"
 fi
 
+# Required from JDK 16 with legacy image API (Decompressor and Compressor)
+JAVA_OPTS="$JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED"
 
 # Execute the JVM
 exec "$JAVA" $JAVA_OPTS -Djava.library.path="$JAVA_LIBRARY_PATH" -cp "$CP" $MAIN_CLASS "$@"

--- a/dcm4che-assembly/src/bin/storescu.bat
+++ b/dcm4che-assembly/src/bin/storescu.bat
@@ -70,4 +70,7 @@ if not "%IMAGE_READER_FACTORY%" == "" ^
 if not "%IMAGE_WRITER_FACTORY%" == "" ^
  set JAVA_OPTS=%JAVA_OPTS% -Dorg.dcm4che3.imageio.codec.ImageWriterFactory=%IMAGE_WRITER_FACTORY%
 
+rem Required from JDK 16 with legacy image API (Decompressor and Compressor)
+set JAVA_OPTS=%JAVA_OPTS% -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.desktop/javax.imageio.stream=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED
+
 "%JAVA%" %JAVA_OPTS% -cp "%CP%" %MAIN_CLASS% %ARGS%


### PR DESCRIPTION
JDK 17 does not allow reflective access of private fields anymore, see this [announcement](https://blogs.oracle.com/javamagazine/java-runtime-encapsulation-internals).