### PR TITLE
Decrement performing ops on exception while writing response Fix #1201

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
@@ -852,10 +852,13 @@ public class Association {
             datasetType = Commands.getWithDatasetType();
         }
         cmd.setInt(Tag.CommandDataSetType, VR.US, datasetType);
-        encoder.writeDIMSE(pc, cmd, writer);
-        if (!Status.isPending(cmd.getInt(Tag.Status, 0))) {
-            decPerforming();
-            startIdleTimeout();
+        try {
+            encoder.writeDIMSE(pc, cmd, writer);
+        } finally {
+            if (!Status.isPending(cmd.getInt(Tag.Status, 0))) {
+                decPerforming();
+                startIdleTimeout();
+            }
         }
     }
 
@@ -1319,6 +1322,10 @@ public class Association {
 
     public EnumSet<QueryOption> getRequestedQueryOptionsFor(String cuid) {
         return QueryOption.toOptions(rq.getExtNegotiationFor(cuid));
+    }
+
+    public int getPerformingOperationCount() {
+        return performing;
     }
 }
 

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/service/DicomServiceRegistry.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/service/DicomServiceRegistry.java
@@ -58,7 +58,7 @@ import org.dcm4che3.net.pdu.PresentationContext;
 public class DicomServiceRegistry implements DimseRQHandler {
 
     private final HashMap<String, DimseRQHandler> services =
-            new HashMap<String, DimseRQHandler>();
+            new HashMap<>();
 
     public void addDicomService(DicomService service) {
         addDimseRQHandler(service, service.getSOPClasses());
@@ -85,7 +85,7 @@ public class DicomServiceRegistry implements DimseRQHandler {
         try {
             lookupService(as, dimse, cmd).onDimseRQ(as, pc, dimse, cmd, data);
         } catch (DicomServiceException e) {
-            Association.LOG.error("{}: processing {} failed. Caused by:\t",
+            Association.LOG.info("{}: processing {} failed. Caused by:\t",
                     as,
                     dimse.toString(cmd, pc.getPCID(), pc.getTransferSyntax()),
                     e);

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/service/DicomServiceRegistry.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/service/DicomServiceRegistry.java
@@ -85,7 +85,7 @@ public class DicomServiceRegistry implements DimseRQHandler {
         try {
             lookupService(as, dimse, cmd).onDimseRQ(as, pc, dimse, cmd, data);
         } catch (DicomServiceException e) {
-            Association.LOG.info("{}: processing {} failed. Caused by:\t",
+            Association.LOG.error("{}: processing {} failed. Caused by:\t",
                     as,
                     dimse.toString(cmd, pc.getPCID(), pc.getTransferSyntax()),
                     e);

--- a/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
+++ b/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
@@ -12,6 +12,7 @@ import org.dcm4che3.data.Attributes;
 import org.dcm4che3.data.Tag;
 import org.dcm4che3.data.VR;
 import org.dcm4che3.net.pdu.AAssociateAC;
+import org.dcm4che3.net.pdu.AAssociateRJ;
 import org.dcm4che3.net.pdu.PresentationContext;
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,6 +30,19 @@ public class AssociationTest {
 
         Device device = new Device();
         device.setExecutor(executorService);
+        device.setAssociationMonitor(new AssociationMonitor() {
+            @Override public void onAssociationEstablished(Association as) {
+            }
+
+            @Override public void onAssociationFailed(Association as, Throwable e) {
+            }
+
+            @Override public void onAssociationRejected(Association as, AAssociateRJ aarj) {
+            }
+
+            @Override public void onAssociationAccepted(Association as) {
+            }
+        });
 
         Connection connection = new Connection();
         connection.setDevice(device);

--- a/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
+++ b/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
@@ -1,0 +1,86 @@
+package org.dcm4che3.net;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.Tag;
+import org.dcm4che3.data.VR;
+import org.dcm4che3.net.pdu.AAssociateAC;
+import org.dcm4che3.net.pdu.PresentationContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the org.dcm4che3.net.Association class
+ */
+public class AssociationTest {
+
+    @Test(expected = BadSocketException.class)
+    public void writeDimseRsp_pduEncoderThrowsException_performingRqCounterDecremented() throws IOException {
+        Socket socket = new BadSocket();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+        Device device = new Device();
+        device.setExecutor(executorService);
+
+        Connection connection = new Connection();
+        connection.setDevice(device);
+
+        Association association = new Association(null, connection, socket);
+        association.handle(new AAssociateAC());
+
+        PresentationContext presentationContext = new PresentationContext(1, "as", "ts");
+        Attributes cmd = new Attributes();
+        cmd.setInt(Tag.CommandField, VR.US, 0x8021);
+        cmd.setInt(Tag.Status, VR.US, Status.Success);
+
+        int performingCount = association.getPerformingOperationCount();
+        try {
+            association.writeDimseRSP(presentationContext, cmd);
+        } finally {
+            Assert.assertEquals("Performing Operation count did not decrement",
+                    performingCount - 1, association.getPerformingOperationCount());
+            executorService.shutdown();
+        }
+    }
+
+    private class BadSocket extends Socket {
+
+        @Override public InputStream getInputStream() {
+            return new DummyInputStream();
+        }
+
+        @Override public OutputStream getOutputStream() {
+            return new BadOutputStream();
+        }
+    }
+
+    private class DummyInputStream extends InputStream {
+
+        @Override public int read() throws IOException {
+            try {
+                // Just a short sleep to simulate the blocking read for nextPDU
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+            }
+            return 0;
+        }
+    }
+
+    private class BadOutputStream extends OutputStream {
+
+        @Override public void write(int b) throws IOException {
+            throw new BadSocketException();
+        }
+    }
+
+    private class BadSocketException extends SocketException {
+    }
+}

--- a/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
+++ b/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
@@ -66,7 +66,7 @@ public class AssociationTest {
 
         Assert.assertEquals("Performing Operation count did not decrement",
                 performingCount - 1, association.getPerformingOperationCount());
-        executorService.shutdown();
+        executorService.shutdownNow();
     }
 
     private class BadSocket extends Socket {
@@ -86,7 +86,7 @@ public class AssociationTest {
 
         @Override public int read() throws IOException {
             try {
-                // Just a short sleep to simulate the blocking read for nextPDU
+                // Simulate the blocking read for nextPDU
                 semaphore.acquire();
             } catch (InterruptedException e) {
             }


### PR DESCRIPTION
Ensures the decrement of the counter always gets performed even when the response cannot be written.

Also adjusts the log level when logging an exception while attempting to process a request in order to retain in error logs to allow for logs to retrieved before the exception stacktrace rolls out of the server logs.