### PR TITLE
Update to OpenCV 4.5.5 and add Mac M1 architecture #1084

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ It already provides modules to store/fetch configuration data to/from LDAP,
 compliant to the DICOM Application Configuration Management Profile,
 specified in [DICOM PS 3.15](http://dicom.nema.org/medical/dicom/current/output/html/part15.html#chapter_H), Annex H.
 
+dcm4che uses a native library for the compression and decompression of images. Here is the list of supported systems and architectures:
+
+| System  | Architecture | Package          | Requirement            |
+|:--------|:-------------|:-----------------|:-----------------------|
+| Linux   | x86 64-bit   | linux-x86-64     | GLIBC_2.14             |
+| Linux   | x86 32-bit   | linux-x86 `*`    | GLIBC_2.7              |
+| Linux   | ARM 64-bit   | linux-aarch64    | GLIBC_2.27             |
+| Linux   | ARM 32-bit   | linux-armv7a     | GLIBC_2.7              |
+| Linux   | s390x        | linux-s390x `*`  | GLIBC_2.7              |
+| Windows | x86 64-bit   | windows-x86-64   | Windows 7, 8, 10 or 11 |
+| Windows | x86 32-bit   | windows-x86      | Windows 7, 8, 10 or 11 |
+| Mac OS  | x86 64-bit   | macosx-x86-64    | Mac OS 10.9 or higher  |
+| Mac OS  | ARM 64-bit   | macosx-aarch64   | Mac OS 11 or higher    |
+`* The binary is not included in the dcm4che package but downloaded at the first use.`
+
 Build
 -----
 After installation of [Maven 3](http://maven.apache.org):

--- a/README.md
+++ b/README.md
@@ -14,19 +14,17 @@ specified in [DICOM PS 3.15](http://dicom.nema.org/medical/dicom/current/output/
 
 dcm4che uses a native library for the compression and decompression of images. Here is the list of supported systems and architectures:
 
-| System  | Architecture | Package          | Requirement            |
-|:--------|:-------------|:-----------------|:-----------------------|
-| Linux   | x86 64-bit   | linux-x86-64     | GLIBC_2.14             |
-| Linux   | x86 32-bit   | linux-x86 `*`    | GLIBC_2.7              |
-| Linux   | ARM 64-bit   | linux-aarch64    | GLIBC_2.27             |
-| Linux   | ARM 32-bit   | linux-armv7a     | GLIBC_2.7              |
-| Linux   | s390x        | linux-s390x `*`  | GLIBC_2.7              |
-| Windows | x86 64-bit   | windows-x86-64   | Windows 7, 8, 10 or 11 |
-| Windows | x86 32-bit   | windows-x86      | Windows 7, 8, 10 or 11 |
-| Mac OS  | x86 64-bit   | macosx-x86-64    | Mac OS 10.9 or higher  |
-| Mac OS  | ARM 64-bit   | macosx-aarch64   | Mac OS 11 or higher    |
-
-`* The binary is not included in the dcm4che package but downloaded at the first use.`
+| System  | Architecture | Package        | Requirement            |
+|:--------|:-------------|:---------------|:-----------------------|
+| Linux   | x86 64-bit   | linux-x86-64   | GLIBC_2.14             |
+| Linux   | x86 32-bit   | linux-x86      | GLIBC_2.7              |
+| Linux   | ARM 64-bit   | linux-aarch64  | GLIBC_2.27             |
+| Linux   | ARM 32-bit   | linux-armv7a   | GLIBC_2.7              |
+| Linux   | s390x        | linux-s390x    | GLIBC_2.7              |
+| Windows | x86 64-bit   | windows-x86-64 | Windows 7, 8, 10 or 11 |
+| Windows | x86 32-bit   | windows-x86    | Windows 7, 8, 10 or 11 |
+| Mac OS  | x86 64-bit   | macosx-x86-64  | Mac OS 10.9 or higher  |
+| Mac OS  | ARM 64-bit   | macosx-aarch64 | Mac OS 11 or higher    |
 
 Build
 -----

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ dcm4che uses a native library for the compression and decompression of images. H
 | Windows | x86 32-bit   | windows-x86      | Windows 7, 8, 10 or 11 |
 | Mac OS  | x86 64-bit   | macosx-x86-64    | Mac OS 10.9 or higher  |
 | Mac OS  | ARM 64-bit   | macosx-aarch64   | Mac OS 11 or higher    |
+
 `* The binary is not included in the dcm4che package but downloaded at the first use.`
 
 Build

--- a/dcm4che-assembly/pom.xml
+++ b/dcm4che-assembly/pom.xml
@@ -562,8 +562,15 @@
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
       <version>${weasis.opencv.native.version}</version>
-      <type>jnilib</type>
+      <type>dylib</type>
       <classifier>macosx-x86-64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.weasis.thirdparty.org.opencv</groupId>
+      <artifactId>libopencv_java</artifactId>
+      <version>${weasis.opencv.native.version}</version>
+      <type>dylib</type>
+      <classifier>macosx-aarch64</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>

--- a/dcm4che-assembly/src/bin/dcm2dcm
+++ b/dcm4che-assembly/src/bin/dcm2dcm
@@ -66,7 +66,7 @@ if [ "x$JAVA_LIBRARY_PATH" = "x" ]; then
         ;;
         mac*)
         LIB_NAME=libopencv_java
-        LIB_EXT=jnilib
+        LIB_EXT=dylib
         ;;
         *)
         LIB_NAME=libopencv_java

--- a/dcm4che-assembly/src/bin/dcm2jpg
+++ b/dcm4che-assembly/src/bin/dcm2jpg
@@ -66,7 +66,7 @@ if [ "x$JAVA_LIBRARY_PATH" = "x" ]; then
         ;;
         mac*)
         LIB_NAME=libopencv_java
