### PR TITLE
IEI-175871 DCM4CHE3 does not support elements> 2GB in length

### DIFF
--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Compressor.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Compressor.java
@@ -362,12 +362,12 @@ public class Compressor implements Closeable {
             iis.setByteOrder(((BulkData)pixels).bigEndian
                     ? ByteOrder.BIG_ENDIAN
                     : ByteOrder.LITTLE_ENDIAN);
-            iis.seek(((BulkData)pixels).offset() + imageParams.getFrameLength() * frameIndex);
+            iis.seek(((BulkData)pixels).offset() + (long) imageParams.getFrameLength() * frameIndex);
         } else {
             iis.setByteOrder(dataset.bigEndian()
                     ? ByteOrder.BIG_ENDIAN
                     : ByteOrder.LITTLE_ENDIAN);
-            iis.seek(imageParams.getFrameLength() * frameIndex);
+            iis.seek((long) imageParams.getFrameLength() * frameIndex);
         }
         DataBuffer db = uncompressedImage.getRaster().getDataBuffer();
         switch (db.getDataType()) {


### PR DESCRIPTION
- Correct issue in calculation of file offset when frameLength * frameIndex is larger than maximum 32 bit integer value. This issue prevents compression of pixel data when pixel data is larger than 2GB.

- Cherry picked commit 4b631d9b8ff51dc6ebdcbcbb443e1b6aeb27ab6c from master branch.