### PR TITLE
Missing NuclearMedicineImageStorage in etc/storescp/storage-sop-classes.properties

### DIFF
--- a/dcm4che-assembly/src/etc/storescp/sop-classes.properties
+++ b/dcm4che-assembly/src/etc/storescp/sop-classes.properties
@@ -53,6 +53,8 @@ EnhancedMRColorImageStorage:*
 
 LegacyConvertedEnhancedMRImageStorage:*
 
+NuclearMedicineImageStorage:*
+
 NuclearMedicineImageStorageRetired:*
 
 UltrasoundImageStorageRetired:*


### PR DESCRIPTION
Could be related to https://github.com/dcm4che/dcm4che/issues/843