### PR TITLE
Fix compression of pixel data when pixel data is larger than 2GB

### DIFF
--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Compressor.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Compressor.java
@@ -384,7 +384,7 @@ public class Compressor extends Decompressor implements Closeable {
         iis.setByteOrder(pixeldata.bigEndian()
                 ? ByteOrder.BIG_ENDIAN
                 : ByteOrder.LITTLE_ENDIAN);
-        iis.seek(pixeldata.offset() + frameLength * frameIndex);
+        iis.seek(pixeldata.offset() + (long) frameLength * frameIndex);
         DataBuffer db = bi.getRaster().getDataBuffer();
         switch (db.getDataType()) {
         case DataBuffer.TYPE_BYTE:


### PR DESCRIPTION
Correct issue in calculation of file offset when frameLength * frameIndex is larger than maximum 32 bit integer value.

This issue prevents compression of pixel data when pixel data is larger than 2GB.