### PR TITLE
Revert the revert and add extra if statements to the readAttributes and readItemHeader methods

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/media/DicomDirReader.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/media/DicomDirReader.java
@@ -74,7 +74,7 @@ public class DicomDirReader implements Closeable {
         try {
             this.in = new DicomInputStream(new RAFInputStreamAdapter(raf));
             this.fmi = in.readFileMetaInformation();
-            this.fsInfo = in.readDataset(-1, Tag.DirectoryRecordSequence);
+            this.fsInfo = in.readDataset(o -> o.tag() == Tag.DirectoryRecordSequence);
             if (in.tag() != Tag.DirectoryRecordSequence)
                 throw new IOException("Missing Directory Record Sequence");
         } catch (IOException e) {

--- a/dcm4che-core/src/main/java/org/dcm4che3/util/LimitedInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/util/LimitedInputStream.java
@@ -1,0 +1,119 @@
+/*
+ * *** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is part of dcm4che, an implementation of DICOM(TM) in
+ * Java(TM), hosted at https://github.com/dcm4che.
+ *
+ * The Initial Developer of the Original Code is
+ * J4Care.
+ * Portions created by the Initial Developer are Copyright (C) 2013-2021
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ * See @authors listed below
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * *** END LICENSE BLOCK *****
+ */
+
+package org.dcm4che3.util;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * @author Gunter Zeilinger (gunterze@protonmail.com)
+ * @since Oct 2021
+ */
+public final class LimitedInputStream extends FilterInputStream {
+
+    private long remaining;
+    private long mark = -1;
+    private final boolean closeSource;
+
+    public LimitedInputStream(InputStream in, long limit, boolean closeSource) {
+        super(Objects.requireNonNull(in));
+        if (limit <= 0) throw new IllegalArgumentException("limit must be > 0");
+        this.remaining = limit;
+        this.closeSource = closeSource;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int result;
+        if (remaining == 0 || (result = in.read()) < 0) {
+            return -1;
+        }
+
+        --remaining;
+        return result;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int result;
+        if (remaining == 0 || (result = in.read(b, off, (int) Math.min(len, remaining))) < 0) {
+            return -1;
+        }
+
+        remaining -= result;
+        return result;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        long result = in.skip(Math.min(n, remaining));
+        remaining -= result;
+        return result;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return (int) Math.min(in.available(), remaining);
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        in.mark(readlimit);
+        mark = remaining;
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        in.reset();
+        remaining = mark;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closeSource) in.close();
+    }
+
+    public long getRemaining() {
+        return remaining;
+    }
+}

--- a/dcm4che-core/src/test/java/org/dcm4che3/io/DicomInputStreamTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/io/DicomInputStreamTest.java
@@ -1,7 +1,10 @@
 package org.dcm4che3.io;
 
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.URL;
 
 import org.dcm4che3.data.Attributes;
@@ -10,11 +13,13 @@ import org.dcm4che3.data.Sequence;
 import org.dcm4che3.data.Tag;
 import org.dcm4che3.data.VR;
 import org.dcm4che3.io.DicomInputStream.IncludeBulkData;
+import org.dcm4che3.util.LimitedInputStream;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Gunter Zeilinger <gunterze@gmail.com>
@@ -23,14 +28,32 @@ public class DicomInputStreamTest {
 
     @Test
     public void testPart10ExplicitVR() throws Exception {
-        Attributes attrs = readFromResource("DICOMDIR", IncludeBulkData.YES);
+        testPart10ExplicitVR(false);
+    }
+
+    @Test
+    public void testPart10ExplicitVRWithLimit() throws Exception {
+        testPart10ExplicitVR(true);
+    }
+
+    private void testPart10ExplicitVR(boolean readWithLimit) throws Exception {
+        Attributes attrs = readFrom("DICOMDIR", IncludeBulkData.YES, readWithLimit);
         Sequence seq = attrs.getSequence(null, Tag.DirectoryRecordSequence);
         assertEquals(44, seq.size());
-   }
+    }
 
     @Test
     public void testPart10Deflated() throws Exception {
-        Attributes attrs = readFromResource("report_dfl", IncludeBulkData.YES);
+        testPart10Deflated(false);
+    }
+
+    @Test
+    public void testPart10DeflatedWithLimit() throws Exception {
+        testPart10Deflated(true);
+    }
+
+    private void testPart10Deflated(boolean readWithLimit) throws Exception {
+        Attributes attrs = readFrom("report_dfl", IncludeBulkData.YES, readWithLimit);
         Sequence seq = attrs.getSequence(null, Tag.ContentSequence);
         assertEquals(5, seq.size());
     }
@@ -63,20 +86,46 @@ public class DicomInputStreamTest {
     }
 
     private static Attributes readFromResource(String name, IncludeBulkData includeBulkData) throws Exception {
+        return readFrom(name, includeBulkData, false);
+    }
+
+    private static Attributes readFrom(String name, IncludeBulkData includeBulkData, boolean readWithLimit) throws Exception {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         URL resource = cl.getResource(name);
         if (resource == null) {
             throw new FileNotFoundException("Could not resolve resource with name: '" + name + "'");
         }
         File file = new File(resource.toURI());
-        try (DicomInputStream in = new DicomInputStream(file)) {
+        try (DicomInputStream in = readWithLimit
+                ? DicomInputStream.createWithLimitFromFileLength(file)
+                : new DicomInputStream(file)) {
             in.setIncludeBulkData(includeBulkData);
             in.setAddBulkDataReferences(includeBulkData == IncludeBulkData.URI);
-            return in.readDataset(-1, -1);
+            return in.readDataset();
         }
     }
 
-    @Test()
+    @Test(expected = EOFException.class)
+    public void testNoOutOfMemoryErrorOnInvalidLength() throws IOException {
+        byte[] b = { 8, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 'e', 'v', 'i', 'l', 'l', 'e', 'n', 'g', 'h' };
+        try ( DicomInputStream in = new DicomInputStream(new ByteArrayInputStream(b))) {
+            in.readDataset();
+        }
+    }
+
+    @Test
+    public void testNoOutOfMemoryErrorOnInvalidLengthIfStreamLengthKnown() throws IOException {
+        byte[] b = { 8, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 'e', 'v', 'i', 'l', 'l', 'e', 'n', 'g', 'h' };
+        try ( DicomInputStream in = new DicomInputStream(new LimitedInputStream(new ByteArrayInputStream(b), b.length, true))) {
+            in.readDataset();
+            fail("Expected exception to be thrown because length of tag exceeds size of dicom stream");
+        } catch (Exception exception) {
+            assertEquals("Length 1735288172 for tag (7665,6C69) @ 12 exceeds remaining 1 (pos: 20)",
+                    exception.getMessage());
+        }
+    }
+
+    @Test
     public void testSRTag0040A170IsObservationClass() throws Exception {
         Attributes attrs =readFromResource("Tag-0040-A170-VR-CS.dcm", IncludeBulkData.NO);
         Attributes findings = attrs.getNestedDataset(Tag.FindingsSequenceTrial);


### PR DESCRIPTION
I've reverted the revert to again apply the changes from pull request [#1139](https://github.com/dcm4che/dcm4che/pull/1139). I've also added more details to the warning message when an unexpected attribute or unexpected non-zero length item is encountered. It now includes the method name in the warning message so its easier to figure out which method is generating the message.
```java
    private static final String UNEXPECTED_NON_ZERO_ITEM_LENGTH =
       "Unexpected item value of {} #{} @ {} during {}";
    private static final String UNEXPECTED_ATTRIBUTE =
        "Unexpected attribute {} #{} @ {} during {}";
```

Note the `during {}` added to the end of the string. This combined with changes to the `skipAttribute(String message, String methodName)` where it will now take the `methodName` as a paramter and also log on debug level the number of actual bytes skipped
```java
private void skipAttribute(String message, String methodName) throws IOException {
    String tagAsString = TagUtils.toString(this.tag);
    LOG.warn(message, tagAsString, length, tagPos, methodName);
    long skipLength = skip(length);
    LOG.debug("Skipped {} actual bytes for {}", skipLength, tagAsString);
}
```

I've dropped the changes that cause the cause it to skip logging a warning message when it encounters a SequenceDelimitationItem or ItemDelimitationItem that are zero length.