### PR TITLE
Update native codecs to 4.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dcm4che uses a native library for the compression and decompression of images. H
 | Linux   | s390x        | linux-s390x    | GLIBC_2.7              |
 | Windows | x86 64-bit   | windows-x86-64 | Windows 7, 8, 10 or 11 |
 | Windows | x86 32-bit   | windows-x86    | Windows 7, 8, 10 or 11 |
-| Mac OS  | x86 64-bit   | macosx-x86-64  | Mac OS 10.9 or higher  |
+| Mac OS  | x86 64-bit   | macosx-x86-64  | Mac OS 10.13 or higher |
 | Mac OS  | ARM 64-bit   | macosx-aarch64 | Mac OS 11 or higher    |
 
 Build

--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJ2kImageWriter.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJ2kImageWriter.java
@@ -110,12 +110,14 @@ class NativeJ2kImageWriter extends ImageWriter {
             ImageCV mat = null;
             try {
                 // Band interleaved mode (PlanarConfiguration = 1) is converted to pixel interleaved
-                // So the input image has always a pixel interleaved mode mode((PlanarConfiguration = 0)
-                mat = ImageConversion.toMat(renderedImage, param.getSourceRegion(), false);
+                // So the input image has always a pixel interleaved mode((PlanarConfiguration = 0)
+                boolean signed = desc.isSigned();
+                // J2K codec requires BGR as input color model
+                mat = ImageConversion.toMat(renderedImage, param.getSourceRegion(), true, signed);
 
                 int cvType = mat.type();
                 int channels = CvType.channels(cvType);
-                boolean signed = desc.isSigned();
+                int epi = channels == 1 ? Imgcodecs.EPI_Monochrome2 : Imgcodecs.EPI_RGB;
                 int dcmFlags = signed ? Imgcodecs.DICOM_FLAG_SIGNED : Imgcodecs.DICOM_FLAG_UNSIGNED;
 
                 int[] params = new int[16];
@@ -127,6 +129,7 @@ class NativeJ2kImageWriter extends ImageWriter {
                 params[Imgcodecs.DICOM_PARAM_COMPONENTS] = channels; // Number of components
                 params[Imgcodecs.DICOM_PARAM_BITS_PER_SAMPLE] = desc.getBitsCompressed(); // Bits per sample
                 params[Imgcodecs.DICOM_PARAM_INTERLEAVE_MODE] = Imgcodecs.ILV_SAMPLE; // Interleave mode
+                params[Imgcodecs.DICOM_PARAM_COLOR_MODEL] = epi; // Photometric interpretation
                 params[Imgcodecs.DICOM_PARAM_J2K_COMPRESSION_FACTOR] = j2kParams.getCompressionRatiofactor(); // JPEG-2000 lossy ratio factor
 
                 dicomParams = new MatOfInt(params);

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <slf4j.version>1.7.32</slf4j.version>
     <logback.version>1.2.9</logback.version>
-    <weasis.core.img.version>4.5.5</weasis.core.img.version>
-    <weasis.opencv.native.version>4.5.5-dcm</weasis.opencv.native.version>
+    <weasis.core.img.version>4.6.0</weasis.core.img.version>
+    <weasis.opencv.native.version>4.6.0-dcm</weasis.opencv.native.version>
     <keycloak.version>20.0.2</keycloak.version>
     <jbossws-cxf-client.version>5.5.0.Final</jbossws-cxf-client.version>
     <apache-cxf.version>3.4.7</apache-cxf.version>


### PR DESCRIPTION
* Update to OpenCV 4.6.0
* Update to CharLS 2.3.4
* Update to OpenJPEG 2.5.0

As the OpenJPEG integration has been completely redesigned, it is necessary to validate that this encoding works properly.

Note also that the OpenJPEG modifications already allow the reading of [DICOM HTJ2k](https://www.dicomstandard.org/workitems) (even if it doesn't exist yet officially in DICOM)