### PR TITLE
IEI-187643 Fixing the configuration bean reflection issue

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/ApplicationEntity.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/ApplicationEntity.java
@@ -43,7 +43,6 @@ import java.io.Serializable;
 import java.net.Socket;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -184,14 +183,17 @@ public class ApplicationEntity implements Serializable {
         setAETitle(aeTitle);
     }
 
-    public List<String> getAETitleAliases() {
+    public List<String> getAeTitleAliases() {
         return new ArrayList<>(aeTitleAliases);
     }
 
-    public void setAETitleAliases(String... aets) {
-        
+    public void setAeTitleAliases(List<String> aets) {
         aeTitleAliases.clear();
-        aeTitleAliases.addAll(Arrays.asList(aets));
+        aeTitleAliases.addAll(aets);
+    }
+    
+    public boolean isAeTitleAlias(String aet) {
+        return aeTitleAliases.contains(aet);
     }
 
     public Map<Class<? extends AEExtension>, AEExtension> getExtensions() {
@@ -265,7 +267,7 @@ public class ApplicationEntity implements Serializable {
      * <p/>
      * <p/>
      * Please note that there could also be alias AE titles for the same AE. You
-     * can get them via {@link #getAETitleAliases()}.
+     * can get them via {@link #getAeTitleAliases()}.
      *
      * @return A String containing the AE title.
      */
@@ -807,8 +809,7 @@ public class ApplicationEntity implements Serializable {
     protected void setApplicationEntityAttributes(ApplicationEntity from) {
         setOlockHash(from.olockHash);
         setDescription(from.description);
-        aeTitleAliases.clear();
-        aeTitleAliases.addAll(from.getAETitleAliases());
+        setAeTitleAliases(from.aeTitleAliases);
         setVendorData(from.vendorData);
         setApplicationClusters(from.applicationClusters);
         setPreferredCalledAETitles(from.preferredCalledAETitles);
@@ -890,5 +891,4 @@ public class ApplicationEntity implements Serializable {
 
         return true;
     }
-
 }

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Device.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Device.java
@@ -54,6 +54,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.concurrent.Executor;
@@ -1062,10 +1063,10 @@ public class Device extends StorageVersionedConfigurableClass implements Seriali
      * @return AE titles of this device, including alias AE titles
      */
     public Collection<String> getApplicationAETitles() {
-        Collection<String> aeTitles = new HashSet<>();
+        Set<String> aeTitles = new HashSet<>();
         
         aeTitles.addAll(applicationEntitiesMap.keySet());
-        applicationEntitiesMap.values().forEach(ae -> aeTitles.addAll(ae.getAETitleAliases()));
+        applicationEntitiesMap.values().forEach(ae -> aeTitles.addAll(ae.getAeTitleAliases()));
 
         return aeTitles;
     }
@@ -1152,9 +1153,9 @@ public class Device extends StorageVersionedConfigurableClass implements Seriali
         
         if (applicationEntity == null) {
             return applicationEntitiesMap.values().stream()
-                .filter(ae -> ae.getAETitleAliases().contains(aet))
-                .findFirst()
-                .orElse(null);
+                    .filter(ae -> ae.isAeTitleAlias(aet))
+                    .findFirst()
+                    .orElse(null);
         }
         
         return applicationEntity;

--- a/dcm4che-net/src/test/java/org/dcm4che3/net/ApplicationEntityTest.java
+++ b/dcm4che-net/src/test/java/org/dcm4che3/net/ApplicationEntityTest.java
@@ -37,6 +37,7 @@
  * ***** END LICENSE BLOCK ***** */
 package org.dcm4che3.net;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -58,25 +59,43 @@ public class ApplicationEntityTest {
     private ApplicationEntity applicationEntity = new ApplicationEntity(AE_TITLE);
 
     @Test
-    public void getAETitleAliases_ReturnsEmptyList_WhenThereIsNoAliases() {
+    public void getAeTitleAliases_ReturnsEmptyList_WhenThereIsNoAliases() {
 
-        assertThat("Returned not empty list", applicationEntity.getAETitleAliases(), is(empty()));
+        assertThat("Returned not empty list", applicationEntity.getAeTitleAliases(), is(empty()));
     }
     
     @Test
-    public void getAETitleAliases_ReturnsCorrectlyPopulatedList_WhenThereAreAliases() {
+    public void getAeTitleAliases_ReturnsCorrectlyPopulatedList_WhenThereAreAliases() {
         
         final String firstAlias = "firstAlias";
         final String secondAlias = "secondAlias";
         
         // Set some random alias first to make sure the list is cleared out first.
-        applicationEntity.setAETitleAliases("alias");
+        applicationEntity.setAeTitleAliases(Arrays.asList("alias"));
 
-        applicationEntity.setAETitleAliases(firstAlias, secondAlias);
+        applicationEntity.setAeTitleAliases(Arrays.asList(firstAlias, secondAlias));
         
         assertThat(
                 "Returned wrong aliases",
-                applicationEntity.getAETitleAliases(),
-                is(Arrays.asList(firstAlias, secondAlias)));
+                applicationEntity.getAeTitleAliases(),
+                containsInAnyOrder(firstAlias, secondAlias));
+    }
+    
+    @Test
+    public void isAeTitleAlias_ReturnsTrue_GivenAeTitleThatIsAlias() {
+        
+        final String alias = "iExist";
+        
+        applicationEntity.setAeTitleAliases(Arrays.asList("AET1", "AET2", alias, "AET3"));
+        
+        assertThat("Returned false", applicationEntity.isAeTitleAlias(alias), is(true));
+    }
+    
+    @Test
+    public void isAeTitleAlias_ReturnsFalse_GivenAeTitleThatIsNotAlias() {
+        
+        applicationEntity.setAeTitleAliases(Arrays.asList("alias1", "alias2"));
+        
+        assertThat("Returned true", applicationEntity.isAeTitleAlias(AE_TITLE), is(false));
     }
 }

--- a/dcm4che-net/src/test/java/org/dcm4che3/net/DeviceTest.java
+++ b/dcm4che-net/src/test/java/org/dcm4che3/net/DeviceTest.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Rule;
@@ -85,7 +86,7 @@ public class DeviceTest {
     @Test
     public void getApplicationEntity_ReturnsNull_GivenNotExistingAeTitle() {
 
-        applicationEntity.setAETitleAliases(FIRST_ALIAS_AE_TITLE);
+        applicationEntity.setAeTitleAliases(Arrays.asList(FIRST_ALIAS_AE_TITLE));
         device.addApplicationEntity(applicationEntity);
 
         assertThat("Returned not null value", device.getApplicationEntity("GoodLuck"), is(nullValue()));
@@ -96,7 +97,7 @@ public class DeviceTest {
 
         // Create and add to device another AE with alias same as the 'main' Application Entity.
         ApplicationEntity anotherApplicationEntity = new ApplicationEntity("NotMyAeTitle");
-        anotherApplicationEntity.setAETitleAliases(AE_TITLE);
+        anotherApplicationEntity.setAeTitleAliases(Arrays.asList(AE_TITLE));
             
         device.addApplicationEntity(anotherApplicationEntity);
         device.addApplicationEntity(applicationEntity);
@@ -108,10 +109,10 @@ public class DeviceTest {
     public void getApplicationEntity_ReturnsCorrectApplicationEntity_GivenValidAeTitleAlias() {
 
         ApplicationEntity aliasedApplicationEntity = new ApplicationEntity("AliasedAe");
-        aliasedApplicationEntity.setAETitleAliases(FIRST_ALIAS_AE_TITLE, SECOND_ALIAS_AE_TITLE);
+        aliasedApplicationEntity.setAeTitleAliases(Arrays.asList(FIRST_ALIAS_AE_TITLE, SECOND_ALIAS_AE_TITLE));
         
         // Add one alias to the 'main' Application Entity just in case.
-        applicationEntity.setAETitleAliases("alias");
+        applicationEntity.setAeTitleAliases(Arrays.asList("alias"));
             
         device.addApplicationEntity(aliasedApplicationEntity);
         device.addApplicationEntity(applicationEntity);
@@ -128,7 +129,7 @@ public class DeviceTest {
         ApplicationEntity defaultApplicationEntity = new ApplicationEntity(Device.DEFAULT_AE_TITLE);
         
         // Add one alias to the 'main' Application Entity just in case.
-        applicationEntity.setAETitleAliases(FIRST_ALIAS_AE_TITLE);
+        applicationEntity.setAeTitleAliases(Arrays.asList(FIRST_ALIAS_AE_TITLE));
         
         device.addApplicationEntity(defaultApplicationEntity);
         device.addApplicationEntity(applicationEntity);
@@ -143,7 +144,7 @@ public class DeviceTest {
     public void getApplicationEntity_ReturnsCorrectApplicationEntity_GivenNotExistingAeTitleButDeviceHasAeAliasWithDefaultTitle() {
 
         ApplicationEntity defaultApplicationEntity = new ApplicationEntity("AET");
-        defaultApplicationEntity.setAETitleAliases(Device.DEFAULT_AE_TITLE);
+        defaultApplicationEntity.setAeTitleAliases(Arrays.asList(Device.DEFAULT_AE_TITLE));
         
         device.addApplicationEntity(defaultApplicationEntity);
         device.addApplicationEntity(applicationEntity);
@@ -161,9 +162,9 @@ public class DeviceTest {
         final String aetAlias = "SomeAlias";
         
         ApplicationEntity anotherApplicationEntity = new ApplicationEntity(aet);
-        anotherApplicationEntity.setAETitleAliases(aetAlias);
+        anotherApplicationEntity.setAeTitleAliases(Arrays.asList(aetAlias));
         
-        applicationEntity.setAETitleAliases(FIRST_ALIAS_AE_TITLE, SECOND_ALIAS_AE_TITLE);
+        applicationEntity.setAeTitleAliases(Arrays.asList(FIRST_ALIAS_AE_TITLE, SECOND_ALIAS_AE_TITLE));
         
         device.addApplicationEntity(anotherApplicationEntity);
         device.addApplicationEntity(applicationEntity);


### PR DESCRIPTION
- Fixed the capitalization of setAeTitleAliases and getAeTitleAliases, as well as change setter back to List, in ApplicationEntity so configuration property name can be found in property descriptor and serialized.
- Added isAeTitleAlias to ApplicationEntity in order to use in Device's stream that looks up AEs to avoid penalty of coping the List.