### PR TITLE
IEI-188525 "Port in use" error when stopping then starting the Audit service right away

### DIFF
--- a/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/ApplicationEntityCache.java
+++ b/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/ApplicationEntityCache.java
@@ -57,6 +57,7 @@ public class ApplicationEntityCache
         return conf.findApplicationEntity(key);
     }
 
+    @Override
     public ApplicationEntity findApplicationEntity(String aet)
             throws ConfigurationException {
         ApplicationEntity ae = get(aet);

--- a/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/ConfigurationCache.java
+++ b/dcm4che-conf/dcm4che-conf-api/src/main/java/org/dcm4che3/conf/api/ConfigurationCache.java
@@ -56,14 +56,11 @@ public abstract class ConfigurationCache<C,T> {
         }
     }
 
-    private final HashMap<String, CacheEntry<T>> cache =
-            new HashMap<String, CacheEntry<T>>();
+    private final HashMap<String, CacheEntry<T>> cache = new HashMap<>();
     private final C conf;
     private long staleTimeout;
 
-    public ConfigurationCache(C conf) {
-        if (conf == null)
-            throw new NullPointerException();
+    protected ConfigurationCache(C conf) {
         this.conf = conf;
     }
 
@@ -78,7 +75,6 @@ public abstract class ConfigurationCache<C,T> {
     public void clear() {
         cache.clear();
     }
-
 
     public T get(String key) throws ConfigurationException {
         long now = System.currentTimeMillis();


### PR DESCRIPTION
- Removed null check and throwing NPE from base ConfigurationCache class as the implementing classes might not even use it and it shouldn't be there to begin with.