### PR TITLE
#1045: Remove logging implementation from libraries.

### DIFF
--- a/dcm4che-core/pom.xml
+++ b/dcm4che-core/pom.xml
@@ -213,10 +213,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/dcm4che-hl7/pom.xml
+++ b/dcm4che-hl7/pom.xml
@@ -61,9 +61,5 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/dcm4che-net/pom.xml
+++ b/dcm4che-net/pom.xml
@@ -68,10 +68,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>


### PR DESCRIPTION
Removed unnecessary logging implementation modules from dcm4che library modules.