### PR TITLE
Adding XRay3DAngiographic to the MultiframeExtractor storage classes

### DIFF
--- a/dcm4che-emf/src/main/java/org/dcm4che3/emf/MultiframeExtractor.java
+++ b/dcm4che-emf/src/main/java/org/dcm4che3/emf/MultiframeExtractor.java
@@ -148,6 +148,7 @@ public class MultiframeExtractor {
         EnhancedXAImageExtractor(UID.XRayAngiographicImageStorage, true),
         EnhancedXRFImageExtractor(UID.XRayRadiofluoroscopicImageStorage, true),
         EnhancedPETImageExtractor(UID.PositronEmissionTomographyImageStorage, true),
+        XRay3DAngiographicImageExtractor(UID.XRay3DAngiographicImageStorage, true),
         NuclearMedicineImageExtractor(UID.NuclearMedicineImageStorage, false),
         UltrasoundMultiFrameImageExtractor(UID.UltrasoundImageStorage, false),
         MultiFrameGrayscaleByteSecondaryCaptureImageExtractor(UID.SecondaryCaptureImageStorage, false),
@@ -177,6 +178,7 @@ public class MultiframeExtractor {
         impls.put(UID.EnhancedXAImageStorage, Impl.EnhancedXAImageExtractor);
         impls.put(UID.EnhancedXRFImageStorage, Impl.EnhancedXRFImageExtractor);
         impls.put(UID.EnhancedPETImageStorage, Impl.EnhancedPETImageExtractor);
+        impls.put(UID.XRay3DAngiographicImageStorage, Impl.XRay3DAngiographicImageExtractor);
         impls.put(UID.NuclearMedicineImageStorage, Impl.NuclearMedicineImageExtractor);
         impls.put(UID.UltrasoundMultiFrameImageStorage, Impl.UltrasoundMultiFrameImageExtractor);
         impls.put(UID.MultiFrameGrayscaleByteSecondaryCaptureImageStorage, Impl.MultiFrameGrayscaleByteSecondaryCaptureImageExtractor);


### PR DESCRIPTION
We'd like to be able to extract multiframe DICOMs that are using the X-Ray 3D Angiographic Storage Class (1.2.840.10008.5.1.4.1.1.13.1.1) with dcm4che. Our initial testing internally suggests this change should make that possible.

There don't appear to be any tests around MultiframeExtractor that I could find, is there somewhere I should be adding one? 

