### PR TITLE
Removed the direct access to the variables from the equals method

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Code.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Code.java
@@ -157,15 +157,15 @@ public class Code implements Serializable {
             return false;
         Code other = (Code) o;
         return equalsIgnoreMeaning(other)
-                && codeMeaning.equals(other.codeMeaning);
+                && Objects.equals(codeMeaning, other.getCodeMeaning());
     }
 
     public boolean equalsIgnoreMeaning(Code other) {
         if (other == this)
             return true;
-        return codeValue.equals(other.codeValue)
-                && Objects.equals(codingSchemeDesignator, other.codingSchemeDesignator)
-                && Objects.equals(codingSchemeVersion, other.codingSchemeVersion);
+        return Objects.equals(codeValue, other.getCodeValue())
+                && Objects.equals(codingSchemeDesignator, other.getCodingSchemeDesignator())
+                && Objects.equals(codingSchemeVersion, other.getCodingSchemeVersion());
     }
 
     @Override

--- a/dcm4che-core/src/main/java/org/dcm4che3/data/IDWithIssuer.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/IDWithIssuer.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.Objects;
 
 import org.dcm4che3.util.StringUtils;
 
@@ -145,16 +146,10 @@ public class IDWithIssuer {
         if (!(obj instanceof IDWithIssuer))
             return false;
         IDWithIssuer other = (IDWithIssuer) obj;
-        return id.equals(other.id) &&
-                (typeOfPatientID == null
-                    ? other.typeOfPatientID == null
-                    : typeOfPatientID.equals(typeOfPatientID)) &&
-                (identifierTypeCode == null
-                    ? other.identifierTypeCode == null
-                    : identifierTypeCode.equals(identifierTypeCode)) &&
-                (issuer == null
-                    ? other.issuer == null
-                    : issuer.equals(other.issuer));
+        return  (Objects.equals(id, other.getID())) &&
+                (Objects.equals(typeOfPatientID, other.getTypeOfPatientID())) &&
+                (Objects.equals(identifierTypeCode, other.getIdentifierTypeCode())) &&
+                (Objects.equals(issuer, other.issuer));
     }
 
     public boolean matches(IDWithIssuer other) {

--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Issuer.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Issuer.java
@@ -39,6 +39,7 @@
 package org.dcm4che3.data;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.dcm4che3.util.StringUtils;
 
@@ -187,13 +188,13 @@ public class Issuer implements Serializable {
         if (!(o instanceof Issuer))
             return false;
         Issuer other = (Issuer) o;
-        return equals(localNamespaceEntityID, other.localNamespaceEntityID)
-                && equals(universalEntityID, other.universalEntityID)
-                && equals(universalEntityIDType, other.universalEntityIDType);
+        return equals(localNamespaceEntityID, other.getLocalNamespaceEntityID())
+                && equals(universalEntityID, other.getUniversalEntityID())
+                && equals(universalEntityIDType, other.getUniversalEntityIDType());
     }
 
     private boolean equals(String s1, String s2) {
-        return s1 == s2 || s1 != null && s1.equals(s2);
+        return Objects.equals(s1, s2);
     }
 
     public boolean matches(Issuer other) {
@@ -201,16 +202,16 @@ public class Issuer implements Serializable {
             return true;
 
         boolean matchLocal = localNamespaceEntityID != null
-                && other.localNamespaceEntityID != null;
+                && other.getLocalNamespaceEntityID() != null;
         boolean matchUniversal = universalEntityID != null
-                && other.universalEntityID != null;
+                && other.getUniversalEntityID() != null;
 
         return (matchLocal || matchUniversal)
             && (!matchLocal
-                || localNamespaceEntityID.equals(other.localNamespaceEntityID))
+                || localNamespaceEntityID.equals(other.getLocalNamespaceEntityID()))
             && (!matchUniversal
-                || universalEntityID.equals(other.universalEntityID)
-                && universalEntityIDType.equals(other.universalEntityIDType));
+                || universalEntityID.equals(other.getUniversalEntityID())
+                && universalEntityIDType.equals(other.getUniversalEntityIDType()));
     }
 
     @Override


### PR DESCRIPTION
[Class has direct access to variables.docx](https://github.com/dcm4che/dcm4che/files/9141985/Class.has.direct.access.to.variables.docx)


Removed Direct access to variables in the classes that were causing problems while comparing hibernate proxy with itself.
Please refer the attached document.