### PR TITLE
IEI-170713 Allows ReferenceIndexingDecorator to work around nodes deleted during refreshes

### DIFF
--- a/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/index/ReferenceIndexingDecorator.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/main/java/org/dcm4che3/conf/core/index/ReferenceIndexingDecorator.java
@@ -146,7 +146,10 @@ public class ReferenceIndexingDecorator extends DelegatingConfiguration {
     public void refreshNode(Path path) throws ConfigurationException {
         removeOldReferablesFromIndex(super.getConfigurationNode(path, null));
         super.refreshNode(path);
-        addReferablesToIndex(path.getPathItems(), super.getConfigurationNode(path, null));
+        Object node = super.getConfigurationNode(path, null);
+        if (node != null) {
+            addReferablesToIndex(path.getPathItems(), node);
+        }
     }
 
     @Override

--- a/dcm4che-conf/dcm4che-conf-core/src/test/java/org/dcm4che3/conf/core/refindexing/RefIndexingTest.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/test/java/org/dcm4che3/conf/core/refindexing/RefIndexingTest.java
@@ -1,34 +1,33 @@
 package org.dcm4che3.conf.core.refindexing;
 
-import org.apache.commons.jxpath.JXPathContext;
 import org.dcm4che3.conf.core.DefaultBeanVitalizer;
 import org.dcm4che3.conf.core.api.Configuration;
 import org.dcm4che3.conf.core.api.Path;
 import org.dcm4che3.conf.core.storage.InMemoryConfiguration;
 import org.dcm4che3.conf.core.index.ReferenceIndexingDecorator;
-import org.dcm4che3.conf.core.util.PathPattern;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
 
 public class RefIndexingTest {
 
-    private HashMap<String, Path> uuidToSimplePathCache;
-    private Configuration configuration;
-    private DefaultBeanVitalizer vitalizer;
-
-    @Before
-    public void init() {
-        configuration = new InMemoryConfiguration();
-        uuidToSimplePathCache = new HashMap<String, Path>();
-        configuration = new ReferenceIndexingDecorator(configuration, uuidToSimplePathCache);
-        vitalizer = new DefaultBeanVitalizer();
-    }
+    private final HashMap<String, Path> uuidToSimplePathCache = new HashMap<>();
+    private final Configuration lowerLevelConfiguration = new InMemoryConfiguration();
+    private final DefaultBeanVitalizer vitalizer = new DefaultBeanVitalizer();
+    private final Configuration configuration = new ReferenceIndexingDecorator(
+            new SampleCachingConfigDecorator(lowerLevelConfiguration),
+            uuidToSimplePathCache
+    );
 
     @Test
     public void testSimpleChanges() {
@@ -51,20 +50,66 @@ public class RefIndexingTest {
         configuration.persistNode(new Path("confRoot"), vitalizer.createConfigNodeFromInstance(sampleBigConf), null);
 
         // check if uuids are indexed
-        Assert.assertEquals(5, uuidToSimplePathCache.size());
+        assertThat("UUIDs should have been indexed", uuidToSimplePathCache.keySet(),
+                hasItems("UUID1", "UUID2", "UUID3", "UUID4", "UUID5"));
 
-        PathPattern pathPattern = new PathPattern(Configuration.REFERENCE_BY_UUID_PATTERN);
-
-        Assert.assertEquals("Romeo", ((Map) configuration.getConfigurationNode(configuration.getPathByUUID("UUID1"), null)).get("myName"));
-        Assert.assertEquals("Juliet", ((Map) configuration.getConfigurationNode(configuration.getPathByUUID("UUID2"), null)).get("myName"));
+        matchUUIDSearch("/confRoot/child1", sampleBigConf.child1);
+        matchUUIDSearch("/confRoot/childList/#0", uuid2obj);
 
         configuration.removeNode(new Path("confRoot","childList"));
 
-        Assert.assertFalse(uuidToSimplePathCache.containsKey("UUID2"));
-        Assert.assertFalse(uuidToSimplePathCache.containsKey("UUID3"));
+        assertThat("UUIDs of removed nodes should not be in cache", uuidToSimplePathCache.keySet(),
+                not(anyOf(hasItem("UUID2"), hasItem("UUID3")))
+        );
 
     }
 
+    @Test
+    public void refreshNode_whenNodeIsNotAvailableInConfigurationAnymore_removesNodeFromIndex() {
+        SampleBigConf sampleBigConf = new SampleBigConf();
+
+        sampleBigConf.child1 = new SampleReferableConfClass("UUID1");
+        sampleBigConf.child1.setMyName("Romeo");
+
+        SampleReferableConfClass uuid2obj = new SampleReferableConfClass("UUID2");
+        uuid2obj.setMyName("Juliet");
+
+        sampleBigConf.childList.add(uuid2obj);
+        sampleBigConf.childList.add(new SampleReferableConfClass("UUID3"));
+
+        sampleBigConf.childMap.put("first", new SampleReferableConfClass("UUID4"));
+        sampleBigConf.childMap.put("second", new SampleReferableConfClass("UUID5"));
+
+        configuration.persistNode(new Path("confRoot"), vitalizer.createConfigNodeFromInstance(sampleBigConf), null);
+
+        // check if uuids are indexed
+        assertThat("UUIDs should have been indexed", uuidToSimplePathCache.keySet(),
+                hasItems("UUID1", "UUID2", "UUID3", "UUID4", "UUID5")
+        );
+
+        Path pathToRemove = new Path("confRoot", "childMap");
+        // cache the node first
+        configuration.getConfigurationNode(pathToRemove, null);
+        lowerLevelConfiguration.removeNode(pathToRemove);
+        configuration.refreshNode(pathToRemove);
+
+        assertThat("UUIDs of removed nodes should not be in cache", uuidToSimplePathCache.keySet(),
+                not(anyOf(hasItem("UUID4"), hasItem("UUID5")))
+        );
+        assertThat("UUIDs of untouched nodes should still be in cache", uuidToSimplePathCache.keySet(),
+                hasItems("UUID1", "UUID2", "UUID3")
+        );
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private void matchUUIDSearch(String expectedPath, SampleReferableConfClass referenceNode) {
+        Path mappedPath = configuration.getPathByUUID(referenceNode.uuid);
+        assertThat("UUID should map to the correct node PATH when searching by UUID",
+                mappedPath.toSimpleEscapedPath(), equalTo(expectedPath));
+        Map<String, Object> mappedNode = (Map<String,Object>) configuration.getConfigurationNode(mappedPath, null);
+        assertThat("Stored node should match the expected path", mappedNode.get("myName"), equalTo(referenceNode.myName));
+    }
 
 
 }

--- a/dcm4che-conf/dcm4che-conf-core/src/test/java/org/dcm4che3/conf/core/refindexing/SampleCachingConfigDecorator.java
+++ b/dcm4che-conf/dcm4che-conf-core/src/test/java/org/dcm4che3/conf/core/refindexing/SampleCachingConfigDecorator.java
@@ -1,0 +1,51 @@
+package org.dcm4che3.conf.core.refindexing;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dcm4che3.conf.core.DelegatingConfiguration;
+import org.dcm4che3.conf.core.api.Configuration;
+import org.dcm4che3.conf.core.api.ConfigurationException;
+import org.dcm4che3.conf.core.api.Path;
+
+/**
+ * A  utility decorator that will remove nodes upon refresh. Used to simulate caching behavior.
+ * @author Homero Cardoso de Almeida (homero.cardosodealmeida@agfa.com)
+ */
+public class SampleCachingConfigDecorator extends DelegatingConfiguration {
+
+    private Map<String, Object> cache;
+
+    public SampleCachingConfigDecorator(Configuration delegate) {
+        super(delegate);
+        cache = new HashMap<>();
+    }
+
+    @Override
+    public Object getConfigurationNode(Path path, Class configurableClass) throws ConfigurationException {
+        Object node = getNodeFromCache(path);
+        if (node == null) {
+            node = super.getConfigurationNode(path, configurableClass);
+            putNodeIntoCache(path, node);
+        }
+        return node;
+    }
+
+    @Override
+    public void refreshNode(Path path) throws ConfigurationException {
+        cache.remove(path.toSimpleEscapedPath());
+    }
+
+    private Object getNodeFromCache(Path nodePath) {
+        return cache.get(nodePath.toSimpleEscapedPath());
+    }
+
+    private void putNodeIntoCache(Path nodePath, Object node) {
+        String key = nodePath.toSimpleEscapedPath();
+        if (node != null) {
+            cache.put(key, node);
+        } else {
+            cache.remove(key);
+        }
+    }
+}


### PR DESCRIPTION
Calls to ReferenceIndexingDecorator.refreshNode can fail if the backend storage was updated behind the scenes (e.g., when a node updates the database directly without updating the cache first) because it tries to read the uuid of a null node. This change makes sure that this decorator verifies if the node exists before trying to reinsert it into the index.