### PR TITLE
IEI-175871 DCM4CHE3 does not support elements> 2GB in length

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/BulkData.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/BulkData.java
@@ -271,9 +271,6 @@ public class BulkData implements Value {
     }
     
     public void setLength(long newLength) {
-        if( newLength!=-1 && (newLength & 1)==1 ) {
-            throw new IllegalArgumentException("Length of bulk data must be even, but was: "+newLength);
-        }
         if( newLength > 0xFFFFFFFEL || newLength<-1 ) {
             throw new IllegalArgumentException("Length of bulk data must not be negative or larger than an unsigned int, but was:"+newLength);
         }


### PR DESCRIPTION
- Fix bug in previous commit where DICOM tags in sequence with values greater than item delimitation tag are not handled properly.
- Remove check for even bulk data length. Both of these changes are inline with how code appears in master