### PR TITLE
IEI-175871 DCM4CHE3 does not support elements> 2GB in length

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Fragments.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Fragments.java
@@ -266,7 +266,7 @@ public class Fragments extends ArrayList<Object> implements Value {
         if(value == Value.NULL) {
             length = 0;
         } else if(value instanceof BulkData) {
-            length = ((BulkData) value).length();
+            length = ((BulkData) value).longLength();
         } else {
             length = ((byte[]) value).length;
         }

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/SAXWriter.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/SAXWriter.java
@@ -236,7 +236,7 @@ public class SAXWriter implements DicomInputHandler {
             throws IOException {
         int tag = dis.tag();
         VR vr = dis.vr();
-        int len = dis.length();
+        long len = dis.unsignedLength();
         if (TagUtils.isGroupLength(tag) || TagUtils.isPrivateCreator(tag)) {
             dis.readValue(dis, attrs);
         } else if (dis.getIncludeBulkData() == IncludeBulkData.NO
@@ -307,7 +307,7 @@ public class SAXWriter implements DicomInputHandler {
     @Override
     public void readValue(DicomInputStream dis, Fragments frags)
             throws IOException {
-        int len = dis.length();
+        long len = dis.unsignedLength();
         Object frag = ByteUtils.EMPTY_BYTES;
         if (len > 0)
             switch (dis.getIncludeFragmentBulkData()) {

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/stream/BulkURIImageInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/stream/BulkURIImageInputStream.java
@@ -52,11 +52,11 @@ public class BulkURIImageInputStream extends ImageInputStreamImpl {
 
     private final ImageInputStream iis;
     private final long offset;
-    private final int length;
+    private final long length;
 
 
 
-    public BulkURIImageInputStream(ImageInputStream iis, long offset, int length) throws IOException {
+    public BulkURIImageInputStream(ImageInputStream iis, long offset, long length) throws IOException {
         this.iis = iis;
         this.offset = offset;
         this.length = length;

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/stream/CloseableImageInputStreamAdapter.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/stream/CloseableImageInputStreamAdapter.java
@@ -96,7 +96,7 @@ public class CloseableImageInputStreamAdapter extends InputStream {
 
     @Override
     public long skip(long n) throws IOException {
-        return iis.skipBytes((int) n);
+        return iis.skipBytes(n);
     }
 
     @Override

--- a/dcm4che-core/src/main/java/org/dcm4che3/util/StreamUtils.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/util/StreamUtils.java
@@ -100,12 +100,15 @@ public class StreamUtils {
         copy(in, out, new byte[COPY_BUFFER_SIZE]);
     }
 
-    public static  void copy(InputStream in, OutputStream out, int len,
-            byte buf[]) throws IOException {
+    public static  void copy(InputStream in, OutputStream out, int len, byte buf[]) throws IOException {
+        copy(in, out, unsignedInt(len), buf);
+    }
+
+    public static  void copy(InputStream in, OutputStream out, long len, byte buf[]) throws IOException {
         if (len < 0)
             throw new IndexOutOfBoundsException();
         while (len > 0) {
-            int count = in.read(buf, 0, Math.min(len, buf.length));
+            int count = in.read(buf, 0, (int) Math.min(len, buf.length));
             if (count < 0)
                 throw new EOFException();
             out.write(buf, 0, count);
@@ -113,12 +116,20 @@ public class StreamUtils {
         }
     }
 
-    public static  void copy(InputStream in, OutputStream out, int len)
-            throws IOException {
-        copy(in, out, len, new byte[Math.min(len, COPY_BUFFER_SIZE)]);
+    public static  void copy(InputStream in, OutputStream out, int len) throws IOException {
+        copy(in, out, unsignedInt(len));
+    }
+
+    public static  void copy(InputStream in, OutputStream out, long len) throws IOException {
+        copy(in, out, len & 0xffffffffL, new byte[(int) Math.min(len, COPY_BUFFER_SIZE)]);
     }
 
     public static void copy(InputStream in, OutputStream out, int len,
+            int swapBytes, byte buf[]) throws IOException {
+        copy(in, out, unsignedInt(len), swapBytes, buf);
+    }
+
+    public static void copy(InputStream in, OutputStream out, long len,
             int swapBytes, byte buf[]) throws IOException {
         if (swapBytes == 1) {
             copy(in, out, len, buf);
@@ -130,7 +141,7 @@ public class StreamUtils {
             throw new IllegalArgumentException("length: " + len);
         int off = 0;
         while (len > 0) {
-            int count = in.read(buf, off, Math.min(len, buf.length - off));
+            int count = in.read(buf, off, (int) Math.min(len, buf.length - off));
             if (count < 0)
                 throw new EOFException();
             len -= count;
@@ -155,8 +166,17 @@ public class StreamUtils {
     }
 
     public static void copy(InputStream in, OutputStream out, int len, int swapBytes) throws IOException {
+        copy(in, out, unsignedInt(len), swapBytes);
+    }
+
+    private static long unsignedInt(int len) {
+        return len & 0xffffffffL;
+    }
+
+    public static void copy(InputStream in, OutputStream out, long len,
+            int swapBytes) throws IOException {
         copy(in, out, len, swapBytes,
-                new byte[Math.min(len, COPY_BUFFER_SIZE)]);
+                new byte[(int) Math.min(len, COPY_BUFFER_SIZE)]);
     }
 
     public static InputStream openFileOrURL(String name) throws IOException {

--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/metadata/BulkDataDicomImageAccessor.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/metadata/BulkDataDicomImageAccessor.java
@@ -140,7 +140,7 @@ public class BulkDataDicomImageAccessor implements DicomImageAccessor {
             long pixelDataLength = Fragments.length(getPixelDataValue());
             if(pixelDataLength % frameLength <= 1) {
                 // Must be within 1 bytes to account for padding
-                frames = (int) pixelDataLength / frameLength;
+                frames = (int)(pixelDataLength / frameLength);
             }
             else {
                 // Number of frames is ambiguous:  return -1.
@@ -180,7 +180,7 @@ public class BulkDataDicomImageAccessor implements DicomImageAccessor {
         else {
             // Uncompressed data stored directly into the PixelData tag.
             int frameLength = calculateFrameLength();
-            long offset  = frameLength * frameIndex;
+            long offset = (long) frameLength * frameIndex;
 
             ImageInputStream iisOfPixelData;
             if(pixelData instanceof BulkData) {

--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/stream/EncapsulatedPixelDataImageInputStream.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/stream/EncapsulatedPixelDataImageInputStream.java
@@ -118,7 +118,7 @@ public class EncapsulatedPixelDataImageInputStream extends MemoryCacheImageInput
             endOfStream = true;
             return false;
         }
-        fragmEndPos = streamPos + dis.length();
+        fragmEndPos = streamPos + dis.unsignedLength();
         mark();
         fragmStartWord = (super.read() << 8) | super.read();
         reset();

--- a/dcm4che-imageio/src/test/java/org/dcm4che3/imageio/dcm/TestDicomImageReader.java
+++ b/dcm4che-imageio/src/test/java/org/dcm4che3/imageio/dcm/TestDicomImageReader.java
@@ -140,11 +140,11 @@ public class TestDicomImageReader {
         DicomImageReader.generateOffsetLengths(pixelDataFragments, offsets.length, basicOffsetTable, longOffsets[0]);
         assertThat(pixelDataFragments).hasSize(offsets.length)
         .contains(
-                new BulkData("compressedPixelData://",longOffsets[0]+8,longOffsets[1]-longOffsets[0]-8,false),
-                new BulkData("compressedPixelData://",longOffsets[1]+8,longOffsets[2]-longOffsets[1]-8,false),
-                new BulkData("compressedPixelData://",longOffsets[2]+8,longOffsets[3]-longOffsets[2]-8,false),
-                new BulkData("compressedPixelData://",longOffsets[3]+8,longOffsets[4]-longOffsets[3]-8,false),
-                new BulkData("compressedPixelData://",longOffsets[4]+8,longOffsets[5]-longOffsets[4]-8,false),
+                new BulkData("compressedPixelData://",longOffsets[0]+8, longOffsets[1]-longOffsets[0]-8,false),
+                new BulkData("compressedPixelData://",longOffsets[1]+8, longOffsets[2]-longOffsets[1]-8,false),
+                new BulkData("compressedPixelData://",longOffsets[2]+8, longOffsets[3]-longOffsets[2]-8,false),
+                new BulkData("compressedPixelData://",longOffsets[3]+8, longOffsets[4]-longOffsets[3]-8,false),
+                new BulkData("compressedPixelData://",longOffsets[4]+8, longOffsets[5]-longOffsets[4]-8,false),
                 new BulkData("compressedPixelData://",longOffsets[5]+8,-1,false),
                 new BulkData("compressedPixelData://", -1, -1, false),
                 new BulkData("compressedPixelData://", -1, -1, false));

--- a/dcm4che-json/src/main/java/org/dcm4che3/json/JSONWriter.java
+++ b/dcm4che-json/src/main/java/org/dcm4che3/json/JSONWriter.java
@@ -188,7 +188,7 @@ public class JSONWriter implements DicomInputHandler {
             throws IOException {
         int tag = dis.tag();
         VR vr = dis.vr();
-        int len = dis.length();
+        long len = dis.unsignedLength();
         if (TagUtils.isGroupLength(tag)) {
             dis.readValue(dis, attrs);
         } else if (dis.getIncludeBulkData() == IncludeBulkData.NO

--- a/dcm4che-tool/dcm4che-tool-dcmdump/src/main/java/org/dcm4che3/tool/dcmdump/DcmDump.java
+++ b/dcm4che-tool/dcm4che-tool-dcmdump/src/main/java/org/dcm4che3/tool/dcmdump/DcmDump.java
@@ -57,6 +57,7 @@ import org.dcm4che3.data.VR;
 import org.dcm4che3.io.DicomInputHandler;
 import org.dcm4che3.io.DicomInputStream;
 import org.dcm4che3.tool.common.CLIUtils;
+import org.dcm4che3.util.ByteUtils;
 import org.dcm4che3.util.TagUtils;
 
 /**
@@ -119,7 +120,7 @@ public class DcmDump implements DicomInputHandler {
             return;
         }
         int tag = dis.tag();
-        byte[] b = dis.readValue();
+        byte[] b = probeValue(dis);
         line.append(" [");
         if (vr.prompt(b, dis.bigEndian(),
                 attrs.getSpecificCharacterSet(),
@@ -134,6 +135,16 @@ public class DcmDump implements DicomInputHandler {
                 || tag == Tag.SpecificCharacterSet
                 || TagUtils.isPrivateCreator(tag))
             attrs.setBytes(tag, vr, b);
+    }
+
+    private byte[] probeValue(DicomInputStream dis) throws IOException {
+        long len = dis.unsignedLength();
+        if (len == 0) return ByteUtils.EMPTY_BYTES;
+        int read = (int) Math.min(len, (width + 7) & ~7);
+        byte[] b = new byte[read];
+        dis.readFully(b);
+        dis.skipFully(len - read);
+        return b;
     }
 
     @Override
@@ -178,7 +189,7 @@ public class DcmDump implements DicomInputHandler {
         VR vr = dis.vr();
         if (vr != null)
             line.append(vr).append(' ');
-        line.append('#').append(dis.length());
+        line.append('#').append(dis.unsignedLength());
     }
 
     private void appendKeyword(DicomInputStream dis, StringBuilder line) {
@@ -201,7 +212,7 @@ public class DcmDump implements DicomInputHandler {
 
     private void appendFragment(StringBuilder line, DicomInputStream dis,
             VR vr) throws IOException {
-        byte[] b = dis.readValue();
+        byte[] b = probeValue(dis);
         line.append(" [");
         if (vr.prompt(b, dis.bigEndian(), null, 
                 width - line.length() - 1, line)) {


### PR DESCRIPTION
- Cherry picked commits 28a3a5b2a02eb96d920d80dab7bc670924a0f7b9 and 930f9ac849f2a12a5db33c8adf2355ac36c30203 from master branch
- Full manual merge for BulkData.java and partial manual merge for DicomInputStream.java, the rest were automatic.
- Additional fixes in CloseableImageInputStreamAdapter and BulkDataDicomImageAccessor since these don't exist in master