### PR TITLE
Update DicomInputStream.skipAttribute: remove extra debug statement

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -841,7 +841,6 @@ public class DicomInputStream extends FilterInputStream
         String tagAsString = TagUtils.toString(this.tag);
         LOG.warn(message, tagAsString, length, tagPos, methodName);
         skipFully(length);
-        LOG.debug("Skipped {} bytes for {}", length, tagAsString);
     }
 
     private void readSequence(int len, Attributes attrs, int sqtag)


### PR DESCRIPTION
Followup to Pull Request #1182 to remove the redundant debug statement.