### PR TITLE
Prevent collision when renaming same file concurrently fix #1189

### DIFF
--- a/dcm4che-tool/dcm4che-tool-storescp/src/main/java/org/dcm4che3/tool/storescp/StoreSCP.java
+++ b/dcm4che-tool/dcm4che-tool-storescp/src/main/java/org/dcm4che3/tool/storescp/StoreSCP.java
@@ -156,7 +156,8 @@ public class StoreSCP {
         }
     }
 
-    private static void renameTo(Association as, File from, File dest)
+    /** method is synchronized to prevent (rare) concurrent access to the same file */
+    private synchronized static void renameTo(Association as, File from, File dest)
             throws IOException {
         LOG.info("{}: M-RENAME {} to {}", as, from, dest);
         if (!dest.getParentFile().mkdirs())


### PR DESCRIPTION
this fix prevents the renameTo() method to be accessed concurrently, because it generated errors in logs and potentially file corruption when accessing the same file.