### PR TITLE
Add a bit of Javadoc to DatePrecision

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/DatePrecision.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/DatePrecision.java
@@ -59,7 +59,28 @@ public class DatePrecision {
         this.includeTimezone = includeTimezone;
     }
 
+    /**
+     * Specifies the precision of a date value (e.g. Calendar.MILLISECOND for millisecond precision).
+     *
+     * For methods that format a date (e.g. {@link Attributes#setDate}), this acts as an input to specify the precision
+     * that should be stored.
+     *
+     * For methods that parse a date (e.g. {@link Attributes#getDate}), this field will be used as a return value. It
+     * returns the precision of the date that was parsed.
+     */
     public int lastField;
+
+    /**
+     * Specifies whether a formatted date includes a timezone in the stored value itself.
+     *
+     * This is only used for values of {@link VR#DT}.
+     *
+     * For methods that format a DT date time, this acts as an input to specify whether the timezone offset should
+     * be appended to the formatted date (e.g. "+0100").
+     *
+     * For methods that parse a DT date time, this field will be used as a return value. It returns whether the parsed
+     * date included a timezone offset.
+     */
     public boolean includeTimezone;
 
 }


### PR DESCRIPTION
This is a bit of explaining Javadoc that was taken over from the older PR https://github.com/dcm4che/dcm4che/pull/1164 which was not merged.