### PR TITLE
prevent NPE from being thrown

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
@@ -807,7 +807,9 @@ public class Association {
     private DimseRSPHandler removeDimseRSPHandler(int msgId) {
         synchronized (rspHandlerForMsgId ) {
             DimseRSPHandler tmp = rspHandlerForMsgId.remove(msgId);
-            tmp.stopTimeout(this);
+            if (tmp != null) {
+              tmp.stopTimeout(this);
+            }
             rspHandlerForMsgId.notifyAll();
             return tmp;
         }


### PR DESCRIPTION
In Association.invoke(PresentationContext, Attributes, DataWriter, DimseRSPHandler, int, int, boolean) :

If encoder.writeDIMSE(pc, cmd, data); throws an exception e, e is caught and removeDimseRSPHandler(rspHandler.getMessageID()); is executed.

But in removeDimseRSPHandler :
if tmp is null then a NPE is thrown

So invoke(PresentationContext, Attributes, DataWriter, DimseRSPHandler, int, int, boolean) will throw the NPE, instead of thowing e.

This PR avoids triggering the NPE, and therefore the exception "e" will be thrown.