### PR TITLE
Allow to set total stream length for DicomInputStream (IEI-106938)

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -136,7 +136,7 @@ public class DicomInputStream extends FilterInputStream
     }
 
     public DicomInputStream(InputStream in, int preambleLength) throws IOException {
-        super(in.markSupported() ? in : new BufferedInputStream(in));
+        super(ensureMarkSupported(in));
         guessTransferSyntax(preambleLength);
     }
 
@@ -149,6 +149,54 @@ public class DicomInputStream extends FilterInputStream
             throw e;
         }
         uri = file.toURI().toString();
+    }
+
+    /**
+     * Create a new DicomInputStream with the given input stream and read limit.
+     * It ensures to never read more than the limit from the stream by wrapping it with a {@link LimitedInputStream}.
+     *
+     * The limit also helps to avoid OutOfMemory errors on parsing corrupt DICOM streams without the need to create
+     * temporary arrays when allocating large tag values. (See also {@link #setAllocateLimit}.)
+     *
+     * @param in input stream to read data from
+     * @param limit limit in bytes
+     * @return new DicomInputStream
+     * @throws IOException if there is a problem reading from the given stream
+     */
+    public static DicomInputStream createWithLimit(InputStream in, long limit) throws IOException {
+        return new DicomInputStream(new LimitedInputStream(ensureMarkSupported(in), limit, true));
+    }
+
+    /**
+     * Create a new DicomInputStream for the given file.
+     *
+     * A limit will be set by reading the length of the file (see also #createWithLimit).
+     *
+     * @param file file to read
+     * @return new DicomInputStream
+     * @throws IOException if there is a problem reading from the given file
+     */
+    public static DicomInputStream createWithLimitFromFileLength(File file) throws IOException {
+        long fileLength = file.length();
+        // Some operating systems may return 0 length for pathnames denoting system-dependent entities such as devices or pipes
+        if(fileLength > 0) {
+            InputStream in = new LimitedInputStream(new BufferedInputStream(new FileInputStream(file)), fileLength, true);
+            DicomInputStream dicomInputStream;
+            try {
+                dicomInputStream = new DicomInputStream(in);
+            } catch (IOException e) {
+                SafeClose.close(in);
+                throw e;
+            }
+            dicomInputStream.setURI(file.toURI().toString());
+            return dicomInputStream;
+        } else {
+            return new DicomInputStream(file);
+        }
+    }
+
+    private static InputStream ensureMarkSupported(InputStream in) {
+        return in.markSupported() ? in : new BufferedInputStream(in);
     }
 
     public final String getTransferSyntax() {
@@ -181,9 +229,13 @@ public class DicomInputStream extends FilterInputStream
      * OutOfMemoryErrors on parsing corrupted DICOM streams.
      * 
      * By default, the limit is set to 67108864 (64 MiB).
+     *
+     * Note: If a limit is given using {@link #createWithLimit} or
+     * {@link #createWithLimitFromFileLength} or by supplying a {@link LimitedInputStream},
+     * then this allocateLimit will be ignored (except for deflated data) and no
+     * temporary arrays need to be created.
      * 
      * @param allocateLimit limit of initial allocated memory or -1 for no limit
-     * 
      */
     public final void setAllocateLimit(int allocateLimit) {
         this.allocateLimit = allocateLimit;

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -262,6 +262,9 @@ public class DicomInputStream extends FilterInputStream
      * @param allocateLimit limit of initial allocated memory or -1 for no limit
      */
     public final void setAllocateLimit(int allocateLimit) {
+        if(allocateLimit < -1 || allocateLimit == 0)
+            throw new IllegalArgumentException("allocateLimit must be a positive number or -1");
+
         this.allocateLimit = allocateLimit;
     }
 
@@ -967,14 +970,14 @@ public class DicomInputStream extends FilterInputStream
                         "Length " + valLen + " for tag " + TagUtils.toString(tag) + " @ " + tagPos  +
                                 " exceeds remaining " + ((LimitedInputStream)in).getRemaining() +  " (pos: " + pos + ")");
             }
-            int allocLen = allocateLimit >= 0 && !limitedStream
+            int allocLen = allocateLimit != -1 && !limitedStream
                     ? Math.min(valLen, allocateLimit)
                     : valLen;
             byte[] value = new byte[allocLen];
             readFully(value, 0, allocLen);
             while (allocLen < valLen) {
                 int newLength = allocLen << 1;
-                if (newLength < 0)
+                if (newLength <= 0)
                     newLength = Integer.MAX_VALUE;
                 if (newLength > valLen)
                     newLength = valLen;

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -548,11 +548,30 @@ public class DicomInputStream extends FilterInputStream
         return readDataset(-1, o -> o.tag == Tag.PixelData);
     }
 
+    /**
+     * @deprecated Use one of the other {@link #readDataset()} methods instead. If you want to
+     * specify a length limit, you may supply a {@link LimitedInputStream} or use
+     * {@link #createWithLimit} or {@link #createWithLimitFromFileLength}.
+     */
     @Deprecated
     public Attributes readDataset(int len, int stopTag) throws IOException {
         return readDataset(len, tagEqualOrGreater(stopTag));
     }
 
+    public Attributes readDataset(int stopTag) throws IOException {
+        return readDataset(tagEqualOrGreater(stopTag));
+    }
+
+    public Attributes readDataset(Predicate<DicomInputStream> stopPredicate) throws IOException {
+        return readDataset(-1, stopPredicate);
+    }
+
+    /**
+     * @deprecated Use one of the other {@link #readDataset()} methods instead. If you want to
+     * specify a length limit, you may supply a {@link LimitedInputStream} or use
+     * {@link #createWithLimit} or {@link #createWithLimitFromFileLength}.
+     */
+    @Deprecated
     public Attributes readDataset(int len, Predicate<DicomInputStream> stopPredicate) throws IOException {
         handler.startDataset(this);
         readFileMetaInformation();

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -155,7 +155,24 @@ public class DicomInputStream extends FilterInputStream
     }
 
     /**
-     * Create a new DicomInputStream with the given input stream and read limit.
+     * Create a new DicomInputStream for the given input stream, Transfer Syntax UID and read limit.
+     * It ensures to never read more than the limit from the stream by wrapping it with a {@link LimitedInputStream}.
+     *
+     * The limit also helps to avoid OutOfMemory errors on parsing corrupt DICOM streams without the need to create
+     * temporary arrays when allocating large tag values. (See also {@link #setAllocateLimit}.)
+     *
+     * @param in input stream to read data from
+     * @param tsuid Transfer Syntax UID
+     * @param limit limit in bytes
+     * @return new DicomInputStream
+     * @throws IOException if there is a problem reading from the given stream
+     */
+    public static DicomInputStream createWithLimit(InputStream in, String tsuid, long limit) throws IOException {
+        return new DicomInputStream(limited(ensureMarkSupported(in), limit), tsuid);
+    }
+
+    /**
+     * Create a new DicomInputStream for the given input stream and read limit.
      * It ensures to never read more than the limit from the stream by wrapping it with a {@link LimitedInputStream}.
      *
      * The limit also helps to avoid OutOfMemory errors on parsing corrupt DICOM streams without the need to create
@@ -167,7 +184,7 @@ public class DicomInputStream extends FilterInputStream
      * @throws IOException if there is a problem reading from the given stream
      */
     public static DicomInputStream createWithLimit(InputStream in, long limit) throws IOException {
-        return new DicomInputStream(new LimitedInputStream(ensureMarkSupported(in), limit, true));
+        return new DicomInputStream(limited(ensureMarkSupported(in), limit));
     }
 
     /**
@@ -183,7 +200,7 @@ public class DicomInputStream extends FilterInputStream
         long fileLength = file.length();
         // Some operating systems may return 0 length for pathnames denoting system-dependent entities such as devices or pipes
         if(fileLength > 0) {
-            InputStream in = new LimitedInputStream(new BufferedInputStream(new FileInputStream(file)), fileLength, true);
+            InputStream in = limited(new BufferedInputStream(new FileInputStream(file)), fileLength);
             DicomInputStream dicomInputStream;
             try {
                 dicomInputStream = new DicomInputStream(in);
@@ -200,6 +217,10 @@ public class DicomInputStream extends FilterInputStream
 
     private static InputStream ensureMarkSupported(InputStream in) {
         return in.markSupported() ? in : new BufferedInputStream(in);
+    }
+
+    private static LimitedInputStream limited(InputStream in, long limit) {
+        return new LimitedInputStream(in, limit, true);
     }
 
     public final String getTransferSyntax() {

--- a/dcm4che-core/src/main/java/org/dcm4che3/media/DicomDirReader.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/media/DicomDirReader.java
@@ -74,7 +74,7 @@ public class DicomDirReader implements Closeable {
         try {
             this.in = new DicomInputStream(new RAFInputStreamAdapter(raf));
             this.fmi = in.readFileMetaInformation();
-            this.fsInfo = in.readDataset(-1, o -> o.tag() == Tag.DirectoryRecordSequence);
+            this.fsInfo = in.readDataset(o -> o.tag() == Tag.DirectoryRecordSequence);
             if (in.tag() != Tag.DirectoryRecordSequence)
                 throw new IOException("Missing Directory Record Sequence");
         } catch (IOException e) {

--- a/dcm4che-core/src/main/java/org/dcm4che3/util/LimitedInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/util/LimitedInputStream.java
@@ -112,4 +112,8 @@ public final class LimitedInputStream extends FilterInputStream {
     public void close() throws IOException {
         if (closeSource) in.close();
     }
+
+    public long getRemaining() {
+        return remaining;
+    }
 }

--- a/dcm4che-core/src/test/java/org/dcm4che3/io/DicomInputStreamTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/io/DicomInputStreamTest.java
@@ -169,7 +169,7 @@ public class DicomInputStreamTest {
         assertEquals("FOR PRESENTATION", attrs.getString(Tag.PresentationIntentType));
     }
 
-    @Test()
+    @Test
     public void testSRTag0040A170IsObservationClass() throws Exception {
         Attributes attrs = readFrom("Tag-0040-A170-VR-CS.dcm", IncludeBulkData.NO);
         Attributes findings = attrs.getNestedDataset(Tag.FindingsSequenceTrial);

--- a/dcm4che-tool/dcm4che-tool-agfa2dcm/src/main/java/org/dcm4che3/tool/agfa2dcm/Agfa2Dcm.java
+++ b/dcm4che-tool/dcm4che-tool-agfa2dcm/src/main/java/org/dcm4che3/tool/agfa2dcm/Agfa2Dcm.java
@@ -136,7 +136,7 @@ public class Agfa2Dcm {
                 if (part != null) part.length -= headerLength;
                 dis = new DicomInputStream(in, 128 - headerLength);
                 dis.setIncludeBulkData(DicomInputStream.IncludeBulkData.NO);
-                Attributes attrs = dis.readDataset(-1, Agfa2Dcm::isArchiveBlobTag);
+                Attributes attrs = dis.readDataset(Agfa2Dcm::isArchiveBlobTag);
                 list.add(part = new Part(format.format(attrs), dis.getPosition() + headerLength));
             }
         }

--- a/dcm4che-tool/dcm4che-tool-dcmdir/src/main/java/org/dcm4che3/tool/dcmdir/DcmDir.java
+++ b/dcm4che-tool/dcm4che-tool-dcmdir/src/main/java/org/dcm4che3/tool/dcmdir/DcmDir.java
@@ -610,7 +610,7 @@ public class DcmDir {
             din = new DicomInputStream(f);
             din.setIncludeBulkData(IncludeBulkData.NO);
             Attributes fmi = din.readFileMetaInformation();
-            Attributes dataset = din.readDataset(-1, o -> o.tag() > Tag.SeriesInstanceUID);
+            Attributes dataset = din.readDataset(o -> o.tag() > Tag.SeriesInstanceUID);
             iuid = (fmi != null)
                     ? fmi.getString(Tag.MediaStorageSOPInstanceUID, null)
                     : dataset.getString(Tag.SOPInstanceUID, null);


### PR DESCRIPTION
Can be used as an alternative to setAllocateLimit() if the stream length is already known upfront.