### PR TITLE
Support reading 2.1GB+ DICOM files

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -729,6 +729,8 @@ public class DicomInputStream extends FilterInputStream
         } else if (length == BulkData.MAGIC_LEN
                 && super.in instanceof ObjectInputStream) {
             attrs.setValue(tag, vr, deserializeBulkData((ObjectInputStream) super.in));
+        } else if (length > Integer.MAX_VALUE) {
+            attrs.setValue(tag, vr, bulkDataCreator.createBulkData(this));
         } else if (includeBulkDataURI) {
             attrs.setValue(tag, vr, bulkDataCreator.createBulkData(this));
         } else {


### PR DESCRIPTION
This fork makes what I hope is a non-invasive change allowing DCM4CHE to read DICOM files that are 2.1GB or larger (e.g. tomography) by leveraging a recent improvement that allows `BulkData` to manage `long`-length data. When `DicomInputStream` encounters a tag with a length greater than the maximum allowed `byte[]` length, it injects a `BulkData` instance into the `Attributes` instead of throwing an exception that the tag value is too long.

I've tested this change through our own code although the easiest way to see it in action is to use `dcm2jpg` with a giant tomography file. Rather than throwing an exception, it produces a JPG of the first frame of the file. You can also see that `dcmdump` is able to dump the contents of the file including the first bit of `PixelData` that previously would cause an exception. I didn't exhaustively test the other tools but assuming `BulkData` is handled properly, this should _just work._

Appreciate the consideration. Thanks!