### PR TITLE
Blocked dimse timeouts

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/PDUEncoder.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/PDUEncoder.java
@@ -43,6 +43,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.dcm4che3.data.Tag;
 import org.dcm4che3.data.UID;
@@ -68,6 +69,7 @@ class PDUEncoder extends PDVOutputStream {
 
     private Association as;
     private OutputStream out;
+    private AtomicBoolean aborted = new AtomicBoolean((false));
     private byte[] buf = new byte[Connection.DEF_MAX_PDU_LENGTH + 6];
     private int pos;
     private int pdvpcid;
@@ -83,30 +85,42 @@ class PDUEncoder extends PDVOutputStream {
     }
 
     public void write(AAssociateRQ rq) throws IOException {
-        encode(rq, PDUType.A_ASSOCIATE_RQ, ItemType.RQ_PRES_CONTEXT);
-        writePDU(pos - 6);
+        if (!aborted.get()) {
+            encode(rq, PDUType.A_ASSOCIATE_RQ, ItemType.RQ_PRES_CONTEXT);
+            writePDU(pos - 6);
+        }
     }
 
     public void write(AAssociateAC ac) throws IOException {
-        encode(ac, PDUType.A_ASSOCIATE_AC, ItemType.AC_PRES_CONTEXT);
-        writePDU(pos - 6);
+        if (!aborted.get()) {
+            encode(ac, PDUType.A_ASSOCIATE_AC, ItemType.AC_PRES_CONTEXT);
+            writePDU(pos - 6);
+        }
     }
 
     public void write(AAssociateRJ rj) throws IOException {
-        write(PDUType.A_ASSOCIATE_RJ, rj.getResult(), rj.getSource(),
-                rj.getReason());
+        if (!aborted.get()) {
+            write(PDUType.A_ASSOCIATE_RJ, rj.getResult(), rj.getSource(),
+                    rj.getReason());
+        }
     }
 
     public void writeAReleaseRQ() throws IOException {
-        write(PDUType.A_RELEASE_RQ, 0, 0, 0);
+        if (!aborted.get()) {
+            write(PDUType.A_RELEASE_RQ, 0, 0, 0);
+        }
     }
 
     public void writeAReleaseRP() throws IOException {
-        write(PDUType.A_RELEASE_RP, 0, 0, 0);
+        if (!aborted.get()) {
+            write(PDUType.A_RELEASE_RP, 0, 0, 0);
+        }
     }
 
     public void write(AAbort aa) throws IOException {
-        write(PDUType.A_ABORT, 0, aa.getSource(), aa.getReason());
+        if (aborted.compareAndSet(false, true)) {
+            write(PDUType.A_ABORT, 0, aa.getSource(), aa.getReason());
+        }
     }
 
     private synchronized void write(int pdutype, int result, int source,

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/PDUEncoder.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/PDUEncoder.java
@@ -67,9 +67,9 @@ import org.dcm4che3.net.pdu.UserIdentityRQ;
  */
 class PDUEncoder extends PDVOutputStream {
 
-    private Association as;
-    private OutputStream out;
-    private AtomicBoolean aborted = new AtomicBoolean((false));
+    private final Association as;
+    private final OutputStream out;
+    private final AtomicBoolean aborted = new AtomicBoolean(false);
     private byte[] buf = new byte[Connection.DEF_MAX_PDU_LENGTH + 6];
     private int pos;
     private int pdvpcid;
@@ -77,7 +77,7 @@ class PDUEncoder extends PDVOutputStream {
     private int pdvpos;
     private int maxpdulen;
     private Thread th;
-    private Object dimseLock = new Object();
+    private final Object dimseLock = new Object();
 
     public PDUEncoder(Association as, OutputStream out) {
         this.as = as;


### PR DESCRIPTION
The first request to abort an association will await the monitor to write the AAbort. The association once aborted will take as the last piece of new data to write the aabort. Any additional threads attempting to write to an aborted association will neither write nor block.