### PR TITLE
Decrement performing ops when exception occurs writing response

### DIFF
--- a/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/Association.java
@@ -749,10 +749,13 @@ public class Association {
             datasetType = Commands.getWithDatasetType();
         }
         cmd.setInt(Tag.CommandDataSetType, VR.US, datasetType);
-        encoder.writeDIMSE(pc, cmd, writer);
-        if (!Status.isPending(cmd.getInt(Tag.Status, 0))) {
-            decPerforming();
-            startIdleTimeout();
+        try {
+            encoder.writeDIMSE(pc, cmd, writer);
+        } finally {
+            if (!Status.isPending(cmd.getInt(Tag.Status, 0))) {
+                decPerforming();
+                startIdleTimeout();
+            }
         }
     }
 
@@ -1268,6 +1271,10 @@ public class Association {
         } else {
             LOG.warn("Attempted to close the association, but it was not ready for data transfer", new IOException("Association not ready for data transfer"));
         }
+    }
+
+    public int getPerformingOperationCount() {
+        return performing;
     }
 }
 

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/service/DicomServiceRegistry.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/service/DicomServiceRegistry.java
@@ -91,7 +91,7 @@ public class DicomServiceRegistry implements DimseRQHandler {
                     e.getLocalizedMessage());
             rspForDimseRQException(as, pc, dimse, cmd, e);
         } catch (DicomServiceException e) {
-            Association.LOG.info("{}: processing {} failed. Caused by:\t",
+            Association.LOG.error("{}: processing {} failed. Caused by:\t",
                     as,
                     dimse.toString(cmd, pc.getPCID(), pc.getTransferSyntax()),
                     e);

--- a/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
+++ b/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
@@ -12,6 +12,7 @@ import org.dcm4che3.data.Attributes;
 import org.dcm4che3.data.Tag;
 import org.dcm4che3.data.VR;
 import org.dcm4che3.net.pdu.AAssociateAC;
+import org.dcm4che3.net.pdu.AAssociateRJ;
 import org.dcm4che3.net.pdu.PresentationContext;
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,6 +30,19 @@ public class AssociationTest {
 
         Device device = new Device();
         device.setExecutor(executorService);
+        device.setAssociationMonitor(new AssociationMonitor() {
+            @Override public void onAssociationEstablished(Association as) {
+            }
+
+            @Override public void onAssociationFailed(Association as, Throwable e) {
+            }
+
+            @Override public void onAssociationRejected(Association as, AAssociateRJ aarj) {
+            }
+
+            @Override public void onAssociationAccepted(Association as) {
+            }
+        });
 
         Connection connection = new Connection();
         connection.setDevice(device);

--- a/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
+++ b/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
@@ -1,0 +1,86 @@
+package org.dcm4che3.net;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.Tag;
+import org.dcm4che3.data.VR;
+import org.dcm4che3.net.pdu.AAssociateAC;
+import org.dcm4che3.net.pdu.PresentationContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the org.dcm4che3.net.Association class
+ */
+public class AssociationTest {
+
+    @Test(expected = BadSocketException.class)
+    public void writeDimseRsp_pduEncoderThrowsException_performingRqCounterDecremented() throws IOException {
+        Socket socket = new BadSocket();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+        Device device = new Device();
+        device.setExecutor(executorService);
+
+        Connection connection = new Connection();
+        connection.setDevice(device);
+
+        Association association = new Association(null, connection, socket);
+        association.handle(new AAssociateAC());
+
+        PresentationContext presentationContext = new PresentationContext(1, "as", "ts");
+        Attributes cmd = new Attributes();
+        cmd.setInt(Tag.CommandField, VR.US, 0x8021);
+        cmd.setInt(Tag.Status, VR.US, Status.Success);
+
+        int performingCount = association.getPerformingOperationCount();
+        try {
+            association.writeDimseRSP(presentationContext, cmd);
+        } finally {
+            Assert.assertEquals("Performing Operation count did not decrement",
+                    performingCount - 1, association.getPerformingOperationCount());
+            executorService.shutdown();
+        }
+    }
+
+    private class BadSocket extends Socket {
+
+        @Override public InputStream getInputStream() {
+            return new DummyInputStream();
+        }
+
+        @Override public OutputStream getOutputStream() {
+            return new BadOutputStream();
+        }
+    }
+
+    private class DummyInputStream extends InputStream {
+
+        @Override public int read() throws IOException {
+            try {
+                // Just a short sleep to simulate the blocking read for nextPDU
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+            }
+            return 0;
+        }
+    }
+
+    private class BadOutputStream extends OutputStream {
+
+        @Override public void write(int b) throws IOException {
+            throw new BadSocketException();
+        }
+    }
+
+    private class BadSocketException extends SocketException {
+    }
+}

--- a/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
+++ b/dcm4che-net/src/test/java/org/dcm4che3/net/AssociationTest.java
@@ -66,7 +66,7 @@ public class AssociationTest {
 
         Assert.assertEquals("Performing Operation count did not decrement",
                 performingCount - 1, association.getPerformingOperationCount());
-        executorService.shutdown();
+        executorService.shutdownNow();
     }
 
     private class BadSocket extends Socket {
@@ -86,7 +86,7 @@ public class AssociationTest {
 
         @Override public int read() throws IOException {
             try {
-                // Just a short sleep to simulate the blocking read for nextPDU
+                // Simulate the blocking read for nextPDU
                 semaphore.acquire();
             } catch (InterruptedException e) {
             }


### PR DESCRIPTION
When writing the dimse response but an exception occurs, decrement the performing operations counter so that the Association can be torn down. Also, changes the log level when an exception occurs while performing a dimse request so that the errors appear in the error log and not roll out of the logs too quickly.