### PR TITLE
IEI-143204 remove bundle import rule for javax.xml

### DIFF
--- a/dcm4che-audit/pom.xml
+++ b/dcm4che-audit/pom.xml
@@ -96,6 +96,13 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>
+              !javax.xml.*;
+            </Import-Package>
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
 - for java 8 this is included in the JRE