### PR TITLE
IEI-175871 DCM4CHE3 does not support elements> 2GB in length

### DIFF
--- a/dcm4che-core/src/test/java/org/dcm4che3/data/BulkDataTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/BulkDataTest.java
@@ -62,7 +62,7 @@ public class BulkDataTest {
     public static final String URL_OFFSET = "file:/path?offset=1234&length=5678";
     public static final String URL_OFFSETS = "file:/path?offsets=1,2,3,4&lengths=5,6,7,8";
     public static final long[] OFFSETS = { 1, 2, 3, 4 };
-    public static final long[] LENGTHS = { 5, 6, 7, 8 };
+    public static final int[] LENGTHS = { 5, 6, 7, 8 };
     public static final int OFFSET = 1234;
     public static final int LENGTH = 5678;
 


### PR DESCRIPTION
- Changes required for backwards compatibility with existing watchfolder code as well as allow watchfolder to use current hap pacs data code.

public BulkData(String uri, long offset, int length, boolean bigEndian)

This method is used by hap.pacs.data. The goal is to use the current hap.pacs.data for Watchfolder. But since hap.pacs.data is also used by the client then when Java compiles the hap.pacs.data code it records the method signature that is in dcm4che V5. The dcm4che version currently used by the client 5.29.0 does not yet have the change to support files >2GB, so the signature is with "int length". So for the time being I need to also have this in dcm4che generic-config. Once the client uses 5.29.2 then the signature will change to "long length" and this function will no longer be needed in dcm4che generic-config

public BulkData(String uri, long[] offsets, int[] lengths, boolean bigEndian)

This method is only used by the hap.pacs.data from 2019. This is the method that watchfolder is currently using but that I am hoping to get away from. I figured that since I was already making a change to the open source I would put this back just in case the watchfolder changes take longer than expected and so we have a plan B to continue to use the hap.pacs.data from 2019 but this is really not desirable.
I dug a bit deeper into just how exactly this BulkData(String, long[], ...) constructor is used. There is no current EI code which uses this constructor directly.
As stated in my earlier comment, the hap.pacs.data code from 2019 uses this constructor, so we need to have the constructor with the int[] as third argument if we want to make dcm4che compatible with this code from 2019. This, of course, doesn't rule out the possibility of having both int[] and long[] constructors.
The constructor is also used by the SAXWriter and JSonWriter classes. The impact of putting the int[] in the BulkData constructor for these two classes is that we will not support [pixel data] fragments > 2GB. This applies to fragments only and the total size of the pixel data can still be > 2GB.
Interesting thing here is that the format of the XML/JSon generated by dcm4che generic-config and master branches is different when dealing with fragments. So I think if we want to have fragments >2GB we should adopt the code same as in master branch. 
