### PR TITLE
IEI-187643 The transient field aliasApplicationEntitiesMap in Device …

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/ApplicationEntity.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/ApplicationEntity.java
@@ -38,6 +38,23 @@
 
 package org.dcm4che3.net;
 
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.Socket;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.UUID;
+
 import org.dcm4che3.conf.core.api.ConfigurableClass;
 import org.dcm4che3.conf.core.api.ConfigurableProperty;
 import org.dcm4che3.conf.core.api.ConfigurableProperty.ConfigurablePropertyType;
@@ -45,16 +62,16 @@ import org.dcm4che3.conf.core.api.ConfigurableProperty.Tag;
 import org.dcm4che3.conf.core.api.LDAP;
 import org.dcm4che3.conf.core.api.Parent;
 import org.dcm4che3.data.Attributes;
-import org.dcm4che3.net.pdu.*;
+import org.dcm4che3.net.pdu.AAbort;
+import org.dcm4che3.net.pdu.AAssociateAC;
+import org.dcm4che3.net.pdu.AAssociateRQ;
+import org.dcm4che3.net.pdu.CommonExtendedNegotiation;
+import org.dcm4che3.net.pdu.ExtendedNegotiation;
+import org.dcm4che3.net.pdu.PresentationContext;
+import org.dcm4che3.net.pdu.RoleSelection;
 import org.dcm4che3.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.Serializable;
-import java.net.Socket;
-import java.security.GeneralSecurityException;
-import java.util.*;
 
 /**
  * DICOM Part 15, Annex H compliant description of a DICOM network service.
@@ -147,7 +164,7 @@ public class ApplicationEntity implements Serializable {
 
     @ConfigurableProperty(name = "dcmAETitleAliases",
             label = "Aliases (alternative AE titles)")
-    private List<String> AETitleAliases = new ArrayList<String>();
+    private final List<String> aeTitleAliases = new ArrayList<>();
 
     @ConfigurableProperty(name = "dcmImplicitRelationalQueryEnabled",
             label = "Enable Implicit Relational C-FIND",
@@ -168,11 +185,13 @@ public class ApplicationEntity implements Serializable {
     }
 
     public List<String> getAETitleAliases() {
-        return new ArrayList<String>(AETitleAliases);
+        return new ArrayList<>(aeTitleAliases);
     }
 
-    public void setAETitleAliases(List<String> AETitleAliases) {
-        this.AETitleAliases = AETitleAliases;
+    public void setAETitleAliases(String... aets) {
+        
+        aeTitleAliases.clear();
+        aeTitleAliases.addAll(Arrays.asList(aets));
     }
 
     public Map<Class<? extends AEExtension>, AEExtension> getExtensions() {
@@ -739,7 +758,7 @@ public class ApplicationEntity implements Serializable {
     public StringBuilder promptTo(StringBuilder sb, String indent) {
         String indent2 = indent + "  ";
         StringUtils.appendLine(sb, indent, "ApplicationEntity[title: ", AETitle);
-        StringUtils.appendLine(sb, indent2, "alias titles: ", AETitleAliases);
+        StringUtils.appendLine(sb, indent2, "alias titles: ", aeTitleAliases);
         StringUtils.appendLine(sb, indent2, "desc: ", description);
         StringUtils.appendLine(sb, indent2, "acceptor: ", associationAcceptor);
         StringUtils.appendLine(sb, indent2, "initiator: ", associationInitiator);
@@ -788,7 +807,8 @@ public class ApplicationEntity implements Serializable {
     protected void setApplicationEntityAttributes(ApplicationEntity from) {
         setOlockHash(from.olockHash);
         setDescription(from.description);
-        setAETitleAliases(from.getAETitleAliases());
+        aeTitleAliases.clear();
+        aeTitleAliases.addAll(from.getAETitleAliases());
         setVendorData(from.vendorData);
         setApplicationClusters(from.applicationClusters);
         setPreferredCalledAETitles(from.preferredCalledAETitles);

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Device.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Device.java
@@ -91,6 +91,8 @@ import org.dcm4che3.util.StringUtils;
 public class Device extends StorageVersionedConfigurableClass implements Serializable {
 
     private static final long serialVersionUID = -5816872456184522866L;
+    
+    public static final String DEFAULT_AE_TITLE = "*";
 
     @ConfigurableProperty(name = "dicomDeviceName", label = "Device name", tags = Tag.PRIMARY)
     private String deviceName;
@@ -1041,16 +1043,17 @@ public class Device extends StorageVersionedConfigurableClass implements Seriali
     }
 
     public ApplicationEntity getApplicationEntity(String aet) {
-        if(aet == null){
+        if (aet == null) {
             throw new IllegalArgumentException("Application Entity Title (aet) is null");
         }
 
         ApplicationEntity ae = findApplicationEntityByAeTitleOrAlias(aet);
 
-        // special fallback: if one ApplicationEntity defines "*" as an alias AET (or even the main AET),
-        // it will get used as a fallback for unknown AETs
-        if (ae == null)
-            ae = findApplicationEntityByAeTitleOrAlias("*");
+        // Special fallback: if one ApplicationEntity defines "*" as an alias AET (or even the main AET),
+        // it will get used as a fallback for unknown AETs.
+        if (ae == null) {
+            ae = findApplicationEntityByAeTitleOrAlias(DEFAULT_AE_TITLE);
+        }
 
         return ae;
     }
@@ -1060,8 +1063,8 @@ public class Device extends StorageVersionedConfigurableClass implements Seriali
      */
     public Collection<String> getApplicationAETitles() {
         Collection<String> aeTitles = new HashSet<>();
+        
         aeTitles.addAll(applicationEntitiesMap.keySet());
-        //add alias AE titles
         applicationEntitiesMap.values().forEach(ae -> aeTitles.addAll(ae.getAETitleAliases()));
 
         return aeTitles;
@@ -1144,15 +1147,16 @@ public class Device extends StorageVersionedConfigurableClass implements Seriali
         return tm;
     }
 
