### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -756,8 +757,7 @@ public class DicomInputStream extends FilterInputStream
             skipFully(length);
         } else {
             if (blkOut == null) {
-                File blkfile = File.createTempFile(blkFilePrefix,
-                        blkFileSuffix, blkDirectory);
+                File blkfile = Files.createTempFile(blkDirectory.toPath(), blkFilePrefix, blkFileSuffix).toFile();
                 if (blkFiles == null)
                     blkFiles = new ArrayList<File>();
                 blkFiles.add(blkfile);

--- a/dcm4che-core/src/test/java/org/dcm4che3/io/DicomOutputStreamTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/io/DicomOutputStreamTest.java
@@ -1,6 +1,7 @@
 package org.dcm4che3.io;
 
 import java.io.*;
+import java.nio.file.Files;
 
 import org.dcm4che3.data.*;
 import org.dcm4che3.util.UIDUtils;
@@ -19,7 +20,7 @@ public class DicomOutputStreamTest {
 
     @Before
     public void setUp() throws IOException {
-        file = File.createTempFile("test", ".dcm");
+        file = Files.createTempFile("test", ".dcm").toFile();
     }
 
     @After

--- a/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
+++ b/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
@@ -56,6 +56,7 @@ import java.net.Socket;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.security.AccessController;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedAction;
@@ -784,7 +785,7 @@ public class AuditLogger {
 
         File f = null;
         try {
-            f = File.createTempFile(spoolFileNamePrefix, spoolFileNameSuffix, spoolDirectory());
+            f = Files.createTempFile(spoolDirectory().toPath(), spoolFileNamePrefix, spoolFileNameSuffix).toFile();
 
             LOG.info("Spool audit message to {}", f);
             FileOutputStream out = new FileOutputStream(f);

--- a/dcm4che-tool/dcm4che-tool-dcmdir/src/main/java/org/dcm4che3/tool/dcmdir/DcmDir.java
+++ b/dcm4che-tool/dcm4che-tool-dcmdir/src/main/java/org/dcm4che3/tool/dcmdir/DcmDir.java
@@ -42,6 +42,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.List;
@@ -328,7 +329,7 @@ public class DcmDir {
     }
 
     private void compact(File f, File bak) throws IOException {
-        File tmp = File.createTempFile("DICOMDIR", null, f.getParentFile());
+        File tmp = Files.createTempFile(f.getParentFile().toPath(), "DICOMDIR", null).toFile();
         DicomDirReader r = new DicomDirReader(f);
         try {
             fsInfo.setFilesetUID(r.getFileSetUID());

--- a/dcm4che-tool/dcm4che-tool-ihe/dcm4che-tool-ihe-modality/src/main/java/org/dcm4che3/tool/ihe/modality/Modality.java
+++ b/dcm4che-tool/dcm4che-tool-ihe/dcm4che-tool-ihe-modality/src/main/java/org/dcm4che3/tool/ihe/modality/Modality.java
@@ -53,6 +53,7 @@ import org.dcm4che3.tool.storescu.StoreSCU;
 import org.dcm4che3.util.UIDUtils;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.security.GeneralSecurityException;
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -362,7 +363,7 @@ public class Modality {
             File tmpDir, final MppsSCU mppsscu, final StoreSCU storescu, final StgCmtSCU stgcmtscu)
             throws IOException {
         printNextStepMessage("Will now scan files in " + fnames);
-        File tmpFile = File.createTempFile(tmpPrefix, tmpSuffix, tmpDir);
+        File tmpFile = Files.createTempFile(tmpDir.toPath(), tmpPrefix, tmpSuffix).toFile();
         tmpFile.deleteOnExit();
         final BufferedWriter fileInfos = new BufferedWriter(new OutputStreamWriter(
                 new FileOutputStream(tmpFile)));

--- a/dcm4che-tool/dcm4che-tool-storescp/src/main/java/org/dcm4che3/tool/storescp/StoreSCP.java
+++ b/dcm4che-tool/dcm4che-tool-storescp/src/main/java/org/dcm4che3/tool/storescp/StoreSCP.java
@@ -108,7 +108,7 @@ public class StoreSCP {
                 String cuid = rq.getString(Tag.AffectedSOPClassUID);
                 String iuid = rq.getString(Tag.AffectedSOPInstanceUID);
                 String tsuid = pc.getTransferSyntax();
-                File file = File.createTempFile(iuid, PART_EXT, storageDir);
+                File file = Files.createTempFile(storageDir.toPath(), iuid, PART_EXT).toFile();
                 try {
                     storeTo(as, as.createFileMetaInformation(iuid, cuid, tsuid),
                             data, file);

--- a/dcm4che-tool/dcm4che-tool-storescu/src/main/java/org/dcm4che3/tool/storescu/StoreSCU.java
+++ b/dcm4che-tool/dcm4che-tool-storescu/src/main/java/org/dcm4che3/tool/storescu/StoreSCU.java
@@ -62,6 +62,7 @@ import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
+import java.nio.file.Files;
 import java.security.GeneralSecurityException;
 import java.text.MessageFormat;
 import java.util.*;
@@ -381,7 +382,7 @@ public class StoreSCU {
 
     public void scanFiles(List<String> fnames, boolean printout)
             throws IOException {
-        tmpFile = File.createTempFile(tmpPrefix, tmpSuffix, tmpDir);
+        tmpFile = Files.createTempFile(tmpDir.toPath(), tmpPrefix, tmpSuffix).toFile();
         tmpFile.deleteOnExit();
         final BufferedWriter fileInfos = new BufferedWriter(
                 new OutputStreamWriter(new FileOutputStream(tmpFile)));

--- a/dcm4che-tool/dcm4che-tool-stowrs/src/main/java/org/dcm4che3/tool/stowrs/StowRS.java
+++ b/dcm4che-tool/dcm4che-tool-stowrs/src/main/java/org/dcm4che3/tool/stowrs/StowRS.java
@@ -756,7 +756,7 @@ public class StowRS {
 
     private void scanFilesNoLimit(List<String> files) {
         try {
-            File tmpFile = File.createTempFile("stowrs-", null, null);
+            File tmpFile = Files.createTempFile("stowrs-", null).toFile();
             tmpFile.deleteOnExit();
             StowChunk stowChunk = new StowChunk(tmpFile);
             try (FileOutputStream out = new FileOutputStream(tmpFile)) {
@@ -777,7 +777,7 @@ public class StowRS {
             return;
 
         try {
-            File tmpFile = File.createTempFile(tmpPrefix, tmpSuffix, tmpDir);
+            File tmpFile = Files.createTempFile(tmpDir.toPath(), tmpPrefix, tmpSuffix).toFile();
             tmpFile.deleteOnExit();
             StowChunk stowChunk = new StowChunk(tmpFile);
             try (FileOutputStream out = new FileOutputStream(tmpFile)) {
@@ -962,7 +962,7 @@ public class StowRS {
 
         try {
             DicomInputStream in = new DicomInputStream(path.toFile());
-            File tmpFile = File.createTempFile("stowrs-", null, null);
+            File tmpFile = Files.createTempFile("stowrs-", null).toFile();
             tmpFile.deleteOnExit();
             Attributes fmi = in.readFileMetaInformation();
             Attributes data = in.readDataset();


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
