### PR TITLE
public tags were incorrectly handled after merging privateCreators wi…

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -2422,6 +2422,7 @@ public class Attributes implements Serializable {
             } else {
                 creatorTag = 0;
                 privateCreator = null;
+                privateCreator0 = null;
             }
 
             if (selection != null && !selection.contains(privateCreator, tag))

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
@@ -862,4 +862,18 @@ public class AttributesTest {
         assertTrue(modifiedAttributes.bigEndian());
         assertArrayEquals(modifiedAttributes.getBytes(Tag.PixelRepresentation), new byte[]{0,1});
     }
+
+    @Test
+    public void testThatNoExceptionWhenPublicTagsAfterPrivateCreators() {
+        Attributes attributes = new Attributes();
+        attributes.setString("MyCreator", 0x00290018, VR.LO, "foo");
+
+        Attributes toAdd = new Attributes();
+        toAdd.setString("MyCreator2", 0x00290018, VR.LO, "bar");
+        toAdd.setString(Tag.PerformedProcedureStepDescription, VR.LO, "CTABD  Abdomen");
+
+        attributes.addAll(toAdd);
+
+        assertEquals(5, attributes.size());
+    }
 }


### PR DESCRIPTION
Related to https://github.com/dcm4che/dcm4che/issues/706, when one Attribute instance with a privateCreator is added to another Attribute instance with a privateCreator - both using the same tag but different values.
Then if a public tag follow these privateCreator tags an exception is thrown:

(0040,0254) is not a private Data Element
java.lang.IllegalArgumentException: (0040,0254) is not a private Data Element
	at org.dcm4che3.data.Attributes.creatorTagOf(Attributes.java:505)
	at org.dcm4che3.data.Attributes.set(Attributes.java:2179)
	at org.dcm4che3.data.Attributes.add(Attributes.java:2471)
	at org.dcm4che3.data.Attributes.addAll(Attributes.java:2228)

This appears to be due to the privateCreator0 variable not being reset to 'null' on public tags.