### PR TITLE
Fix loading of BulkData when accessing binary values as String(s)

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -532,6 +532,10 @@ public class Attributes implements Serializable {
 
     private Object decodeStringValue(int index) {
         Object value = loadBulkData(values[index]);
+        return decodeStringValue(index, value);
+    }
+
+    private Object decodeStringValue(int index, Object value) {
         if (value instanceof byte[]) {
             value = vrs[index].toStrings((byte[]) value, bigEndian,
                     getSpecificCharacterSet(vrs[index]));
@@ -844,12 +848,13 @@ public class Attributes implements Serializable {
             vr = vrs[index];
         else
             updateVR(index, vr);
-        if (vr.isStringType()) {
-            value = decodeStringValue(index);
-            if (value == Value.NULL)
-                return defVal;
-        }
 
+        value = loadBulkData(value);
+        if (vr.isStringType()) {
+            value = decodeStringValue(index, value);
+        }
+        if (value == Value.NULL)
+            return defVal;
         try {
             return vr.toString(value, bigEndian, valueIndex, defVal);
         } catch (UnsupportedOperationException e) {
@@ -879,11 +884,13 @@ public class Attributes implements Serializable {
             vr = vrs[index];
         else
             updateVR(index, vr);
+
+        value = loadBulkData(value);
         if (vr.isStringType()) {
-            value = decodeStringValue(index);
-            if (value == Value.NULL)
-                return StringUtils.EMPTY_STRING;
+            value = decodeStringValue(index, value);
         }
+        if (value == Value.NULL)
+            return StringUtils.EMPTY_STRING;
         try {
             return toStrings(vr.toStrings(value, bigEndian,
                     getSpecificCharacterSet(vr)));

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
@@ -561,6 +561,7 @@ public class AttributesTest {
         int[] UINTS = { 0xffff,  Short.MAX_VALUE };
         float[] FLOATS = { -Float.MIN_VALUE,  0.1234f, Float.MAX_VALUE };
         double[] DOUBLES = { -Double.MIN_VALUE,  0.1234, Double.MAX_VALUE };
+        String[] DOUBLES_AS_STRINGS = { "-4.9E-324", "0.1234", "1.7976931348E308" };
         String URI = "http://host/path";
 
         Attributes a = new Attributes();
@@ -628,6 +629,7 @@ public class AttributesTest {
             assertEquals(URI, b.getString(Tag.SelectorURValue));
             assertArrayEquals(FLOATS, b.getFloats(Tag.SelectorDSValue), 0);
             assertArrayEquals(DOUBLES, b.getDoubles(Tag.SelectorODValue), 0);
+            assertArrayEquals(DOUBLES_AS_STRINGS, b.getStrings(Tag.SelectorFDValue));
             assertEquals(DOUBLES[0], b.getDouble(Tag.SelectorFDValue, 0), 0);
             assertArrayEquals(INTS, b.getInts(Tag.SelectorOLValue));
             assertEquals(FLOATS[0], b.getFloat(Tag.SelectorFLValue, 0), 0);


### PR DESCRIPTION
When accessing a binary value (e.g. VR=FD) as a String (or String[]) via getString() or getStrings() the loading of BulkData was not implemented.