### PR TITLE
#1077 Add a get method to get the previously reflected method retrieves

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/PathProvider.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/PathProvider.java
@@ -1,0 +1,5 @@
+package org.dcm4che3.io;
+
+public interface PathProvider {
+    String getPath();
+}

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/PathRandomAccessFile.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/PathRandomAccessFile.java
@@ -1,0 +1,18 @@
+package org.dcm4che3.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+public class PathRandomAccessFile extends RandomAccessFile implements PathProvider {
+    private final String path;
+
+    public PathRandomAccessFile(File f, String mode) throws IOException {
+        super(f,mode);
+        this.path = f.getAbsolutePath();
+    }
+
+    @Override public String getPath() {
+        return path;
+    }
+}

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/RAFInputStreamAdapter.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/RAFInputStreamAdapter.java
@@ -45,7 +45,7 @@ import java.io.RandomAccessFile;
 /**
  * @author Gunter Zeilinger <gunterze@gmail.com>
  */
-public class RAFInputStreamAdapter extends InputStream {
+public class RAFInputStreamAdapter extends InputStream implements RandomAccessFileProvider{
 
     private final RandomAccessFile raf;
     private long markedPos;
@@ -92,5 +92,9 @@ public class RAFInputStreamAdapter extends InputStream {
     @Override
     public boolean markSupported() {
         return true;
+    }
+
+    @Override public RandomAccessFile getRandomAccessFile() {
+        return raf;
     }
 }

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/RandomAccessFileProvider.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/RandomAccessFileProvider.java
@@ -1,0 +1,7 @@
+package org.dcm4che3.io;
+
+import java.io.RandomAccessFile;
+
+public interface RandomAccessFileProvider {
+    RandomAccessFile getRandomAccessFile();
+}

--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/FileStreamSegment.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/FileStreamSegment.java
@@ -49,6 +49,8 @@ import javax.imageio.stream.FileImageInputStream;
 import javax.imageio.stream.FileImageOutputStream;
 
 import org.dcm4che3.imageio.codec.ImageDescriptor;
+import org.dcm4che3.io.PathProvider;
+import org.dcm4che3.io.RandomAccessFileProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,6 +83,9 @@ class FileStreamSegment extends StreamSegment {
     }
 
     public static String getFilePath(RandomAccessFile file) {
+        if( file instanceof PathProvider) {
+            return ((PathProvider) file).getPath();
+        }
         try {
             Field fpath = RandomAccessFile.class.getDeclaredField("path");
             if (fpath != null) {
@@ -94,6 +99,9 @@ class FileStreamSegment extends StreamSegment {
     }
 
     public static RandomAccessFile getRandomAccessFile(FileImageInputStream fstream) {
+        if( fstream instanceof RandomAccessFileProvider ) {
+            return ((RandomAccessFileProvider) fstream).getRandomAccessFile();
+        }
         try {
             Field fRaf = FileImageInputStream.class.getDeclaredField("raf");
             if (fRaf != null) {

--- a/dcm4che-imageio-test/src/test/java/org/dcm4che3/imageio/dcm/TestDicomImageReader.java
+++ b/dcm4che-imageio-test/src/test/java/org/dcm4che3/imageio/dcm/TestDicomImageReader.java
@@ -64,6 +64,7 @@ import org.dcm4che3.data.Tag;
 import org.dcm4che3.data.VR;
 import org.dcm4che3.imageio.plugins.dcm.DicomImageReader;
 import org.dcm4che3.imageio.plugins.dcm.DicomMetaData;
+import org.dcm4che3.imageio.stream.RAFFileImageInputStream;
 import org.dcm4che3.io.DicomInputStream;
 import org.dcm4che3.io.DicomInputStream.IncludeBulkData;
 import org.dcm4che3.util.ByteUtils;
@@ -119,7 +120,7 @@ public class TestDicomImageReader {
 
     @Test
     public void testReadNoPixelData_ImageInputStream() throws FileNotFoundException, IOException {
-    	try(FileImageInputStream is = new FileImageInputStream(new File(TEST_DATA_DIR+REPORT_DFL))) {
+    	try(FileImageInputStream is = new RAFFileImageInputStream(new File(TEST_DATA_DIR+REPORT_DFL))) {
     		reader.setInput(is);
     		reader.getStreamMetadata();
     		Attributes withPostPixelData = reader.readPostPixeldata();
@@ -129,14 +130,14 @@ public class TestDicomImageReader {
 
     @Test 
     public void testReadCompressedPostPixelData_fromImageInputStream() throws IOException {
-        try(FileImageInputStream is = new FileImageInputStream(new File("target/test-data/" + US_MF_RLE))) {
+        try(FileImageInputStream is = new RAFFileImageInputStream(new File("target/test-data/" + US_MF_RLE))) {
             testReadPostPixelData(is);
         }
     }
     
     @Test 
     public void testReadUncompressedPostPixelData_fromImageInputStream() throws IOException {
-        try(FileImageInputStream is = new FileImageInputStream(new File("target/test-data/" + NM_MF))) {
+        try(FileImageInputStream is = new RAFFileImageInputStream(new File("target/test-data/" + NM_MF))) {
             testReadPostPixelData(is);
         }
     }
@@ -148,7 +149,7 @@ public class TestDicomImageReader {
     @Test
     public void testReadCompressedSingleFrame_fromImageInputStream() throws IOException {
         File file = new File("target/test-data/"+ NM_JPLY);
-        try(FileImageInputStream is = new FileImageInputStream(file)) {
+        try(FileImageInputStream is = new RAFFileImageInputStream(file)) {
             log.trace("Reading file {} iis {}", file, is);
             reader.setInput(is);
             Raster r = reader.readRaster(0, reader.getDefaultReadParam());
@@ -305,7 +306,7 @@ public class TestDicomImageReader {
 
     private Raster testReadRasterFromImageInputStream(String ifname, int imageIndex)
             throws IOException {
-        FileImageInputStream iis = new FileImageInputStream(new File("target/test-data/" + ifname));
+        FileImageInputStream iis = new RAFFileImageInputStream(new File("target/test-data/" + ifname));
         try {
             return testReadRasterFromInput(iis, imageIndex);
         } finally {

--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Compressor.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Compressor.java
@@ -72,6 +72,7 @@ import org.dcm4che3.image.BufferedImageUtils;
 import org.dcm4che3.image.Overlays;
 import org.dcm4che3.imageio.codec.jpeg.PatchJPEGLS;
 import org.dcm4che3.imageio.codec.jpeg.PatchJPEGLSImageOutputStream;
+import org.dcm4che3.imageio.stream.RAFFileImageInputStream;
 import org.dcm4che3.io.DicomEncodingOptions;
 import org.dcm4che3.io.DicomOutputStream;
 import org.dcm4che3.util.ByteUtils;
@@ -376,7 +377,7 @@ public class Compressor extends Decompressor implements Closeable {
 
     public BufferedImage readFrame(int frameIndex) throws IOException {
         if (iis == null)
-            iis = new FileImageInputStream(file);
+            iis = new RAFFileImageInputStream(file);
 
         if (decompressor != null)
             return decompressFrame(iis, frameIndex);

--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Decompressor.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Decompressor.java
@@ -72,6 +72,7 @@ import org.dcm4che3.data.Value;
 import org.dcm4che3.image.PhotometricInterpretation;
 import org.dcm4che3.imageio.codec.jpeg.PatchJPEGLS;
 import org.dcm4che3.imageio.codec.jpeg.PatchJPEGLSImageInputStream;
+import org.dcm4che3.imageio.stream.RAFFileImageInputStream;
 import org.dcm4che3.imageio.stream.SegmentedInputImageStream;
 import org.dcm4che3.io.DicomEncodingOptions;
 import org.dcm4che3.io.DicomOutputStream;
@@ -277,7 +278,7 @@ public class Decompressor {
 
     public FileImageInputStream createImageInputStream()
             throws IOException {
-        return new FileImageInputStream(file);
+        return new RAFFileImageInputStream(file);
     }
 
     public void writeFrameTo(ImageInputStream iis, int frameIndex,

--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/plugins/dcm/DicomImageReader.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/plugins/dcm/DicomImageReader.java
@@ -76,6 +76,7 @@ import org.dcm4che3.imageio.codec.jpeg.PatchJPEGLS;
 import org.dcm4che3.imageio.codec.jpeg.PatchJPEGLSImageInputStream;
 import org.dcm4che3.imageio.stream.EncapsulatedPixelDataImageInputStream;
 import org.dcm4che3.imageio.stream.ImageInputStreamAdapter;
+import org.dcm4che3.imageio.stream.RAFFileImageInputStream;
 import org.dcm4che3.imageio.stream.SegmentedInputImageStream;
 import org.dcm4che3.io.BulkDataDescriptor;
 import org.dcm4che3.io.DicomInputStream;
@@ -296,7 +297,7 @@ public class DicomImageReader extends ImageReader implements Closeable {
     private void openiis() throws IOException {
         if (iis == null) {
             if (pixelDataFile != null) {
-                iis = new FileImageInputStream(pixelDataFile);
+                iis = new RAFFileImageInputStream(pixelDataFile);
             } else if (pixeldataBytes != null) {
                 iis = new SegmentedInputImageStream(pixeldataBytes);
             }

--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/stream/RAFFileImageInputStream.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/stream/RAFFileImageInputStream.java
@@ -1,0 +1,32 @@
+package org.dcm4che3.imageio.stream;
+
+import org.dcm4che3.io.PathProvider;
+import org.dcm4che3.io.PathRandomAccessFile;
+import org.dcm4che3.io.RandomAccessFileProvider;
+
+import javax.imageio.stream.FileImageInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+public class RAFFileImageInputStream extends FileImageInputStream implements RandomAccessFileProvider, PathProvider {
+    private final PathRandomAccessFile raf;
+
+    public RAFFileImageInputStream(File f) throws FileNotFoundException, IOException {
+        this(new PathRandomAccessFile(f,"r"));
+    }
+
+    public RAFFileImageInputStream(PathRandomAccessFile raf) {
+        super(raf);
+        this.raf = raf;
+    }
+
+    @Override public RandomAccessFile getRandomAccessFile() {
+        return raf;
+    }
+
+    @Override public String getPath() {
+        return raf.getPath();
+    }
+}

--- a/dcm4che-tool/dcm4che-tool-dcm2jpg/src/main/java/org/dcm4che3/tool/dcm2jpg/Dcm2Jpg.java
+++ b/dcm4che-tool/dcm4che-tool-dcm2jpg/src/main/java/org/dcm4che3/tool/dcm2jpg/Dcm2Jpg.java
@@ -42,6 +42,7 @@ import org.apache.commons.cli.*;
 import org.dcm4che3.data.Attributes;
 import org.dcm4che3.image.ICCProfile;
 import org.dcm4che3.imageio.plugins.dcm.DicomImageReadParam;
+import org.dcm4che3.imageio.stream.RAFFileImageInputStream;
 import org.dcm4che3.io.DicomInputStream;
 import org.dcm4che3.tool.common.CLIUtils;
 import org.dcm4che3.util.SafeClose;
@@ -426,7 +427,7 @@ public class Dcm2Jpg {
     }
 
     public BufferedImage readImageFromImageInputStream(File file) throws IOException {
-        try (ImageInputStream iis = new FileImageInputStream(file)) {
+        try (ImageInputStream iis = new RAFFileImageInputStream(file)) {
             imageReader.setInput(iis);
             return imageReader.read(frame - 1, readParam());
         }


### PR DESCRIPTION
If you run dcm4che imageio opencv decompression under JDK >=11, you get a lot of error messages about reflection becoming illegal shortly and being disallowed.  The changes attached fix this as long as you implement the appropriate methods to get the path name and/or random access file object on the response.