### PR TITLE
Allow length > 2Gib for BulkData

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/SAXWriter.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/SAXWriter.java
@@ -249,7 +249,7 @@ public class SAXWriter implements DicomInputHandler {
             startElement("DicomAttribute");
             if (vr == VR.SQ || len == -1) {
                 dis.readValue(dis, attrs);
-            } else if (len > 0) {
+            } else if (len != 0) {
                 if (dis.isIncludeBulkDataURI()) {
                     writeBulkData(dis.createBulkData(dis));
                 } else {


### PR DESCRIPTION
Our service organization is getting more and more cases, where customers have DICOM data with values above the 2Gib limit that dcm4che currently supports.

In one particular case we received a multiframe which is uncompressed and the PixelData is slightly above 2Gib. While it is obviously not very smart to send in such data uncompressed, as it could be represented compressed without problems (and much more efficiently), we cannot really do anything about it as the data comes from a thirdparty and the customer expects us to be able to archive such data.

This PR is now a first suggestion (work in progress!) to fix the most important use cases for us. We want to be able to compress such data, and additionally I changed the SAXWriter a bit, so that it can be successfully represented as XML (with BulkData references).

The compression using the Transcoder seems to work perfectly with those changes (tested with dcm2dcm command).

Note that with the current change, the BulkData reference still has a negative number as length in the URI (as can be tested with the dcm2xml command). This should be probably still be changed.
Also, within the DicomInputStream there are many more places where currently the int length is used, where instead the longLength() should be used.

@gunterze, I would like to get your general feedback on this improvement, before continuing any work on it.
Thanks!

Relates to: https://github.com/dcm4che/dcm4che/issues/1243#issuecomment-1297580711 and IEI-175871