### PR TITLE
IEI-169967 Make the StorageVersionedConfigurationClass serializable

### DIFF
--- a/dcm4che-conf/dcm4che-conf-core-api/src/main/java/org/dcm4che3/conf/core/api/StorageVersionedConfigurableClass.java
+++ b/dcm4che-conf/dcm4che-conf-core-api/src/main/java/org/dcm4che3/conf/core/api/StorageVersionedConfigurableClass.java
@@ -1,13 +1,19 @@
 package org.dcm4che3.conf.core.api;
 
+import java.io.Serializable;
+
 /**
  * This base class represent a "root" {@link ConfigurableClass} that gets backed
  * by the storage and thus has a (JPA) version associated with it.  
  * 
  * @author Maciek Siemczyk (maciek.siemczyk@agfa.com)
+ * 
+ * @see Serializable
  */
-public abstract class StorageVersionedConfigurableClass {
-
+public abstract class StorageVersionedConfigurableClass implements Serializable {
+    
+    private static final long serialVersionUID = -4117224687761026222L;
+    
     private long storageVersion;
 
     public long getStorageVersion() {


### PR DESCRIPTION
- Fixed loosing Device storage version while using remote EJB client with DicomConfiguration