### PR TITLE
Allow to specify whether to apply timezone offset via DatePrecision

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -1251,7 +1251,7 @@ public class Attributes implements Serializable {
     }
 
     public Date getDate(int tag) {
-        return getDate(null, tag, null, 0, null, new DatePrecision());
+        return getDate(null, tag, null, 0, null, null);
     }
 
     public Date getDate(int tag, DatePrecision precision) {
@@ -1259,7 +1259,7 @@ public class Attributes implements Serializable {
     }
 
     public Date getDate(int tag, Date defVal) {
-        return getDate(null, tag, null, 0, defVal, new DatePrecision());
+        return getDate(null, tag, null, 0, defVal, null);
     }
 
     public Date getDate(int tag, Date defVal, DatePrecision precision) {
@@ -1267,7 +1267,7 @@ public class Attributes implements Serializable {
     }
 
     public Date getDate(int tag, int valueIndex) {
-        return getDate(null, tag, null, valueIndex, null, new DatePrecision());
+        return getDate(null, tag, null, valueIndex, null, null);
     }
 
     public Date getDate(int tag, int valueIndex, DatePrecision precision) {
@@ -1275,7 +1275,7 @@ public class Attributes implements Serializable {
     }
 
     public Date getDate(int tag, int valueIndex, Date defVal) {
-        return getDate(null, tag, null, valueIndex, defVal, new DatePrecision());
+        return getDate(null, tag, null, valueIndex, defVal, null);
     }
 
     public Date getDate(int tag, int valueIndex, Date defVal,
@@ -1284,7 +1284,7 @@ public class Attributes implements Serializable {
     }
 
     public Date getDate(String privateCreator, int tag) {
-        return getDate(privateCreator, tag, null, 0, null, new DatePrecision());
+        return getDate(privateCreator, tag, null, 0, null, null);
     }
 
     public Date getDate(String privateCreator, int tag, DatePrecision precision) {
@@ -1297,7 +1297,7 @@ public class Attributes implements Serializable {
     }
 
     public Date getDate(String privateCreator, int tag, VR vr) {
-        return getDate(privateCreator, tag, vr, 0, null, new DatePrecision());
+        return getDate(privateCreator, tag, vr, 0, null, null);
     }
 
     public Date getDate(String privateCreator, int tag, VR vr,
@@ -1306,7 +1306,7 @@ public class Attributes implements Serializable {
     }
 
     public Date getDate(String privateCreator, int tag, VR vr, Date defVal) {
-        return getDate(privateCreator, tag, vr, 0, defVal, new DatePrecision());
+        return getDate(privateCreator, tag, vr, 0, defVal, null);
     }
 
     public Date getDate(String privateCreator, int tag, VR vr, Date defVal,
@@ -1316,7 +1316,7 @@ public class Attributes implements Serializable {
 
     public Date getDate(String privateCreator, int tag, int valueIndex) {
         return getDate(privateCreator, tag, null, valueIndex, null,
-                new DatePrecision());
+                null);
     }
 
     public Date getDate(String privateCreator, int tag, int valueIndex,
@@ -1327,7 +1327,7 @@ public class Attributes implements Serializable {
     public Date getDate(String privateCreator, int tag, int valueIndex,
             Date defVal) {
         return getDate(privateCreator, tag, null, valueIndex, defVal,
-                new DatePrecision());
+                null);
     }
 
     public Date getDate(String privateCreator, int tag, int valueIndex,
@@ -1337,7 +1337,7 @@ public class Attributes implements Serializable {
 
     public Date getDate(String privateCreator, int tag, VR vr, int valueIndex) {
         return getDate(privateCreator, tag, vr, valueIndex, null,
-                new DatePrecision());
+                null);
     }
 
     public Date getDate(String privateCreator, int tag, VR vr, int valueIndex,
@@ -1348,7 +1348,7 @@ public class Attributes implements Serializable {
     public Date getDate(String privateCreator, int tag, VR vr, int valueIndex,
             Date defVal) {
         return getDate(privateCreator, tag, vr, valueIndex, defVal,
-                new DatePrecision());
+                null);
     }
 
     public Date getDate(String privateCreator, int tag, VR vr, int valueIndex,
@@ -1374,6 +1374,9 @@ public class Attributes implements Serializable {
             if (value == Value.NULL)
                 return defVal;
 
+            if(precision == null)
+                precision = new DatePrecision(vr);
+
             return vr.toDate(value, getTimeZone(), valueIndex, false, defVal, precision);
         } catch (IllegalArgumentException e) {
             LOG.info("Invalid value of {} {}", TagUtils.toString(tag), vr);
@@ -1382,7 +1385,7 @@ public class Attributes implements Serializable {
     }
 
     public Date getDate(long tag) {
-        return getDate(null, tag, null, new DatePrecision());
+        return getDate(null, tag, null, null);
     }
 
     public Date getDate(long tag, DatePrecision precision) {
@@ -1390,7 +1393,7 @@ public class Attributes implements Serializable {
     }
 
     public Date getDate(long tag, Date defVal) {
-        return getDate(null, tag, defVal, new DatePrecision());
+        return getDate(null, tag, defVal, null);
     }
 
     public Date getDate(long tag, Date defVal, DatePrecision precision) {
@@ -1398,7 +1401,7 @@ public class Attributes implements Serializable {
     }
 
     public Date getDate(String privateCreator, long tag) {
-        return getDate(privateCreator, tag, null, new DatePrecision());
+        return getDate(privateCreator, tag, null, null);
     }
 
     public Date getDate(String privateCreator, long tag, DatePrecision precision) {
@@ -1406,7 +1409,7 @@ public class Attributes implements Serializable {
     }
 
     public Date getDate(String privateCreator, long tag, Date defVal) {
-        return getDate(privateCreator, tag, defVal, new DatePrecision());
+        return getDate(privateCreator, tag, defVal, null);
     }
 
     public Date getDate(String privateCreator, long tag, Date defVal,
@@ -1422,6 +1425,9 @@ public class Attributes implements Serializable {
         if (da == null)
             return defVal;
         try {
+            if(precision == null)
+                precision = new DatePrecision(VR.DT);
+
             return VR.DT.toDate(da + tm, getTimeZone(), 0, false, null,
                     precision);
         } catch (IllegalArgumentException e) {
@@ -1433,7 +1439,7 @@ public class Attributes implements Serializable {
     }
 
     public Date[] getDates(int tag) {
-        return getDates(null, tag, null, new DatePrecisions());
+        return getDates(null, tag, null, null);
     }
 
     public Date[] getDates(int tag, DatePrecisions precisions) {
@@ -1441,7 +1447,7 @@ public class Attributes implements Serializable {
     }
 
     public Date[] getDates(String privateCreator, int tag) {
-        return getDates(privateCreator, tag, null, new DatePrecisions());
+        return getDates(privateCreator, tag, null, null);
     }
 
     public Date[] getDates(String privateCreator, int tag,
@@ -1450,7 +1456,7 @@ public class Attributes implements Serializable {
     }
 
     public Date[] getDates(String privateCreator, int tag, VR vr) {
-        return getDates(privateCreator, tag, vr, new DatePrecisions());
+        return getDates(privateCreator, tag, vr, null);
     }
 
     public Date[] getDates(String privateCreator, int tag, VR vr,
@@ -1476,6 +1482,9 @@ public class Attributes implements Serializable {
             if (value == Value.NULL)
                 return DateUtils.EMPTY_DATES;
 
+            if(precisions == null)
+                precisions = new DatePrecisions(vr);
+
             return vr.toDates(value, getTimeZone(), false, precisions);
         } catch (IllegalArgumentException e) {
             LOG.info("Invalid value of {} {}", TagUtils.toString(tag), vr);
@@ -1484,7 +1493,7 @@ public class Attributes implements Serializable {
     }
 
     public Date[] getDates(long tag) {
-        return getDates(null, tag, new DatePrecisions());
+        return getDates(null, tag, null);
     }
 
     public Date[] getDates(long tag, DatePrecisions precisions) {
@@ -1492,7 +1501,7 @@ public class Attributes implements Serializable {
     }
 
     public Date[] getDates(String privateCreator, long tag) {
-        return getDates(privateCreator, tag, new DatePrecisions());
+        return getDates(privateCreator, tag, null);
     }
 
     public Date[] getDates(String privateCreator, long tag,
@@ -1509,16 +1518,35 @@ public class Attributes implements Serializable {
             return DateUtils.EMPTY_DATES;
         
         Date[] dates = new Date[da.length];
-        precisions.precisions = new DatePrecision[da.length];
+        if (precisions == null) {
+            precisions = new DatePrecisions();
+        }
+        DatePrecision precisionTemplate = null;
+        if (precisions.precisions.length > 0) {
+            precisionTemplate = precisions.precisions[0];
+        }
+        if (precisions.precisions.length != da.length) {
+            precisions.precisions = new DatePrecision[da.length];
+        }
         int i = 0;
         try {
             TimeZone tz = getTimeZone();
-            while (i < tm.length)
+            while (i < tm.length) {
+                if (precisions.precisions[i] == null) {
+                    precisions.precisions[i] =
+                            precisionTemplate == null ? new DatePrecision(VR.DT) : new DatePrecision(precisionTemplate);
+                }
                 dates[i++] = VR.DT.toDate(da[i] + tm[i], tz, 0, false, null,
-                        precisions.precisions[i] = new DatePrecision());
-            while (i < da.length)
+                        precisions.precisions[i]);
+            }
+            while (i < da.length) {
+                if (precisions.precisions[i] == null) {
+                    precisions.precisions[i] =
+                            precisionTemplate == null ? new DatePrecision(VR.DA) : new DatePrecision(precisionTemplate);
+                }
                 dates[i++] = VR.DA.toDate(da[i], tz, 0, false, null,
-                        precisions.precisions[i] = new DatePrecision());
+                        precisions.precisions[i]);
+            }
         } catch (IllegalArgumentException e) {
             LOG.info("Invalid value of {} DA or {} TM",
                     TagUtils.toString(daTag),
@@ -1581,7 +1609,7 @@ public class Attributes implements Serializable {
     private DateRange toDateRange(String s, VR vr) {
         String[] range = splitRange(s);
         TimeZone tz = getTimeZone();
-        DatePrecision precision = new DatePrecision();
+        DatePrecision precision = new DatePrecision(vr);
         Date start = range[0] == null ? null
                 : vr.toDate(range[0], tz, 0, false, null, precision);
         Date end = range[1] == null ? null
@@ -1638,7 +1666,7 @@ public class Attributes implements Serializable {
     private DateRange toDateRange(String da, String tm) {
         String[] darange = splitRange(da);
         String[] tmrange = splitRange(tm);
-        DatePrecision precision = new DatePrecision();
+        DatePrecision precision = new DatePrecision(VR.DT);
         return new DateRange(
                 darange[0] == null ? null
                         : VR.DT.toDate(tmrange[0] == null
@@ -2039,7 +2067,7 @@ public class Attributes implements Serializable {
 
     public Object setDate(String privateCreator, int tag, VR vr,
             Date... ds) {
-        return setDate(privateCreator, tag, vr, new DatePrecision(), ds);
+        return setDate(privateCreator, tag, vr, new DatePrecision(vr), ds);
     }
 
     public Object setDate(String privateCreator, int tag, VR vr,
@@ -2057,7 +2085,7 @@ public class Attributes implements Serializable {
     }
 
     public void setDate(String privateCreator, long tag, Date dt) {
-        setDate(privateCreator, tag, new DatePrecision(), dt);
+        setDate(privateCreator, tag, new DatePrecision(VR.DT), dt);
     }
 
     public void setDate(String privateCreator, long tag,
@@ -2077,7 +2105,7 @@ public class Attributes implements Serializable {
     }
 
     public Object setDateRange(String privateCreator, int tag, VR vr, DateRange range) {
-        return setDateRange(privateCreator, tag, vr, new DatePrecision(), range);
+        return setDateRange(privateCreator, tag, vr, new DatePrecision(vr), range);
     }
 
     public Object setDateRange(String privateCreator, int tag, VR vr, DatePrecision precision, DateRange range) {
@@ -3289,7 +3317,7 @@ public class Attributes implements Serializable {
                             continue;
                     if (dateRange != null)
                         if (dateRange.contains(
-                                vr.toDate(val, getTimeZone(), 0, false, null, new DatePrecision())))
+                                vr.toDate(val, getTimeZone(), 0, false, null, new DatePrecision(vr))))
                             return true;
                         else
                             continue;

--- a/dcm4che-core/src/main/java/org/dcm4che3/data/DatePrecision.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/DatePrecision.java
@@ -50,16 +50,59 @@ public class DatePrecision {
         this(Calendar.MILLISECOND, false);
     }
 
+    public DatePrecision(VR vr) {
+        // apply timezone offset for VR.DT (as that always includes date and time), but not when reading VR.DA and VR.TM
+        // values separately (because a timezone offset cannot be correctly applied for only a date or only a time).
+        this(Calendar.MILLISECOND, false, vr == VR.DT);
+    }
+
     public DatePrecision(int lastField) {
-        this(lastField, false);
+        this(lastField, false, true);
     }
 
     public DatePrecision(int lastField, boolean includeTimezone) {
-        this.lastField = lastField;
-        this.includeTimezone = includeTimezone;
+        this(lastField, includeTimezone, true);
     }
 
+    public DatePrecision(int lastField, boolean includeTimezone, boolean applyTimezoneOffset) {
+        this.lastField = lastField;
+        this.includeTimezone = includeTimezone;
+        this.applyTimezoneOffset = applyTimezoneOffset;
+    }
+
+    public DatePrecision(DatePrecision copyFrom) {
+        this(copyFrom.lastField, copyFrom.includeTimezone, copyFrom.applyTimezoneOffset);
+    }
+
+    /**
+     * Specifies the precision of a date value (e.g. Calendar.MILLISECOND for millisecond precision).
+     *
+     * For methods that format a date (e.g. {@link Attributes#setDate}), this acts as an input to specify the precision
+     * that should be stored.
+     *
+     * For methods that parse a date (e.g. {@link Attributes#getDate}), this field will be used as a return value. It
+     * returns the precision of the date that was parsed.
+     */
     public int lastField;
+
+    /**
+     * Specifies whether a formatted date includes a timezone in the stored value itself.
+     *
+     * This is only used for values of {@link VR#DT}.
+     *
+     * For methods that format a DT date time, this acts as an input to specify whether the timezone offset should
+     * be appended to the formatted date (e.g. "+0100").
+     *
+     * For methods that parse a DT date time, this field will be used as a return value. It returns whether the parsed
+     * date included a timezone offset.
+     */
     public boolean includeTimezone;
 
+    /**
+     * Specifies whether the timezone offset (specified by {@link Tag#TimezoneOffsetFromUTC} or
+     * {@link Attributes#getDefaultTimeZone()}) should be applied when parsing and formatting dates and times.
+     *
+     * This field is always used as an input (for both parsing and formatting), never as a return value.
+     */
+    public boolean applyTimezoneOffset;
 }

--- a/dcm4che-core/src/main/java/org/dcm4che3/data/DatePrecisions.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/DatePrecisions.java
@@ -44,5 +44,13 @@ package org.dcm4che3.data;
  */
 public class DatePrecisions {
 
+    public DatePrecisions() {
+        // empty
+    }
+
+    public DatePrecisions(VR vr) {
+        this.precisions = new DatePrecision[] {new DatePrecision(vr)};
+    }
+
     public DatePrecision[] precisions;
 }

--- a/dcm4che-core/src/main/java/org/dcm4che3/data/StringValueType.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/StringValueType.java
@@ -478,18 +478,32 @@ enum StringValueType implements ValueType {
             throw new UnsupportedOperationException();
 
         if (val instanceof String) {
-            precisions.precisions = new DatePrecision[1];
-            return new Date[] { temporalType.parse(tz, (String) val, ceil,
-                    precisions.precisions[0] = new DatePrecision()) };
+            if (precisions.precisions == null || precisions.precisions.length != 1) {
+                precisions.precisions = new DatePrecision[1];
+            }
+            if (precisions.precisions[0] == null) {
+                precisions.precisions[0] = new DatePrecision();
+            }
+            return new Date[] {temporalType.parse(tz, (String) val, ceil, precisions.precisions[0])};
         }
         if (val instanceof String[]) {
             String[] ss = (String[]) val;
             Date[] is = new Date[ss.length];
-            precisions.precisions = new DatePrecision[ss.length];
+            DatePrecision precisionTemplate;
+            if (precisions.precisions.length > 0 && precisions.precisions[0] != null) {
+                precisionTemplate = precisions.precisions[0];
+            } else {
+                precisionTemplate = new DatePrecision();
+            }
+            if (precisions.precisions.length != ss.length) {
+                precisions.precisions = new DatePrecision[ss.length];
+            }
             for (int i = 0; i < is.length; i++) {
                 if (ss[i] != null) {
-                    is[i] = temporalType.parse(tz, ss[i], ceil, 
-                            precisions.precisions[i] = new DatePrecision());
+                    if (precisions.precisions[i] == null) {
+                        precisions.precisions[i] = new DatePrecision(precisionTemplate);
+                    }
+                    is[i] = temporalType.parse(tz, ss[i], ceil, precisions.precisions[i]);
                 }
             }
             return is;

--- a/dcm4che-core/src/main/java/org/dcm4che3/data/TemporalType.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/TemporalType.java
@@ -54,37 +54,37 @@ enum TemporalType {
         public Date parse(TimeZone tz, String s, boolean ceil,
                 DatePrecision precision) {
             precision.lastField = Calendar.DAY_OF_MONTH;
-            return DateUtils.parseDA(null, s, ceil);
+            return DateUtils.parseDA(precision.applyTimezoneOffset ? tz : null, s, ceil);
         }
 
         @Override
         public String format(TimeZone tz, Date date,
                 DatePrecision precision) {
-            return DateUtils.formatDA(null, date);
+            return DateUtils.formatDA(precision.applyTimezoneOffset ? tz : null, date);
         }
     }, DT {
         @Override
         public Date parse(TimeZone tz, String s, boolean ceil,
                 DatePrecision precision) {
-            return DateUtils.parseDT(tz, s, ceil, precision);
+            return DateUtils.parseDT(precision.applyTimezoneOffset ? tz : null, s, ceil, precision);
         }
 
         @Override
         public String format(TimeZone tz, Date date,
                 DatePrecision precision) {
-            return DateUtils.formatDT(tz, date, precision);
+            return DateUtils.formatDT(precision.applyTimezoneOffset ? tz : null, date, precision);
         }
     }, TM {
         @Override
         public Date parse(TimeZone tz, String s, boolean ceil,
                 DatePrecision precision) {
-            return DateUtils.parseTM(tz, s, ceil, precision);
+            return DateUtils.parseTM(precision.applyTimezoneOffset ? tz : null, s, ceil, precision);
         }
 
         @Override
         public String format(TimeZone tz, Date date,
                 DatePrecision precision) {
-            return DateUtils.formatTM(tz, date, precision);
+            return DateUtils.formatTM(precision.applyTimezoneOffset ? tz : null, date, precision);
         }
     };
 


### PR DESCRIPTION
If not specified, by default, it will be applied for VR.DT values and when accessing (get/set) VR.DA and VR.TM values combined, but not when accessing them separately.

Explanation:
The change done in https://github.com/dcm4che/dcm4che/issues/699 is causing quite some problems in our application.
In particular, when accessing a "combined" (long) dateAndTime tag (e.g. Tag.StudyDateAndTime) the current handling is quite inconsistent: When setting a Date, the VR.TM value will be timezone corrected, but the VR.DA value will not (!), which is incorrect if the timezone offset goes over midnight to the next/previous day.
When getting a Date, the offset will be applied for both the VR.DA and VR.TM values, making the behavior even more inconsistent. (Set and get methods should behave consistently.)

With these changes, I want to make this behavior consistent. Please see the new unit tests.
When accessing date and time combined (long tag), then the correction will always happen by default.
When accessing them separately, then no correction will be done by default (because it is impossible to do it correctly).

Additionally, using a new field in DatePrecision, the behavior can also be controlled by the user.

I know that ideally we should eventually introduce methods which work with the new java.time types, as you mentioned in https://github.com/dcm4che/dcm4che/issues/787
That would be nice of course! But until then, I believe that these changes already improve the behavior a lot, and allow the user quite some flexibility.