### PR TITLE
IEI-169967 Add storage version awareness to root configurable classes

### DIFF
--- a/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/TCConfiguration.java
+++ b/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/TCConfiguration.java
@@ -3,6 +3,7 @@ package org.dcm4che3.conf.api;
 import org.dcm4che3.conf.core.api.ConfigurableClass;
 import org.dcm4che3.conf.core.api.ConfigurableProperty;
 import org.dcm4che3.conf.core.api.ConfigurationException;
+import org.dcm4che3.conf.core.api.StorageVersionedConfigurableClass;
 import org.dcm4che3.net.TCGroupConfigAEExtension;
 import org.dcm4che3.net.TransferCapability;
 
@@ -10,13 +11,16 @@ import java.util.*;
 
 /**
  * @author Roman K
+ * @author Maciek Siemczyk (maciek.siemczyk@agfa.com)
+ * 
+ * @see StorageVersionedConfigurableClass
  */
 @ConfigurableClass
-public class TCConfiguration {
+public class TCConfiguration extends StorageVersionedConfigurableClass {
 
     @ConfigurableProperty
-    private Map<String, TCGroup> transferCapabilityGroups = new TreeMap<String, TCGroup>();
-
+    private Map<String, TCGroup> transferCapabilityGroups = new TreeMap<>();
+    
     /**
      * Persists default group config
      * Deprecated. Do not use it in upgrade scripts.
@@ -57,7 +61,7 @@ public class TCConfiguration {
         }
 
         @ConfigurableProperty
-        List<TransferCapability> transferCapabilities = new ArrayList<TransferCapability>();
+        List<TransferCapability> transferCapabilities = new ArrayList<>();
 
         public List<TransferCapability> getTransferCapabilities() {
             return transferCapabilities;

--- a/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/upgrade/ConfigurationMetadata.java
+++ b/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/upgrade/ConfigurationMetadata.java
@@ -40,31 +40,31 @@
 
 package org.dcm4che3.conf.api.upgrade;
 
-import org.dcm4che3.conf.api.upgrade.UpgradeScript;
-import org.dcm4che3.conf.core.api.ConfigurableClass;
-import org.dcm4che3.conf.core.api.ConfigurableProperty;
-import org.dcm4che3.net.DeviceExtension;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import org.dcm4che3.conf.core.api.ConfigurableClass;
+import org.dcm4che3.conf.core.api.ConfigurableProperty;
+import org.dcm4che3.conf.core.api.StorageVersionedConfigurableClass;
+
 /**
  * @author Roman K
+ * @author Maciek Siemczyk (maciek.siemczyk@agfa.com)
+ * 
+ * @see StorageVersionedConfigurableClass
  */
 @ConfigurableClass
-public class ConfigurationMetadata {
+public class ConfigurationMetadata extends StorageVersionedConfigurableClass {
 
-    @ConfigurableProperty(
-            label = "Global configuration version"
-    )
+    @ConfigurableProperty(label = "Global configuration version")
     private String version;
 
     @ConfigurableProperty(type = ConfigurableProperty.ConfigurablePropertyType.ExtensionsProperty)
     private Map<Class<? extends ConfigurationMetadataExtension>, ConfigurationMetadataExtension> extensions =
-            new HashMap<Class<? extends ConfigurationMetadataExtension>, ConfigurationMetadataExtension>();
+            new HashMap<>();
 
     @ConfigurableProperty
-    Map<String, UpgradeScript.UpgradeScriptMetadata> metadataOfUpgradeScripts = new HashMap<String, UpgradeScript.UpgradeScriptMetadata>();
+    Map<String, UpgradeScript.UpgradeScriptMetadata> metadataOfUpgradeScripts = new HashMap<>();
 
     public String getVersion() {
         return version;

--- a/dcm4che-conf/dcm4che-conf-api/src/test/java/org/dcm4che3/conf/api/tests/ConfigurationMetadataTest.java
+++ b/dcm4che-conf/dcm4che-conf-api/src/test/java/org/dcm4che3/conf/api/tests/ConfigurationMetadataTest.java
@@ -1,0 +1,20 @@
+package org.dcm4che3.conf.api.tests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.dcm4che3.conf.api.upgrade.ConfigurationMetadata;
+import org.dcm4che3.conf.core.api.StorageVersionedConfigurableClass;
+import org.junit.Test;
+
+public class ConfigurationMetadataTest {
+
+    @Test
+    public void configurationMetadata_ExtendsStorageVersionedConfigurableClass_BecauseItIsRootConfigurationClass() {
+        
+        assertThat(
+            "ConfigurationMetadata is root class and should be extending StorageVersionedConfigurableClass",
+            StorageVersionedConfigurableClass.class.isAssignableFrom(ConfigurationMetadata.class),
+            equalTo(true));
+    }
+}

--- a/dcm4che-conf/dcm4che-conf-api/src/test/java/org/dcm4che3/conf/api/tests/TCConfigurationTest.java
+++ b/dcm4che-conf/dcm4che-conf-api/src/test/java/org/dcm4che3/conf/api/tests/TCConfigurationTest.java
@@ -1,0 +1,20 @@
+package org.dcm4che3.conf.api.tests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.dcm4che3.conf.api.TCConfiguration;
+import org.dcm4che3.conf.core.api.StorageVersionedConfigurableClass;
+import org.junit.Test;
+
+public class TCConfigurationTest {
+
+    @Test
+    public void tcConfiguration_ExtendsStorageVersionedConfigurableClass_BecauseItIsRootConfigurationClass() {
+        
+        assertThat(
+            "TCConfiguration is root class and should be extending StorageVersionedConfigurableClass",
+            StorageVersionedConfigurableClass.class.isAssignableFrom(TCConfiguration.class),
+            equalTo(true));
+    }
+}

--- a/dcm4che-conf/dcm4che-conf-core-api/src/main/java/org/dcm4che3/conf/core/api/Configuration.java
+++ b/dcm4che-conf/dcm4che-conf-core-api/src/main/java/org/dcm4che3/conf/core/api/Configuration.java
@@ -86,6 +86,10 @@ public interface Configuration extends BatchRunner {
     String WEAK_REFERENCE_KEY = "weakReference";
     String REFERENCE_BY_UUID_PATTERN = "//*[_.uuid='{uuid}']";
 
+    /**
+     * A special property key that indicates the database (JPA controlled) version of the containing node.
+     */
+    String VERSION_KEY = "_.version";
 
     enum ConfigStorageType {
         JSON_FILE,

--- a/dcm4che-conf/dcm4che-conf-core-api/src/main/java/org/dcm4che3/conf/core/api/StorageVersionedConfigurableClass.java
+++ b/dcm4che-conf/dcm4che-conf-core-api/src/main/java/org/dcm4che3/conf/core/api/StorageVersionedConfigurableClass.java
@@ -1,0 +1,22 @@
+package org.dcm4che3.conf.core.api;
+
+/**
+ * This base class represent a "root" {@link ConfigurableClass} that gets backed
+ * by the storage and thus has a (JPA) version associated with it.  
+ * 
+ * @author Maciek Siemczyk (maciek.siemczyk@agfa.com)
+ */
+public abstract class StorageVersionedConfigurableClass {
+
+    private long storageVersion;
+
+    public long getStorageVersion() {
+
+        return storageVersion;
+    }
+
+    public void setStorageVersion(long version) {
+
+        this.storageVersion = version;
+    }    
+}

--- a/dcm4che-conf/dcm4che-conf-core-api/src/test/java/org/dcm4che3/conf/core/api/tests/StorageVersionedConfigurableClassTest.java
+++ b/dcm4che-conf/dcm4che-conf-core-api/src/test/java/org/dcm4che3/conf/core/api/tests/StorageVersionedConfigurableClassTest.java
@@ -1,0 +1,29 @@
+package org.dcm4che3.conf.core.api.tests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.dcm4che3.conf.core.api.StorageVersionedConfigurableClass;
+import org.junit.Test;
+
+public class StorageVersionedConfigurableClassTest {
+
+    private StorageVersionedConfigurableClass storageVersionedConfigurableClass
+        = new TestableStorageVersionedConfigurableClass();
+    
+    @Test
+    public void contructor_SetsMemberCorrecly_WhenCalled() {
+        
+        assertThat("Wrong default version", storageVersionedConfigurableClass.getStorageVersion(), equalTo(0L));
+    }
+
+    @Test
+    public void setStorageVersion_SetsMemberCorrecly_WhenCalled() {
+        
+        storageVersionedConfigurableClass.setStorageVersion(Integer.MAX_VALUE + 1L);
+        
+        assertThat("Wrong version", storageVersionedConfigurableClass.getStorageVersion(), equalTo(2147483648L));
+    }
+
+    private static final class TestableStorageVersionedConfigurableClass extends StorageVersionedConfigurableClass { }
+}

--- a/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/adapters/ReflectiveAdapter.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/adapters/ReflectiveAdapter.java
@@ -39,8 +39,20 @@
  */
 package org.dcm4che3.conf.core.adapters;
 
-import com.google.common.util.concurrent.SettableFuture;
-import org.dcm4che3.conf.core.api.*;
+import java.lang.reflect.Field;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.commons.lang.StringUtils;
+import org.dcm4che3.conf.core.api.ConfigurableProperty;
+import org.dcm4che3.conf.core.api.Configuration;
+import org.dcm4che3.conf.core.api.ConfigurationException;
+import org.dcm4che3.conf.core.api.Path;
+import org.dcm4che3.conf.core.api.TypeSafeConfiguration;
+import org.dcm4che3.conf.core.api.StorageVersionedConfigurableClass;
 import org.dcm4che3.conf.core.api.internal.ConfigProperty;
 import org.dcm4che3.conf.core.api.internal.ConfigReflection;
 import org.dcm4che3.conf.core.api.internal.ConfigTypeAdapter;
@@ -52,9 +64,7 @@ import org.dcm4che3.conf.core.util.PathFollower;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Field;
-import java.util.*;
-import java.util.concurrent.Future;
+import com.google.common.util.concurrent.SettableFuture;
 
 /**
  * Reflective adapter that handles classes with ConfigurableClass annotations.<br/>
@@ -62,12 +72,14 @@ import java.util.concurrent.Future;
  * <p/>
  * User has to use the special constructor and initialize providedConfObj when the
  * already created conf object should be used instead of instantiating one
+ * 
+ * @author Roman K
+ * @author Maciek Siemczyk (maciek.siemczyk@agfa.com)
  */
 @SuppressWarnings("unchecked")
 public class ReflectiveAdapter<T> implements ConfigTypeAdapter<T, Map<String, Object>> {
 
-
-    private static Logger log = LoggerFactory.getLogger(ReflectiveAdapter.class);
+    private static final Logger log = LoggerFactory.getLogger(ReflectiveAdapter.class);
 
     private T providedConfObj;
 
@@ -168,6 +180,14 @@ public class ReflectiveAdapter<T> implements ConfigTypeAdapter<T, Map<String, Ob
             populateFields(configNode, ctx, clazz, confObj);
         }
 
+        // Set the storage version if needed. 
+        if (StorageVersionedConfigurableClass.class.isAssignableFrom(clazz)) {
+            Long version = (Long) configNode.get(Configuration.VERSION_KEY);
+            
+            if (version != null) {
+                ((StorageVersionedConfigurableClass) confObj).setStorageVersion(version);
+            }
+        }
     }
 
     private void populateFields(Map<String, Object> configNode, LoadingContext ctx, Class<T> clazz, T confObj) {
@@ -202,7 +222,7 @@ public class ReflectiveAdapter<T> implements ConfigTypeAdapter<T, Map<String, Ob
         // TODO: replace with proxy
 
         // if no config context - leave the parent unset
-        TypeSafeConfiguration typeSafeConfig = ctx.getTypeSafeConfiguration();
+        TypeSafeConfiguration<?> typeSafeConfig = ctx.getTypeSafeConfiguration();
         if (typeSafeConfig == null) return;
 
         // Get path of this object in the storage
@@ -212,7 +232,10 @@ public class ReflectiveAdapter<T> implements ConfigTypeAdapter<T, Map<String, Ob
 
         // parent is either the first or the second in the path (otherwise cannot really get the parent)
 
-        if (configProperties.size() < 1) return;
+        if (configProperties.isEmpty()) {
+            return;
+        }
+        
         configProperties.removeLast();
         int nodesAbove = 1;
 
@@ -220,16 +243,23 @@ public class ReflectiveAdapter<T> implements ConfigTypeAdapter<T, Map<String, Ob
         if (!configProperties.peekLast().isConfObject()) {
             configProperties.removeLast();
             nodesAbove++;
-            if (configProperties.size() == 0) return;
-            if (!configProperties.peekLast().isConfObject()) return;
+            if (configProperties.isEmpty()) {
+                return;
+            }
+            
+            if (!configProperties.peekLast().isConfObject()) {
+                return;
+            }
         }
 
         // now we are looking at the parent
         ConfigProperty parentProp = configProperties.peekLast();
 
         if (!parentField.getType().isAssignableFrom(parentProp.getRawClass())) {
-            log.warn("Parent type mismatch: config structure denotes " + parentProp.getRawClass() + ", but the class has a field of type " + parentField.getType()
-                    + " config object uuid=" + uuid + ", config class " + clazz);
+            log.warn(
+                    "Parent type mismatch: config structure denotes {}, but the class"
+                        + "has a field of type {} config object uuid={}, config class {}.",
+                    parentProp.getRawClass(), parentField.getType(), uuid, clazz);
             return;
         }
 
@@ -248,7 +278,7 @@ public class ReflectiveAdapter<T> implements ConfigTypeAdapter<T, Map<String, Ob
 
         Class<T> clazz = (Class<T>) object.getClass();
 
-        Map<String, Object> configNode = new TreeMap<String, Object>();
+        Map<String, Object> configNode = new TreeMap<>();
 
         // get data from all the configurable fields
         for (ConfigProperty fieldProperty : ConfigReflection.getAllConfigurableFields(clazz)) {
@@ -259,59 +289,71 @@ public class ReflectiveAdapter<T> implements ConfigTypeAdapter<T, Map<String, Ob
                 throw new ConfigurationException("Error while serializing configuration field '" + fieldProperty.getName() + "' in class " + clazz.getSimpleName(), e);
             }
         }
+        
+        // Set the storage version if needed. 
+        if (StorageVersionedConfigurableClass.class.isAssignableFrom(clazz)) {
+            configNode.put(Configuration.VERSION_KEY, ((StorageVersionedConfigurableClass) object).getStorageVersion());
+        }
 
         return configNode;
     }
-
 
     @Override
     public Map<String, Object> getSchema(ConfigProperty property, ProcessingContext ctx) throws ConfigurationException {
 
         Class<T> clazz = (Class<T>) property.getType();
 
-        Map<String, Object> classMetaDataWrapper = new HashMap<String, Object>();
-        Map<String, Object> classMetaData = new HashMap<String, Object>();
-        classMetaDataWrapper.put("properties", classMetaData);
-        classMetaDataWrapper.put("type", "object");
-        classMetaDataWrapper.put("class", clazz.getSimpleName());
+        Map<String, Object> classMetaDataWrapper = new HashMap<>();
+        Map<String, Object> classMetaData = new HashMap<>();
+        classMetaDataWrapper.put(PropertySchema.PROPERTIES_KEY, classMetaData);
+        classMetaDataWrapper.put(PropertySchema.TYPE_KEY, "object");
+        classMetaDataWrapper.put(PropertySchema.CLASS_KEY, clazz.getSimpleName());
 
         // find out if we need to include uiOrder metadata
-        boolean includeOrder = false;
-
-
-        for (ConfigProperty configurableChildProperty : ConfigReflection.getAllConfigurableFields(clazz))
-            if (configurableChildProperty.getAnnotation(ConfigurableProperty.class).order() != 0) includeOrder = true;
+        boolean includeOrder = ConfigReflection.getAllConfigurableFields(clazz).stream()
+            .map(configurableProperty -> configurableProperty.getAnnotation(ConfigurableProperty.class))
+            .anyMatch(annotation -> annotation.order() != 0);
         
         // populate properties
-
         for (ConfigProperty prop : ConfigReflection.getAllConfigurableFields(clazz)) {
 
-            ConfigTypeAdapter childAdapter = ctx.getVitalizer().lookupTypeAdapter(prop);
-            Map<String, Object> childPropertyMetadata = new LinkedHashMap<String, Object>();
+            ConfigTypeAdapter<?, ?> childAdapter = ctx.getVitalizer().lookupTypeAdapter(prop);
+            Map<String, Object> childPropertyMetadata = new LinkedHashMap<>();
             classMetaData.put(prop.getAnnotatedName(), childPropertyMetadata);
 
-            if (!"".equals( prop.getLabel() ) )
-                childPropertyMetadata.put("title", prop.getLabel());
+            setPropertyAttributeIfPresent(childPropertyMetadata, prop.getLabel(), PropertySchema.TITLE_KEY);
+            setPropertyAttributeIfPresent(childPropertyMetadata, prop.getDescription(), "description");
 
-            if (!"".equals( prop.getDescription() ) )
-                childPropertyMetadata.put("description", prop.getDescription());
             try {
-                if (!prop.getDefaultValue().equals(ConfigurableProperty.NO_DEFAULT_VALUE))
+                if (!prop.getDefaultValue().equals(ConfigurableProperty.NO_DEFAULT_VALUE)) {
                     childPropertyMetadata.put("default", childAdapter.normalize(prop.getDefaultValue(), prop, ctx));
+                }
             } catch (ClassCastException e) {
                 childPropertyMetadata.put("default", 0);
             }
-            if (!prop.getTags().isEmpty())
+            
+            if (!prop.getTags().isEmpty()) {
                 childPropertyMetadata.put("tags", prop.getTags());
+            }
 
-            if (includeOrder)
-                childPropertyMetadata.put("uiOrder", prop.getOrder());
+            if (includeOrder) {
+                childPropertyMetadata.put(PropertySchema.UI_ORDER_KEY, prop.getOrder());
+            }
 
-            childPropertyMetadata.put("uiGroup", prop.getGroup());
+            childPropertyMetadata.put(PropertySchema.UI_GROUP_KEY, prop.getGroup());
+            
+            // Make optimistic lock hashes read-only so people don't mess with them.
+            if (prop.isOlockHash()) {
+                childPropertyMetadata.put(PropertySchema.READONLY_KEY, true);    
+            }
 
             // also merge in the metadata from this child itself
             Map<String, Object> childMetaData = childAdapter.getSchema(prop, ctx);
             if (childMetaData != null) childPropertyMetadata.putAll(childMetaData);
+        }
+        
+        if (StorageVersionedConfigurableClass.class.isAssignableFrom(clazz)) {
+            addStorageVersionSchemaProperty(classMetaData);
         }
 
         return classMetaDataWrapper;
@@ -320,5 +362,42 @@ public class ReflectiveAdapter<T> implements ConfigTypeAdapter<T, Map<String, Ob
     @Override
     public Map<String, Object> normalize(Object configNode, ConfigProperty property, ProcessingContext ctx) throws ConfigurationException {
         return (Map<String, Object>) configNode;
+    }
+    
+    private void setPropertyAttributeIfPresent(
+            final Map<String, Object> childPropertyMetadata,
+            final String propertyAttributeValue,
+            final String propertyAttributeKey) {
+        
+        if (StringUtils.isNotEmpty(propertyAttributeValue)) {
+            childPropertyMetadata.put(propertyAttributeKey, propertyAttributeValue);
+        }
+    }
+        
+    private void addStorageVersionSchemaProperty(Map<String, Object> classMetaData) {
+
+        Map<String, Object> versionProperty = new HashMap<>();
+        versionProperty.put(PropertySchema.TYPE_KEY, "integer");
+        versionProperty.put(PropertySchema.UI_GROUP_KEY, "Other");
+        versionProperty.put(PropertySchema.READONLY_KEY, true);
+        
+        classMetaData.put(Configuration.VERSION_KEY, versionProperty);
+    }
+    
+    public static final class PropertySchema {
+        
+        /**
+         * Private constructor to prevent instantiation.
+         */
+        private PropertySchema() { }
+        
+        public static final String CLASS_KEY = "class";
+        public static final String TYPE_KEY = "type";
+        public static final String PROPERTIES_KEY = "properties";
+        
+        public static final String TITLE_KEY = "title";
+        public static final String UI_ORDER_KEY = "uiOrder";
+        public static final String UI_GROUP_KEY = "uiGroup";
+        public static final String READONLY_KEY = "readonly";
     }
 }

--- a/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/adapters/ReflectiveAdapter.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/adapters/ReflectiveAdapter.java
@@ -182,10 +182,10 @@ public class ReflectiveAdapter<T> implements ConfigTypeAdapter<T, Map<String, Ob
 
         // Set the storage version if needed. 
         if (StorageVersionedConfigurableClass.class.isAssignableFrom(clazz)) {
-            Long version = (Long) configNode.get(Configuration.VERSION_KEY);
+            Number version = (Number) configNode.get(Configuration.VERSION_KEY);
             
             if (version != null) {
-                ((StorageVersionedConfigurableClass) confObj).setStorageVersion(version);
+                ((StorageVersionedConfigurableClass) confObj).setStorageVersion(version.longValue());
             }
         }
     }

--- a/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/olock/OLockMergeDualFilter.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/olock/OLockMergeDualFilter.java
@@ -90,12 +90,12 @@ class OLockMergeDualFilter extends ADualNodeFilter {
 
             // We are NOT merging now
 
-            if (newNode.get(HashBasedOptimisticLockingConfiguration.OLD_OLOCK_HASH_KEY).equals(newNode.get(Configuration.OLOCK_HASH_KEY))) {
+            if (newNode.get(OLockNodeMerger.OLD_OLOCK_HASH_KEY).equals(newNode.get(Configuration.OLOCK_HASH_KEY))) {
                 // If we met a olocked node where new node did not change, then we swap and turn on merging (from old to new)
                 isMerging.push(true);
                 swap(oldNode, newNode);
             } else {
-                if (newNode.get(HashBasedOptimisticLockingConfiguration.OLD_OLOCK_HASH_KEY).equals(oldNode.get(Configuration.OLOCK_HASH_KEY))) {
+                if (newNode.get(OLockNodeMerger.OLD_OLOCK_HASH_KEY).equals(oldNode.get(Configuration.OLOCK_HASH_KEY))) {
                     // If we met a olocked node where new node changed, then check the hash in old node and if it's not changed - keep going
                     isMerging.push(false);
                 } else {
@@ -111,11 +111,11 @@ class OLockMergeDualFilter extends ADualNodeFilter {
             Map<String, Object> actualOldNode = newNode;
 
 
-            if (actualNewNode.get(HashBasedOptimisticLockingConfiguration.OLD_OLOCK_HASH_KEY).equals(actualNewNode.get(Configuration.OLOCK_HASH_KEY))) {
+            if (actualNewNode.get(OLockNodeMerger.OLD_OLOCK_HASH_KEY).equals(actualNewNode.get(Configuration.OLOCK_HASH_KEY))) {
                 // If we met a olocked node where new node did not change, then keep on merging (from old to new)
                 isMerging.push(true);
             } else {
-                if (actualNewNode.get(HashBasedOptimisticLockingConfiguration.OLD_OLOCK_HASH_KEY).equals(actualOldNode.get(Configuration.OLOCK_HASH_KEY))) {
+                if (actualNewNode.get(OLockNodeMerger.OLD_OLOCK_HASH_KEY).equals(actualOldNode.get(Configuration.OLOCK_HASH_KEY))) {
                     // If we met a olocked node where new node changed, then check the hash in old node and if it's not changed, swap and switch to non-merging mode
                     isMerging.push(false);
                     swap(actualOldNode, actualNewNode);

--- a/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/olock/OLockNodeMerger.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/olock/OLockNodeMerger.java
@@ -1,0 +1,51 @@
+package org.dcm4che3.conf.core.olock;
+
+import java.util.Map;
+
+import org.dcm4che3.conf.core.api.Configuration;
+import org.dcm4che3.conf.core.util.ConfigNodeTraverser;
+
+/**
+ * This class is responsible for merging configuration nodes using
+ * hash-based optimistic locking approach. This is accomplished by
+ * traversing the nodes and using {@link AConfigNodeFilter}s to
+ * do the actual work. 
+ * 
+ * @author Maciek Siemczyk (maciek.siemczyk@agfa.com)
+ * 
+ * @see OLockHashCalcFilter
+ * @see OLockMergeDualFilter
+ */
+public class OLockNodeMerger {
+    
+    public static final String OLD_OLOCK_HASH_KEY = "#old_hash";
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private OLockNodeMerger() { }
+    
+    /**
+     * Merges two configuration nodes together using the optimistic locking hashes for comparison.
+     * 
+     * @param nodeBeingPersisted Config node with "new" data.
+     * @param nodeInStorage Config node as it is currently in the storage.
+     */
+    public static void merge(
+            Map<String, Object> nodeBeingPersisted,
+            Map<String, Object> nodeInStorage) {
+
+        // save old hashes in node being persisted
+        ConfigNodeTraverser.traverseMapNode(nodeBeingPersisted, new OLockCopyFilter(OLD_OLOCK_HASH_KEY));
+
+        // calculate current hashes in node being persisted and set them in OLOCK_HASH_KEY property,
+        // ensure to ignore OLD_OLOCK_HASH_KEY property in calculation
+        ConfigNodeTraverser.traverseMapNode(nodeBeingPersisted, new OLockHashCalcFilter(OLD_OLOCK_HASH_KEY));
+
+        ////// merge the object /////
+        ConfigNodeTraverser.dualTraverseMapNodes(nodeInStorage, nodeBeingPersisted, new OLockMergeDualFilter());
+
+        // filter all the set #hash properties out before persisting the node in the storage
+        ConfigNodeTraverser.traverseMapNode(nodeBeingPersisted, new CleanupFilter(OLD_OLOCK_HASH_KEY, Configuration.OLOCK_HASH_KEY));
+    }
+}

--- a/dcm4che-conf/dcm4che-conf-core/src/test/java/org/dcm4che3/conf/core/tests/adapters/ReflectiveAdapterTest.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/test/java/org/dcm4che3/conf/core/tests/adapters/ReflectiveAdapterTest.java
@@ -1,0 +1,390 @@
+package org.dcm4che3.conf.core.tests.adapters;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dcm4che3.conf.core.DefaultBeanVitalizer;
+import org.dcm4che3.conf.core.adapters.ReflectiveAdapter;
+import org.dcm4che3.conf.core.adapters.ReflectiveAdapter.PropertySchema;
+import org.dcm4che3.conf.core.api.ConfigurableClass;
+import org.dcm4che3.conf.core.api.ConfigurableProperty;
+import org.dcm4che3.conf.core.api.ConfigurableProperty.ConfigurablePropertyType;
+import org.dcm4che3.conf.core.api.Configuration;
+import org.dcm4che3.conf.core.api.StorageVersionedConfigurableClass;
+import org.dcm4che3.conf.core.api.internal.ConfigProperty;
+import org.dcm4che3.conf.core.api.internal.ConfigReflection;
+import org.dcm4che3.conf.core.context.LoadingContext;
+import org.dcm4che3.conf.core.context.SavingContext;
+import org.junit.Test;
+
+public class ReflectiveAdapterTest {
+    
+    private final Map<String, Object> configNode = new HashMap<>();
+    
+    private final DefaultBeanVitalizer beanVitalizer = new DefaultBeanVitalizer();
+    private final LoadingContext loadingContext = new LoadingContext(beanVitalizer);
+    private final SavingContext savingContext = new SavingContext(beanVitalizer);
+    
+    /**
+     * System Under Test (SUT).
+     */
+    private ReflectiveAdapter<Object> reflectiveAdapter = new ReflectiveAdapter<Object>();
+
+    @Test
+    public void fromConfigNode_ReturnsCorrectlyDeserializedObject_GivenValidConfigNodeAndPropertyForConfigurableClass() {
+        
+        final String expectedStringSetting = "C";
+        final Integer expectedIntegerSetting = 88;
+        final Boolean expectedBooleanSetting = true;
+        
+        configNode.put("stringSetting", expectedStringSetting);
+        configNode.put("integerSetting", expectedIntegerSetting);
+        configNode.put("booleanSetting", expectedBooleanSetting);
+        configNode.put("extraValue", "boom");
+        
+        ConfigProperty property = ConfigReflection.getDummyPropertyForClass(TestConfigurableClass.class);
+        
+        Object actualObject = reflectiveAdapter.fromConfigNode(configNode, property, loadingContext, null);
+        
+        assertThat("Returned object", actualObject, notNullValue());
+        assertThat("Object is wrong type", actualObject, instanceOf(TestConfigurableClass.class));
+        
+        TestConfigurableClass testConfigurableClass = (TestConfigurableClass) actualObject;
+        
+        assertThat("String setting", testConfigurableClass.getStringSetting(), equalTo(expectedStringSetting));
+        assertThat("Integer setting", testConfigurableClass.getIntegerSetting(), equalTo(expectedIntegerSetting));
+        assertThat("Boolean setting", testConfigurableClass.getBooleanSetting(), equalTo(expectedBooleanSetting));
+    }
+    
+    @Test
+    public void fromConfigNode_PopulatesStorageVersionAndReturnsDeserializedObject_GivenValidConfigNodeAndPropertyForClassExtendingStorageVersionedConfigurableClass() {
+        
+        final long expectedVersion = 7L;
+        final String expectedSomeConfig = "A";
+         
+        configNode.put(AStorageVersionedConfigurableClass.PROPERTY_NAME, expectedSomeConfig);
+        configNode.put(Configuration.VERSION_KEY, expectedVersion);
+        
+        ConfigProperty property = ConfigReflection.getDummyPropertyForClass(AStorageVersionedConfigurableClass.class);
+        
+        Object actualObject = reflectiveAdapter.fromConfigNode(configNode, property, loadingContext, null);
+        
+        assertThat("Returned object", actualObject, notNullValue());
+        assertThat("Object is wrong type", actualObject, instanceOf(AStorageVersionedConfigurableClass.class));
+        
+        AStorageVersionedConfigurableClass storageVersionedConfigurableClass
+                = (AStorageVersionedConfigurableClass) actualObject;
+        
+        assertThat("Wrong version", storageVersionedConfigurableClass.getStorageVersion(), equalTo(expectedVersion));
+        assertThat("Some config", storageVersionedConfigurableClass.getSomeConfig(), equalTo(expectedSomeConfig));
+    }
+    
+    @Test
+    public void fromConfigNode_DoesNotPopulateStorageVersionAndReturnsDeserializedObject_GivenConfigNodeWithoutVersionAndPropertyForClassExtendingStorageVersionedConfigurableClass() {
+        
+        final String expectedSomeConfig = "B";
+        
+        configNode.put(AStorageVersionedConfigurableClass.PROPERTY_NAME, expectedSomeConfig);
+        
+        ConfigProperty property = ConfigReflection.getDummyPropertyForClass(AStorageVersionedConfigurableClass.class);
+        
+        Object actualObject = reflectiveAdapter.fromConfigNode(configNode, property, loadingContext, null);
+        
+        assertThat("Returned object", actualObject, notNullValue());
+        assertThat("Object is wrong type", actualObject, instanceOf(AStorageVersionedConfigurableClass.class));
+        
+        AStorageVersionedConfigurableClass storageVersionedConfigurableClass
+                = (AStorageVersionedConfigurableClass) actualObject;
+        
+        assertThat("Wrong version", storageVersionedConfigurableClass.getStorageVersion(), equalTo(0L));
+        assertThat("Some config", storageVersionedConfigurableClass.getSomeConfig(), equalTo(expectedSomeConfig));
+    }
+
+    @Test
+    public void toConfigNode_ReturnsCorrectlySerializedMap_GivenValidObjectAndPropertyForConfigurableClass() {
+        
+        final String expectedStringSetting = "stringy";
+        final Integer expectedIntegerSetting = 999;
+        final Boolean expectedBooleanSetting = true;
+        
+        Map<String, Object> expectedConfigNode = new HashMap<>();
+        expectedConfigNode.put(TestConfigurableClass.STRING_PROPERTY_NAME, expectedStringSetting);
+        expectedConfigNode.put(TestConfigurableClass.INTEGER_PROPERTY_NAME, expectedIntegerSetting);
+        expectedConfigNode.put(TestConfigurableClass.BOOLESN_PROPERTY_NAME, expectedBooleanSetting);
+          
+        ConfigProperty property = ConfigReflection.getDummyPropertyForClass(TestConfigurableClass.class);
+        
+        TestConfigurableClass objectToSerialize = new TestConfigurableClass();
+        objectToSerialize.setStringSetting(expectedStringSetting);
+        objectToSerialize.setIntegerSetting(expectedIntegerSetting);
+        objectToSerialize.setBooleanSetting(expectedBooleanSetting);
+        
+        Map<String, Object> actualConfigNode = reflectiveAdapter
+                .toConfigNode(objectToSerialize, property, savingContext);
+        
+        assertThat("Returned map", actualConfigNode, equalTo(expectedConfigNode));
+    }
+    
+    @Test
+    public void toConfigNode_PopulateStorageVersionAndReturnsSerializedMap_GivenValidObjectAndPropertyForClassExtendingStorageVersionedConfigurableClass() {
+        
+        final String expectedSomeConfig = "versionedClass";
+        final long expectedStorageVersion = 451;
+        
+        Map<String, Object> expectedConfigNode = new HashMap<>();
+        expectedConfigNode.put(AStorageVersionedConfigurableClass.PROPERTY_NAME, expectedSomeConfig);
+        expectedConfigNode.put(Configuration.VERSION_KEY, expectedStorageVersion);
+        
+        ConfigProperty property = ConfigReflection.getDummyPropertyForClass(AStorageVersionedConfigurableClass.class);
+        
+        AStorageVersionedConfigurableClass objectToSerialize = new AStorageVersionedConfigurableClass();
+        objectToSerialize.setSomeConfig(expectedSomeConfig);
+        objectToSerialize.setStorageVersion(expectedStorageVersion);
+        
+        Map<String, Object> actualConfigNode = reflectiveAdapter
+            .toConfigNode(objectToSerialize, property, savingContext);
+        
+        assertThat("Returned map", actualConfigNode, equalTo(expectedConfigNode));
+    }
+    
+    @Test
+    public void getSchema_ReturnsCorrectlyPopulatedMap_GivenPropertyForConfigurableClass() {
+        
+        Map<String, Object> expectedProperties = new HashMap<>();
+        addExpectedConfigurableProperty(expectedProperties, TestConfigurableClass.STRING_PROPERTY_NAME, "string");
+        addExpectedConfigurableProperty(expectedProperties, TestConfigurableClass.INTEGER_PROPERTY_NAME, "integer");
+        addExpectedConfigurableProperty(expectedProperties, TestConfigurableClass.BOOLESN_PROPERTY_NAME, "boolean");
+        
+        Map<String, Object> expectedSchema = new HashMap<>();
+        expectedSchema.put(PropertySchema.TYPE_KEY, "object");
+        expectedSchema.put(PropertySchema.CLASS_KEY, "TestConfigurableClass");
+        expectedSchema.put(PropertySchema.PROPERTIES_KEY, expectedProperties);
+          
+        ConfigProperty property = ConfigReflection.getDummyPropertyForClass(TestConfigurableClass.class);
+        
+        Map<String, Object> actualSchema = reflectiveAdapter.getSchema(property, loadingContext);
+        
+        assertThat("Returned map", actualSchema, equalTo(expectedSchema));
+    }
+    
+    @Test
+    public void getSchema_ReturnsCorrectlyPopulatedMap_GivenPropertyForConfigurableClassWithOlockHash() {
+        
+        Map<String, Object> expectedProperties = new HashMap<>();
+        addExpectedConfigurableProperty(expectedProperties, Configuration.OLOCK_HASH_KEY, "string", true);
+        
+        Map<String, Object> expectedSchema = new HashMap<>();
+        expectedSchema.put(PropertySchema.TYPE_KEY, "object");
+        expectedSchema.put(PropertySchema.CLASS_KEY, "OlockHashConfigurableClass");
+        expectedSchema.put(PropertySchema.PROPERTIES_KEY, expectedProperties);
+          
+        ConfigProperty property = ConfigReflection.getDummyPropertyForClass(OlockHashConfigurableClass.class);
+        
+        Map<String, Object> actualSchema = reflectiveAdapter.getSchema(property, loadingContext);
+        
+        assertThat("Returned map", actualSchema, equalTo(expectedSchema));
+    }
+    
+    @Test
+    public void getSchema_ReturnsCorrectlyPopulatedMap_GivenPropertyForConfigurableClassWithOrderedProperties() {
+        
+        Map<String, Object> orderOnePropertyExtraValues = new HashMap<>();
+        orderOnePropertyExtraValues.put(PropertySchema.UI_ORDER_KEY, 1);
+        orderOnePropertyExtraValues.put(PropertySchema.UI_GROUP_KEY, "Fun group");
+        
+        Map<String, Object> expectedProperties = new HashMap<>();
+        addExpectedConfigurableProperty(expectedProperties, "orderOne", "string").putAll(orderOnePropertyExtraValues);
+        addExpectedConfigurableProperty(expectedProperties, "orderTwo", "string").put(PropertySchema.UI_ORDER_KEY, 2);
+        
+        Map<String, Object> expectedSchema = new HashMap<>();
+        expectedSchema.put(PropertySchema.TYPE_KEY, "object");
+        expectedSchema.put(PropertySchema.CLASS_KEY, "GuiOrderedConfigurableClass");
+        expectedSchema.put(PropertySchema.PROPERTIES_KEY, expectedProperties);
+          
+        ConfigProperty property = ConfigReflection.getDummyPropertyForClass(GuiOrderedConfigurableClass.class);
+        
+        Map<String, Object> actualSchema = reflectiveAdapter.getSchema(property, loadingContext);
+        
+        assertThat("Returned map", actualSchema, equalTo(expectedSchema));
+    }
+    
+    @Test
+    public void getSchema_ReturnsCorrectlyPopulatedMap_GivenPropertyForClassExtendingStorageVersionedConfigurableClass() {
+        
+        Map<String, Object> expectedProperties = new HashMap<>();
+        addExpectedConfigurableProperty(
+            expectedProperties, AStorageVersionedConfigurableClass.PROPERTY_NAME, "string");
+        addExpectedConfigurableProperty(expectedProperties, Configuration.VERSION_KEY, "integer", true);
+        
+        Map<String, Object> expectedSchema = new HashMap<>();
+        expectedSchema.put(PropertySchema.TYPE_KEY, "object");
+        expectedSchema.put(PropertySchema.CLASS_KEY, "AStorageVersionedConfigurableClass");
+        expectedSchema.put(PropertySchema.PROPERTIES_KEY, expectedProperties);
+          
+        ConfigProperty property = ConfigReflection.getDummyPropertyForClass(AStorageVersionedConfigurableClass.class);
+        
+        Map<String, Object> actualSchema = reflectiveAdapter.getSchema(property, loadingContext);
+        
+        assertThat("Returned map", actualSchema, equalTo(expectedSchema));
+    }
+    
+    private Map<String, Object> addExpectedConfigurableProperty(
+            final Map<String, Object> expectedProperties,
+            final String propertyName,
+            final String propertyType) {
+    
+        return addExpectedConfigurableProperty(expectedProperties, propertyName, propertyType, propertyName, null);
+    }
+    
+    private Map<String, Object> addExpectedConfigurableProperty(
+            final Map<String, Object> expectedProperties,
+            final String propertyName,
+            final String propertyType,
+            final boolean propertyReadOnly) {
+    
+        return addExpectedConfigurableProperty(expectedProperties, propertyName, propertyType, null, propertyReadOnly);
+    }
+    
+    private Map<String, Object> addExpectedConfigurableProperty(
+            final Map<String, Object> expectedProperties,
+            final String propertyName,
+            final String propertyType,
+            final String propertyTitle,
+            final Boolean propertyReadOnly) {
+
+        Map<String, Object> propertySchema = new HashMap<>();
+        
+        propertySchema.put(PropertySchema.TYPE_KEY, propertyType);
+        propertySchema.put(PropertySchema.UI_GROUP_KEY, "Other");
+        
+        if (propertyTitle != null) {
+            propertySchema.put(PropertySchema.TITLE_KEY, propertyTitle);
+        }
+        
+        if (propertyReadOnly != null) {
+            propertySchema.put(PropertySchema.READONLY_KEY, propertyReadOnly);    
+        }
+        
+        expectedProperties.put(propertyName, propertySchema);
+        
+        return propertySchema;
+    }
+
+    @ConfigurableClass
+    public static final class TestConfigurableClass {
+        
+        public static final String STRING_PROPERTY_NAME = "stringSetting";
+        public static final String INTEGER_PROPERTY_NAME = "integerSetting";
+        public static final String BOOLESN_PROPERTY_NAME = "booleanSetting";
+        
+        @ConfigurableProperty
+        private String stringSetting;
+
+        @ConfigurableProperty
+        private Integer integerSetting;
+        
+        @ConfigurableProperty
+        private Boolean booleanSetting;
+
+        public String getStringSetting() {
+
+            return stringSetting;
+        }
+
+        public void setStringSetting(String stringSetting) {
+
+            this.stringSetting = stringSetting;
+        }
+
+        public Integer getIntegerSetting() {
+
+            return integerSetting;
+        }
+
+        public void setIntegerSetting(Integer integerSetting) {
+
+            this.integerSetting = integerSetting;
+        }
+
+        public Boolean getBooleanSetting() {
+
+            return booleanSetting;
+        }
+
+        public void setBooleanSetting(Boolean booleanSetting) {
+
+            this.booleanSetting = booleanSetting;
+        }
+    }
+    
+    @ConfigurableClass
+    public static final class OlockHashConfigurableClass {
+        
+        @ConfigurableProperty(type = ConfigurablePropertyType.OptimisticLockingHash)
+        private String olockHash;
+
+        public String getOlockHash() {
+
+            return olockHash;
+        }
+
+        public void setOl(String olockHash) {
+
+            this.olockHash = olockHash;
+        }
+    }
+    
+    @ConfigurableClass
+    public static final class GuiOrderedConfigurableClass {
+        
+        @ConfigurableProperty(order = 2)
+        private String orderTwo;
+        
+        @ConfigurableProperty(order = 1, group = "Fun group")
+        private String orderOne;
+        
+        public String getOrderTwo() {
+
+            return orderTwo;
+        }
+
+        public void setOrderTwo(String orderTwo) {
+
+            this.orderTwo = orderTwo;
+        }
+
+        public String getOrderOne() {
+
+            return orderOne;
+        }
+
+        public void setOrderOne(String orderOne) {
+
+            this.orderOne = orderOne;
+        }
+    }
+    
+    @ConfigurableClass
+    public static final class AStorageVersionedConfigurableClass extends StorageVersionedConfigurableClass {
+        
+        public static final String PROPERTY_NAME = "someConfig";
+        
+        @ConfigurableProperty
+        private String someConfig;
+
+        public String getSomeConfig() {
+
+            return someConfig;
+        }
+
+        public void setSomeConfig(String someConfig) {
+
+            this.someConfig = someConfig;
+        }
+    }
+}

--- a/dcm4che-conf/dcm4che-conf-core/src/test/java/org/dcm4che3/conf/core/tests/adapters/ReflectiveAdapterTest.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/test/java/org/dcm4che3/conf/core/tests/adapters/ReflectiveAdapterTest.java
@@ -85,9 +85,32 @@ public class ReflectiveAdapterTest {
     }
     
     @Test
+    public void fromConfigNode_PopulatesStorageVersionAndReturnsDeserializedObject_GivenValidConfigNodeWithIntegerVersionAndPropertyForClassExtendingStorageVersionedConfigurableClass() {
+        
+        final long expectedVersion = 8L;
+        final String expectedSomeConfig = "B";
+         
+        configNode.put(AStorageVersionedConfigurableClass.PROPERTY_NAME, expectedSomeConfig);
+        configNode.put(Configuration.VERSION_KEY, (int) expectedVersion);
+        
+        ConfigProperty property = ConfigReflection.getDummyPropertyForClass(AStorageVersionedConfigurableClass.class);
+        
+        Object actualObject = reflectiveAdapter.fromConfigNode(configNode, property, loadingContext, null);
+        
+        assertThat("Returned object", actualObject, notNullValue());
+        assertThat("Object is wrong type", actualObject, instanceOf(AStorageVersionedConfigurableClass.class));
+        
+        AStorageVersionedConfigurableClass storageVersionedConfigurableClass
+                = (AStorageVersionedConfigurableClass) actualObject;
+        
+        assertThat("Wrong version", storageVersionedConfigurableClass.getStorageVersion(), equalTo(expectedVersion));
+        assertThat("Some config", storageVersionedConfigurableClass.getSomeConfig(), equalTo(expectedSomeConfig));
+    }
+    
+    @Test
     public void fromConfigNode_DoesNotPopulateStorageVersionAndReturnsDeserializedObject_GivenConfigNodeWithoutVersionAndPropertyForClassExtendingStorageVersionedConfigurableClass() {
         
-        final String expectedSomeConfig = "B";
+        final String expectedSomeConfig = "C";
         
         configNode.put(AStorageVersionedConfigurableClass.PROPERTY_NAME, expectedSomeConfig);
         

--- a/dcm4che-conf/dcm4che-conf-core/src/test/java/org/dcm4che3/conf/core/tests/olock/OLockNodeMergerTest.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/test/java/org/dcm4che3/conf/core/tests/olock/OLockNodeMergerTest.java
@@ -1,0 +1,87 @@
+package org.dcm4che3.conf.core.tests.olock;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dcm4che3.conf.core.api.Configuration;
+import org.dcm4che3.conf.core.api.OptimisticLockException;
+import org.dcm4che3.conf.core.olock.OLockNodeMerger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class OLockNodeMergerTest {
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    private final Map<String, Object> nodeBeingPersisted = new HashMap<>();
+    private final Map<String, Object> nodeInStorage = new HashMap<>();
+    
+    @Test
+    public void merge_DoesNotChangeNodeBeingPersisted_GivenNodeBeingPersistedMatchingNodeInStorage() {
+        
+        final Map<String, Object> expectedNodeBeingPersisted = new HashMap<>();
+        expectedNodeBeingPersisted.put("setting", "one and only");
+        
+        nodeBeingPersisted.putAll(expectedNodeBeingPersisted);
+        nodeBeingPersisted.put(Configuration.OLOCK_HASH_KEY, "wf8jEDyPvsPKvDHQVrjCCNblq9E=");
+        
+        nodeInStorage.putAll(expectedNodeBeingPersisted);
+        
+        OLockNodeMerger.merge(nodeBeingPersisted, nodeInStorage);
+        
+        assertThat("Node being persisted", nodeBeingPersisted, equalTo(expectedNodeBeingPersisted));
+    }
+    
+    @Test
+    public void merge_MergesNodeBeingPersistedIntoStorageNode_GivenNodeBeingPersistedWithOneNewSettingAndCorrectOldHash() {
+        
+        final Map<String, Object> expectedNodeBeingPersisted = new HashMap<>();
+        expectedNodeBeingPersisted.put("setting A", 1);
+        expectedNodeBeingPersisted.put("setting B", 2);
+        
+        nodeBeingPersisted.putAll(expectedNodeBeingPersisted);
+        nodeBeingPersisted.put(Configuration.OLOCK_HASH_KEY, "UfsuOBRrANEFW1XebTWk8Y8EFlQ=");
+        
+        nodeInStorage.put("setting A", 1);
+        nodeInStorage.put(Configuration.OLOCK_HASH_KEY, "UfsuOBRrANEFW1XebTWk8Y8EFlQ=");
+        
+        OLockNodeMerger.merge(nodeBeingPersisted, nodeInStorage);
+        
+        assertThat("Node being persisted", nodeBeingPersisted, equalTo(expectedNodeBeingPersisted));
+    }
+    
+    @Test
+    public void merge_ThrowsOptimisticLockException_GivenNodeBeingPersistedWithDifferentHashThanNodeInStorage() {
+        
+        expectedException.expect(OptimisticLockException.class);
+        expectedException.expectMessage("Concurrent modification at path ''");
+
+        nodeBeingPersisted.put("setting", "one and only");
+        nodeBeingPersisted.put(Configuration.OLOCK_HASH_KEY, "bad hash");
+        
+        nodeInStorage.putAll(nodeBeingPersisted);
+        nodeInStorage.put(Configuration.OLOCK_HASH_KEY, "I have changed since you asked");
+        
+        OLockNodeMerger.merge(nodeBeingPersisted, nodeInStorage);
+    }
+    
+    @Test
+    public void merge_ThrowsOptimisticLockException_GivenNodeBeingPersistedWithDifferentHashThanNewGeneratedOne() {
+        
+        expectedException.expect(OptimisticLockException.class);
+        expectedException.expectMessage("Concurrent modification at path ''");
+
+        nodeBeingPersisted.put("setting", "one and only");
+        nodeBeingPersisted.put(Configuration.OLOCK_HASH_KEY, "bad hash");
+        
+        nodeInStorage.putAll(nodeBeingPersisted);
+        nodeInStorage.put(Configuration.OLOCK_HASH_KEY, "wf8jEDyPvsPKvDHQVrjCCNblq9E=");
+        
+        OLockNodeMerger.merge(nodeBeingPersisted, nodeInStorage);
+    }
+}

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Device.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Device.java
@@ -38,29 +38,41 @@
 
 package org.dcm4che3.net;
 
-import org.dcm4che3.conf.core.api.ConfigurableClass;
-import org.dcm4che3.conf.core.api.ConfigurableProperty;
-import org.dcm4che3.conf.core.api.ConfigurableProperty.ConfigurablePropertyType;
-import org.dcm4che3.conf.core.api.ConfigurableProperty.Tag;
-import org.dcm4che3.conf.core.api.LDAP;
-import org.dcm4che3.data.Code;
-import org.dcm4che3.data.Issuer;
-import org.dcm4che3.util.StringUtils;
-
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.GeneralSecurityException;
 import java.security.KeyManagementException;
 import java.security.cert.X509Certificate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TimeZone;
+import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+
+import org.dcm4che3.conf.core.api.ConfigurableClass;
+import org.dcm4che3.conf.core.api.ConfigurableProperty;
+import org.dcm4che3.conf.core.api.ConfigurableProperty.ConfigurablePropertyType;
+import org.dcm4che3.conf.core.api.ConfigurableProperty.Tag;
+import org.dcm4che3.conf.core.api.LDAP;
+import org.dcm4che3.conf.core.api.StorageVersionedConfigurableClass;
+import org.dcm4che3.data.Code;
+import org.dcm4che3.data.Issuer;
+import org.dcm4che3.util.StringUtils;
 
 /**
  * DICOM Part 15, Annex H compliant description of a DICOM enabled system or
@@ -75,7 +87,7 @@ import java.util.concurrent.TimeUnit;
         objectClasses = {"dcmDevice", "dicomDevice"},
         distinguishingField = "dicomDeviceName")
 @ConfigurableClass(referable = true)
-public class Device implements Serializable {
+public class Device extends StorageVersionedConfigurableClass implements Serializable {
 
     private static final long serialVersionUID = -5816872456184522866L;
 
@@ -251,7 +263,7 @@ public class Device implements Serializable {
     private transient volatile SSLContext sslContext;
     private transient volatile KeyManager km;
     private transient volatile TrustManager tm;
-
+    
     public Device() {
     }
 


### PR DESCRIPTION
- Added StorageVersionedConfigurableClass base class that stores the storage version and extended Device, TCConfiguratio, and ConfigurationMetadata with it.
- Modified Reflective Adapter to propagate storage version back and forth between serialized and de-serialized objects. Also updated the schema code to include the storage version as new read-only property and changed Optimistic Lock Hash property to read-only.
- Extracted Optimistic Lock Hash comparison and merge code (not low level algorithm) to new class, called OLockMergeDualFilter, so it can be called outside of olock namespace.
- Added unit tests for new and changed code