### PR TITLE
IEI-196571 decrement the performing operations counter when the pduencoder throws an exception

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
@@ -95,11 +95,11 @@ public class Association {
     private int performing;
     private Timeout timeout;
     private final IntHashMap<DimseRSPHandler> rspHandlerForMsgId =
-            new IntHashMap<DimseRSPHandler>();
+            new IntHashMap<>();
     private final IntHashMap<CancelRQHandler> cancelHandlerForMsgId =
-            new IntHashMap<CancelRQHandler>();
+            new IntHashMap<>();
     private final HashMap<String,HashMap<String,PresentationContext>> pcMap =
-            new HashMap<String,HashMap<String,PresentationContext>>();
+            new HashMap<>();
 
     Association(ApplicationEntity ae, Connection local, Socket sock)
             throws IOException {
@@ -183,8 +183,9 @@ public class Association {
     }
 
     public Object setProperty(String key, Object value) {
-        if (properties == null)
-            properties = new HashMap<String, Object>();
+        if (properties == null) {
+            properties = new HashMap<>();
+        }
         return properties.put(key, value);
     }
 
@@ -748,11 +749,15 @@ public class Association {
             writer = new DataWriterAdapter(data);
             datasetType = Commands.getWithDatasetType();
         }
+
         cmd.setInt(Tag.CommandDataSetType, VR.US, datasetType);
-        encoder.writeDIMSE(pc, cmd, writer);
-        if (!Status.isPending(cmd.getInt(Tag.Status, 0))) {
-            decPerforming();
-            startIdleTimeout();
+        try {
+            encoder.writeDIMSE(pc, cmd, writer);
+        } finally {
+            if (!Status.isPending(cmd.getInt(Tag.Status, 0))) {
+                decPerforming();
+                startIdleTimeout();
+            }
         }
     }
 
@@ -785,8 +790,9 @@ public class Association {
 
     private HashMap<String, PresentationContext> initTSMap(String as) {
         HashMap<String, PresentationContext> tsMap = pcMap.get(as);
-        if (tsMap == null)
-            pcMap.put(as, tsMap = new HashMap<String, PresentationContext>());
+        if (tsMap == null) {
+            pcMap.put(as, tsMap = new HashMap<>());
+        }
         return tsMap;
     }
 
@@ -1266,8 +1272,13 @@ public class Association {
             }
 
         } else {
-            LOG.warn("Attempted to close the association, but it was not ready for data transfer", new IOException("Association not ready for data transfer"));
+            LOG.warn("Attempted to close the association, but it was not ready for data transfer",
+                    new IOException("Association not ready for data transfer"));
         }
+    }
+
+    public int getPerformingOperationCount() {
+        return performing;
     }
 }
 

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/service/DicomServiceRegistry.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/service/DicomServiceRegistry.java
@@ -58,7 +58,7 @@ import org.dcm4che3.net.pdu.PresentationContext;
 public class DicomServiceRegistry implements DimseRQHandler {
 
     private final HashMap<String, DimseRQHandler> services =
-            new HashMap<String, DimseRQHandler>();
+            new HashMap<>();
 
     public void addDicomService(DicomService service) {
         addDimseRQHandler(service, service.getSOPClasses());
@@ -85,7 +85,7 @@ public class DicomServiceRegistry implements DimseRQHandler {
         try {
             lookupService(as, dimse, cmd).onDimseRQ(as, pc, dimse, cmd, data);
         } catch (DicomServiceException e) {
-            Association.LOG.warn("{}: processing {} failed. Caused by:\t",
+            Association.LOG.error("{}: processing {} failed. Caused by:\t",
                     as,
                     dimse.toString(cmd, pc.getPCID(), pc.getTransferSyntax()),
                     e);

--- a/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
+++ b/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
@@ -1,0 +1,86 @@
+package org.dcm4che3.net;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.Tag;
+import org.dcm4che3.data.VR;
+import org.dcm4che3.net.pdu.AAssociateAC;
+import org.dcm4che3.net.pdu.PresentationContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the org.dcm4che3.net.Association class
+ */
+public class AssociationTest {
+
+    @Test(expected = BadSocketException.class)
+    public void writeDimseRsp_pduEncoderThrowsException_performingRqCounterDecremented() throws IOException {
+        Socket socket = new BadSocket();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+        Device device = new Device();
+        device.setExecutor(executorService);
+
+        Connection connection = new Connection();
+        connection.setDevice(device);
+
+        Association association = new Association(null, connection, socket);
+        association.handle(new AAssociateAC());
+
+        PresentationContext presentationContext = new PresentationContext(1, "as", "ts");
+        Attributes cmd = new Attributes();
+        cmd.setInt(Tag.CommandField, VR.US, 0x8021);
+        cmd.setInt(Tag.Status, VR.US, Status.Success);
+
+        int performingCount = association.getPerformingOperationCount();
+        try {
+            association.writeDimseRSP(presentationContext, cmd);
+        } finally {
+            Assert.assertEquals("Performing Operation count did not decrement",
+                    performingCount - 1, association.getPerformingOperationCount());
+            executorService.shutdown();
+        }
+    }
+
+    private class BadSocket extends Socket {
+
+        @Override public InputStream getInputStream() {
+            return new DummyInputStream();
+        }
+
+        @Override public OutputStream getOutputStream() {
+            return new BadOutputStream();
+        }
+    }
+
+    private class DummyInputStream extends InputStream {
+
+        @Override public int read() throws IOException {
+            try {
+                // Just a short sleep to simulate the blocking read for nextPDU
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+            }
+            return 0;
+        }
+    }
+
+    private class BadOutputStream extends OutputStream {
+
+        @Override public void write(int b) throws IOException {
+            throw new BadSocketException();
+        }
+    }
+
+    private class BadSocketException extends SocketException {
+    }
+}


### PR DESCRIPTION
This will allow the Association to be closed and the thread it is consuming to be returned to the thread pool.