### PR TITLE
Update DicomInputStream.skipAttribute: use skipfully() instead of skip()

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -804,7 +804,6 @@ public class DicomInputStream extends FilterInputStream
         String tagAsString = TagUtils.toString(this.tag);
         LOG.warn(message, tagAsString, length, tagPos, methodName);
         skipFully(length);
-        LOG.debug("Skipped {} bytes for {}", length, tagAsString);
     }
 
     private void readSequence(int len, Attributes attrs, int sqtag)

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -803,8 +803,8 @@ public class DicomInputStream extends FilterInputStream
     private void skipAttribute(String message, String methodName) throws IOException {
         String tagAsString = TagUtils.toString(this.tag);
         LOG.warn(message, tagAsString, length, tagPos, methodName);
-        long skipLength = skip(length);
-        LOG.debug("Skipped {} actual bytes for {}", skipLength, tagAsString);
+        skipFully(length);
+        LOG.debug("Skipped {} bytes for {}", length, tagAsString);
     }
 
     private void readSequence(int len, Attributes attrs, int sqtag)


### PR DESCRIPTION
Follow up to discussion on #1182  so that we use skipFully instead of skip for the skipAttributes method on the generic-config branch.