-    private final ApplicationEntity findApplicationEntityByAeTitleOrAlias(String aet) {
+    private ApplicationEntity findApplicationEntityByAeTitleOrAlias(String aet) {
         ApplicationEntity applicationEntity = applicationEntitiesMap.get(aet);
-        if(applicationEntity == null) {
-            //check alias AE titles
-            applicationEntity =  applicationEntitiesMap.values().stream()
+        
+        if (applicationEntity == null) {
+            return applicationEntitiesMap.values().stream()
                 .filter(ae -> ae.getAETitleAliases().contains(aet))
                 .findFirst()
                 .orElse(null);
         }
+        
         return applicationEntity;
     }
 

--- a/dcm4che-net/src/test/java/org/dcm4che3/net/ApplicationEntityTest.java
+++ b/dcm4che-net/src/test/java/org/dcm4che3/net/ApplicationEntityTest.java
@@ -1,0 +1,82 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is part of dcm4che, an implementation of DICOM(TM) in
+ * Java(TM), hosted at https://github.com/dcm4che.
+ *
+ * The Initial Developer of the Original Code is
+ * Agfa Healthcare.
+ * Portions created by the Initial Developer are Copyright (C) 2022
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ * See @authors listed below
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+package org.dcm4che3.net;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+/**
+ * @author Maciek Siemczyk
+ */
+public class ApplicationEntityTest {
+
+    private static final String AE_TITLE = "SomeAET";
+    
+    /**
+     * System Under Test (SUT).
+     */
+    private ApplicationEntity applicationEntity = new ApplicationEntity(AE_TITLE);
+
+    @Test
+    public void getAETitleAliases_ReturnsEmptyList_WhenThereIsNoAliases() {
+
+        assertThat("Returned not empty list", applicationEntity.getAETitleAliases(), is(empty()));
+    }
+    
+    @Test
+    public void getAETitleAliases_ReturnsCorrectlyPopulatedList_WhenThereAreAliases() {
+        
+        final String firstAlias = "firstAlias";
+        final String secondAlias = "secondAlias";
+        
+        // Set some random alias first to make sure the list is cleared out first.
+        applicationEntity.setAETitleAliases("alias");
+
+        applicationEntity.setAETitleAliases(firstAlias, secondAlias);
+        
+        assertThat(
+                "Returned wrong aliases",
+                applicationEntity.getAETitleAliases(),
+                is(Arrays.asList(firstAlias, secondAlias)));
+    }
+}


### PR DESCRIPTION
…class is null in the returned device instances from remote EJB

- Changed the ApplicationEntity setAETitleAliases to be more in-line with master code by accepting String varargs argument instead of List and added new unit tests for this functionality.
- Cleaned up some code in Device.
- Reworked the newly added DeviceTest to more definitive and added the missing cases.