### PR TITLE
Provide methods for setting multi-valued combined DateAndTime tags

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -2087,20 +2087,20 @@ public class Attributes implements Serializable {
         return set(privateCreator, tag, vr, vr.toValue(ds, applyTimezoneOffset ? getTimeZone() : null, precision));
     }
 
-    public void setDate(long tag, Date dt) {
+    public void setDate(long tag, Date... dt) {
         setDate(null, tag, dt);
     }
 
-    public void setDate(long tag, DatePrecision precision, Date dt) {
+    public void setDate(long tag, DatePrecision precision, Date... dt) {
         setDate(null, tag, precision, dt);
     }
 
-    public void setDate(String privateCreator, long tag, Date dt) {
+    public void setDate(String privateCreator, long tag, Date... dt) {
         setDate(privateCreator, tag, new DatePrecision(), dt);
     }
 
     public void setDate(String privateCreator, long tag,
-            DatePrecision precision, Date dt) {
+            DatePrecision precision, Date... dt) {
         int daTag = (int) (tag >>> 32);
         int tmTag = (int) tag;
         setDate(privateCreator, daTag, VR.DA, true, precision, dt);

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
@@ -311,11 +311,14 @@ public class AttributesTest {
         Attributes a = new Attributes();
         a.setDefaultTimeZone(DateUtils.timeZone("+0000"));
         a.setDate(Tag.StudyDateAndTime, new Date(0));
+        a.setDate(Tag.DateAndTimeOfLastCalibration, new Date(0), new Date(100000000));
         a.setString(Tag.PatientBirthDate, VR.DA, "19700101");
         a.setString(Tag.PatientBirthTime, VR.TM, "000000.000");
         a.setString(Tag.ContextGroupVersion, VR.DT, "19700101");
         assertEquals("19700101", a.getString(Tag.StudyDate));
         assertEquals("000000.000", a.getString(Tag.StudyTime));
+        assertArrayEquals(new String[] {"19700101", "19700102"}, a.getStrings(Tag.DateOfLastCalibration));
+        assertArrayEquals(new String[] {"000000.000", "034640.000"}, a.getStrings(Tag.TimeOfLastCalibration));
 
         a.setTimezoneOffsetFromUTC("+0100");
         assertEquals("19700101", a.getString(Tag.StudyDate));
@@ -323,6 +326,8 @@ public class AttributesTest {
         assertEquals("19700101", a.getString(Tag.PatientBirthDate));
         assertEquals("000000.000", a.getString(Tag.PatientBirthTime));
         assertEquals("19700101", a.getString(Tag.ContextGroupVersion));
+        assertArrayEquals(new String[] {"19700101", "19700102"}, a.getStrings(Tag.DateOfLastCalibration));
+        assertArrayEquals(new String[] {"010000.000", "044640.000"}, a.getStrings(Tag.TimeOfLastCalibration));
 
         a.setTimezoneOffsetFromUTC("-0100");
         assertEquals("19691231", a.getString(Tag.StudyDate));
@@ -330,6 +335,8 @@ public class AttributesTest {
         assertEquals("19700101", a.getString(Tag.PatientBirthDate));
         assertEquals("000000.000", a.getString(Tag.PatientBirthTime));
         assertEquals("19700101", a.getString(Tag.ContextGroupVersion));
+        assertArrayEquals(new String[] {"19691231", "19700102"}, a.getStrings(Tag.DateOfLastCalibration));
+        assertArrayEquals(new String[] {"230000.000", "024640.000"}, a.getStrings(Tag.TimeOfLastCalibration));
     }
 
     @Test


### PR DESCRIPTION
A small improvement to allow also multiple values for the `setDate(long tag, ...)` methods.

The corresponding `getDates(long tag)` methods already existed, so it is unclear to me why the setters were restricted to a single value only previously.

I also extended the unit tests to cover the changed methods and additionally also cover the updateTimezone() logic also for multi-valued DA and TM tags (which was previously uncovered, see https://sonarcloud.io/code?id=org.dcm4che%3Adcm4che-parent&selected=org.dcm4che%3Adcm4che-parent%3Adcm4che-core%2Fsrc%2Fmain%2Fjava%2Forg%2Fdcm4che3%2Fdata%2FAttributes.java ).