-        LIB_EXT=jnilib
+        LIB_EXT=dylib
         ;;
         *)
         LIB_NAME=libopencv_java

--- a/dcm4che-assembly/src/bin/storescu
+++ b/dcm4che-assembly/src/bin/storescu
@@ -67,7 +67,7 @@ if [ "x$JAVA_LIBRARY_PATH" = "x" ]; then
         ;;
         mac*)
         LIB_NAME=libopencv_java
-        LIB_EXT=jnilib
+        LIB_EXT=dylib
         ;;
         *)
         LIB_NAME=libopencv_java

--- a/dcm4che-assembly/src/main/assembly/component.xml
+++ b/dcm4che-assembly/src/main/assembly/component.xml
@@ -251,7 +251,15 @@
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
       <outputDirectory>lib/macosx-x86-64</outputDirectory>
       <includes>
-        <include>*:*:jnilib:macosx-x86-64:*</include>
+        <include>*:*:dylib:macosx-x86-64:*</include>
+      </includes>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
+      <outputDirectory>lib/macosx-aarch64</outputDirectory>
+      <includes>
+        <include>*:*:dylib:macosx-aarch64:*</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>

--- a/dcm4che-imageio-test/pom.xml
+++ b/dcm4che-imageio-test/pom.xml
@@ -71,7 +71,22 @@
         <os-name>macosx</os-name>
         <cpu-name>x86-64</cpu-name>
         <lib-file-name>libopencv_java</lib-file-name>
-        <lib-file-ext>jnilib</lib-file-ext>
+        <lib-file-ext>dylib</lib-file-ext>
+      </properties>
+    </profile>
+    <profile>
+      <id>mac-m1</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <properties>
+        <skipTests>false</skipTests>
+        <os-name>macosx</os-name>
+        <cpu-name>aarch64</cpu-name>
+        <lib-file-name>libopencv_java</lib-file-name>
+        <lib-file-ext>dylib</lib-file-ext>
       </properties>
     </profile>
     <profile>

--- a/dcm4che-jboss-modules/pom.xml
+++ b/dcm4che-jboss-modules/pom.xml
@@ -186,8 +186,15 @@
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
       <version>${weasis.opencv.native.version}</version>
-      <type>jnilib</type>
+      <type>dylib</type>
       <classifier>macosx-x86-64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.weasis.thirdparty.org.opencv</groupId>
+      <artifactId>libopencv_java</artifactId>
+      <version>${weasis.opencv.native.version}</version>
+      <type>dylib</type>
+      <classifier>macosx-aarch64</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>

--- a/dcm4che-jboss-modules/src/main/assembly/modules.xml
+++ b/dcm4che-jboss-modules/src/main/assembly/modules.xml
@@ -189,7 +189,15 @@
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
       <outputDirectory>/modules/org/dcm4che/imageio/main/lib/macosx-x86_64</outputDirectory>
       <includes>
-        <include>*:*:jnilib:macosx-x86-64:*</include>
+        <include>*:*:dylib:macosx-x86-64:*</include>
+      </includes>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
+      <outputDirectory>/modules/org/dcm4che/imageio/main/lib/macosx-aarch64</outputDirectory>
+      <includes>
+        <include>*:*:dylib:macosx-aarch64:*</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <slf4j.version>1.7.32</slf4j.version>
     <logback.version>1.2.9</logback.version>
-    <weasis.core.img.version>4.5.3</weasis.core.img.version>
-    <weasis.opencv.native.version>4.5.3-dcm</weasis.opencv.native.version>
+    <weasis.core.img.version>4.5.5</weasis.core.img.version>
+    <weasis.opencv.native.version>4.5.5-dcm</weasis.opencv.native.version>
     <keycloak.version>15.1.0</keycloak.version>
     <jbossws-cxf-client.version>5.4.4.Final</jbossws-cxf-client.version>
     <apache-cxf.version>3.4.4</apache-cxf.version>


### PR DESCRIPTION
* Update to OpenCV 4.5.5
* Update to charls 2.2.1
* Update openjepg (January 2022)
* Mac binaries are now signed
* Add Mac M1 architecture
* Replace file extension .jnilib with .dylib (see https://bugs.openjdk.java.net/browse/JDK-8127215 )
* Add a summary of the requirements:
 
dcm4che uses a native library for the compression and decompression of images. Here is the list of supported systems and architectures:

| System  | Architecture | Package          | Requirement            |
|:--------|:-------------|:-----------------|:-----------------------|
| Linux   | x86 64-bit   | linux-x86-64     | GLIBC_2.14             |
| Linux   | x86 32-bit   | linux-x86 `*`    | GLIBC_2.7              |
| Linux   | ARM 64-bit   | linux-aarch64    | GLIBC_2.27             |
| Linux   | ARM 32-bit   | linux-armv7a     | GLIBC_2.7              |
| Linux   | s390x        | linux-s390x `*`  | GLIBC_2.7              |
| Windows | x86 64-bit   | windows-x86-64   | Windows 7, 8, 10 or 11 |
| Windows | x86 32-bit   | windows-x86      | Windows 7, 8, 10 or 11 |
| Mac OS  | x86 64-bit   | macosx-x86-64    | Mac OS 10.9 or higher  |
| Mac OS  | ARM 64-bit   | macosx-aarch64   | Mac OS 11 or higher    |

`* The binary is not included in the dcm4che package but downloaded at the first use.`