### PR TITLE
Consider VR when decoding Strings in add and addSelected methods

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -2279,7 +2279,7 @@ public class Attributes implements Serializable {
             if (vr.useSpecificCharacterSet()) {
                 value = other.loadBulkData(vr, value);
                 if (value instanceof byte[])
-                    value = other.getSpecificCharacterSet().decode((byte[]) value);
+                    value = vr.toStrings(value, other.bigEndian(), other.getSpecificCharacterSet());
             }
         }
         if (value instanceof Sequence) {
@@ -2514,7 +2514,7 @@ public class Attributes implements Serializable {
                     if (decodeStringValue && vr.useSpecificCharacterSet()) {
                         value = other.loadBulkData(vr, value);
                         if (value instanceof byte[])
-                            value = other.getSpecificCharacterSet().decode((byte[]) value);
+                            value = vr.toStrings(value, other.bigEndian(), other.getSpecificCharacterSet());
                     }
                     set(privateCreator0, tag, vr,
                             toggleEndian(vr, value, toggleEndian));

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
@@ -863,6 +863,36 @@ public class AttributesTest {
     }
 
     @Test
+    public void testAddShouldCorrectlyDecodeStrings() {
+        Attributes aLeft = new Attributes();
+        aLeft.setSpecificCharacterSet("ISO_IR 192");
+
+        Attributes aRight = new Attributes();
+        aRight.setSpecificCharacterSet("ISO_IR 100");
+        byte[] studyid = new byte[] {0x33, 0x33, 0x34, 0x31, 0x34, 0x20};
+        aRight.setBytes(Tag.StudyID, VR.SH, studyid);
+
+        aLeft.addNotSelected(aRight, Tag.SpecificCharacterSet);
+
+        assertEquals("Padding space should be removed", "33414", aLeft.getString(Tag.StudyID));
+    }
+
+    @Test
+    public void testAddSelectedShouldCorrectlyDecodeStrings() {
+        Attributes aLeft = new Attributes();
+        aLeft.setSpecificCharacterSet("ISO_IR 192");
+
+        Attributes aRight = new Attributes();
+        aRight.setSpecificCharacterSet("ISO_IR 100");
+        byte[] studyid = new byte[] {0x33, 0x33, 0x34, 0x31, 0x34, 0x20};
+        aRight.setBytes(Tag.StudyID, VR.SH, studyid);
+
+        aLeft.addSelected(aRight, null, Tag.StudyID);
+
+        assertEquals("Padding space should be removed", "33414", aLeft.getString(Tag.StudyID));
+    }
+
+    @Test
     public void testGetValuePrivateCreatorSh() {
         Attributes dataset = new Attributes();
 


### PR DESCRIPTION
Fix for a problem with VRs that should trim leading and trailing spaces. See the new unit tests.