### PR TITLE
Add dcm4che-tool-dcmassoc

### DIFF
--- a/dcm4che-assembly/pom.xml
+++ b/dcm4che-assembly/pom.xml
@@ -309,6 +309,11 @@
     </dependency>
     <dependency>
       <groupId>org.dcm4che.tool</groupId>
+      <artifactId>dcm4che-tool-dcmassoc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.dcm4che.tool</groupId>
       <artifactId>dcm4che-tool-dcmbenchmark</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/dcm4che-assembly/src/bin/dcmassoc
+++ b/dcm4che-assembly/src/bin/dcmassoc
@@ -1,0 +1,58 @@
+#!/bin/sh
+# -------------------------------------------------------------------------
+# findscu  Launcher
+# -------------------------------------------------------------------------
+
+MAIN_CLASS=org.dcm4che3.tool.dcmassoc.DcmAssoc
+MAIN_JAR=dcm4che-tool-dcmassoc-${project.version}.jar
+
+DIRNAME="`dirname "$0"`"
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false;
+case "`uname`" in
+    CYGWIN*)
+        cygwin=true
+        ;;
+esac
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+    [ -n "$DCM4CHE_HOME" ] &&
+        DCM4CHE_HOME=`cygpath --unix "$DCM4CHE_HOME"`
+    [ -n "$JAVA_HOME" ] &&
+        JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+fi
+
+# Setup DCM4CHE_HOME
+if [ "x$DCM4CHE_HOME" = "x" ]; then
+    DCM4CHE_HOME=`cd "$DIRNAME"/..; pwd`
+fi
+
+# Setup the JVM
+if [ "x$JAVA_HOME" != "x" ]; then
+    JAVA=$JAVA_HOME/bin/java
+else
+    JAVA="java"
+fi
+
+# Setup the classpath
+CP="$DCM4CHE_HOME/etc/dcmassoc/"
+CP="$CP:$DCM4CHE_HOME/etc/certs/"
+CP="$CP:$DCM4CHE_HOME/lib/$MAIN_JAR"
+CP="$CP:$DCM4CHE_HOME/lib/dcm4che-core-${project.version}.jar"
+CP="$CP:$DCM4CHE_HOME/lib/dcm4che-net-${project.version}.jar"
+CP="$CP:$DCM4CHE_HOME/lib/dcm4che-tool-common-${project.version}.jar"
+CP="$CP:$DCM4CHE_HOME/lib/slf4j-api-${slf4j.version}.jar"
+CP="$CP:$DCM4CHE_HOME/lib/logback-core-${logback.version}.jar"
+CP="$CP:$DCM4CHE_HOME/lib/logback-classic-${logback.version}.jar"
+CP="$CP:$DCM4CHE_HOME/lib/commons-cli-${commons-cli.version}.jar"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+    JAVA=`cygpath --path --windows "$JAVA"`
+    CP=`cygpath --path --windows "$CP"`
+fi
+
+# Execute the JVM
+exec "$JAVA" $JAVA_OPTS -cp "$CP" $MAIN_CLASS "$@"

--- a/dcm4che-assembly/src/bin/dcmassoc.bat
+++ b/dcm4che-assembly/src/bin/dcmassoc.bat
@@ -1,0 +1,54 @@
+@echo off
+rem -------------------------------------------------------------------------
+rem findscu  Launcher
+rem -------------------------------------------------------------------------
+
+if not "%ECHO%" == ""  echo %ECHO%
+if "%OS%" == "Windows_NT"  setlocal
+
+set MAIN_CLASS=org.dcm4che3.tool.dcmassoc.DcmAssoc
+set MAIN_JAR=dcm4che-tool-dcmassoc-${project.version}.jar
+
+set DIRNAME=.\
+if "%OS%" == "Windows_NT" set DIRNAME=%~dp0%
+
+rem Read all command line arguments
+
+set ARGS=
+:loop
+if [%1] == [] goto end
+        set ARGS=%ARGS% %1
+        shift
+        goto loop
+:end
+
+if not "%DCM4CHE_HOME%" == "" goto HAVE_DCM4CHE_HOME
+
+set DCM4CHE_HOME=%DIRNAME%..
+
+:HAVE_DCM4CHE_HOME
+
+if not "%JAVA_HOME%" == "" goto HAVE_JAVA_HOME
+
+set JAVA=java
+
+goto SKIP_SET_JAVA_HOME
+
+:HAVE_JAVA_HOME
+
+set JAVA=%JAVA_HOME%\bin\java
+
+:SKIP_SET_JAVA_HOME
+
+set CP=%DCM4CHE_HOME%\etc\dcmassoc\
+set CP=%CP%;%DCM4CHE_HOME%\etc\certs\
+set CP=%CP%;%DCM4CHE_HOME%\lib\%MAIN_JAR%
+set CP=%CP%;%DCM4CHE_HOME%\lib\dcm4che-core-${project.version}.jar
+set CP=%CP%;%DCM4CHE_HOME%\lib\dcm4che-net-${project.version}.jar
+set CP=%CP%;%DCM4CHE_HOME%\lib\dcm4che-tool-common-${project.version}.jar
+set CP=%CP%;%DCM4CHE_HOME%\lib\slf4j-api-${slf4j.version}.jar
+set CP=%CP%;%DCM4CHE_HOME%\lib\logback-core-${logback.version}.jar
+set CP=%CP%;%DCM4CHE_HOME%\lib\logback-classic-${logback.version}.jar
+set CP=%CP%;%DCM4CHE_HOME%\lib\commons-cli-${commons-cli.version}.jar
+
+"%JAVA%" %JAVA_OPTS% -cp "%CP%" %MAIN_CLASS% %ARGS%

--- a/dcm4che-assembly/src/etc/dcmassoc/logback.xml
+++ b/dcm4che-assembly/src/etc/dcmassoc/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5p - %m%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="org.dcm4che3.net.Association" level="DEBUG"/>
+  <logger name="org.dcm4che3.net.Timeout" level="DEBUG"/>
+  <logger name="org.dcm4che3.net.Dimse" level="DEBUG"/>
+  <logger name="org.dcm4che3.imageio.codec.Decompressor" level="DEBUG"/>
+  <root level="INFO">
+    <appender-ref ref="stdout"/>
+  </root>
+</configuration>

--- a/dcm4che-assembly/src/main/assembly/component.xml
+++ b/dcm4che-assembly/src/main/assembly/component.xml
@@ -140,6 +140,7 @@
         <include>org.dcm4che.tool:dcm4che-tool-dcm2pdf</include>
         <include>org.dcm4che.tool:dcm4che-tool-dcm2str</include>
         <include>org.dcm4che.tool:dcm4che-tool-dcm2xml</include>
+        <include>org.dcm4che.tool:dcm4che-tool-dcmassoc</include>
         <include>org.dcm4che.tool:dcm4che-tool-dcmbenchmark</include>
         <include>org.dcm4che.tool:dcm4che-tool-dcmdir</include>
         <include>org.dcm4che.tool:dcm4che-tool-dcmdump</include>

--- a/dcm4che-tool/dcm4che-tool-dcmassoc/README.md
+++ b/dcm4che-tool/dcm4che-tool-dcmassoc/README.md
@@ -1,0 +1,254 @@
+```
+usage: storescu [options] -c <aet>@<host>:<port> [<file>..][<directory>..]
+
+The storescu application implements a Service Class User (SCU) for the
+Storage Service Class and for the Verification SOP Class. For each DICOM
+file on the command line it sends a C-STORE message to a Storage Service
+Class Provider (SCP) and waits for a response. If no DICOM file is
+specified, it sends a DICOM C-ECHO message and waits for a response. The
+application can be used to transmit DICOM images and other DICOM composite
+objects and to verify basic DICOM connectivity.
+-
+Options:
+    --accept-timeout <ms>                 timeout in ms for receiving
+                                          A-ASSOCIATE-AC, no timeout by
+                                          default
+ -b,--bind <aet[@ip]>                     specify AE Title, local address
+                                          of the Application Entity
+                                          provided by this application;
+                                          use STORESCU and pick up any
+                                          valid local address to bind the
+                                          socket by default.
+ -c,--connect <aet@host:port>             specify AE Title, remote address
+                                          and port of the remote
+                                          Application Entity.
+    --connect-timeout <ms>                timeout in ms for TCP connect,
+                                          no timeout by default
+ -h,--help                                display this help and exit
+    --idle-timeout <ms>                   timeout in ms for aborting idle
+                                          Associations, no timeout by
+                                          default
+    --key-pass <password>                 password for accessing the key
+                                          in the key store, key store
+                                          password by default
+    --key-store <file|url>                file path or URL of key store
+                                          containing the private key,
+                                          resource:key.p12 by default
+    --key-store-pass <password>           password for key store
+                                          containing the private key,
+                                          'secret' by default
+    --key-store-type <storetype>          type of key store containing the
+                                          private key, PKCS12 by default
+    --max-ops-invoked <no>                maximum number of operations
+                                          this AE may invoke
+                                          asynchronously, unlimited by
+                                          default
+    --max-ops-performed <no>              maximum number of operations
+                                          this AE may perform
+                                          asynchronously, unlimited by
+                                          default
+    --max-pdulen-rcv <length>             specifies maximal length of
+                                          received P-DATA TF PDUs
+                                          communicated during association
+                                          establishment. 0 indicates that
+                                          no maximum length is specified.
+                                          16378 by default
+    --max-pdulen-snd <length>             specifies maximal length of sent
+                                          P-DATA-TF PDUs by this AE. The
+                                          actual maximum length of sent
+                                          P-DATA-TF PDUs is also limited
+                                          by the maximal length of
+                                          received P-DATA-TF PDUs of the
+                                          peer AE communicated during
+                                          association establishment. 16378
+                                          by default
+    --not-async                           do not use asynchronous mode;
+                                          equivalent to
+                                          --max-ops-invoked=1 and
+                                          --max-ops-performed=1
+    --not-pack-pdv                        send only one PDV in one
+                                          P-Data-TF PDU; pack command and
+                                          data PDV in one P-DATA-TF PDU by
+                                          default
+    --prior-high                          set HIGH priority in invoked
+                                          DIMSE-C operation, MEDIUM by
+                                          default
+    --prior-low                           set LOW priority in invoked
+                                          DIMSE-C operation, MEDIUM by
+                                          default
+    --proxy <[user:password@]host:port>   specify host and port of the
+                                          HTTP Proxy to tunnel the DICOM
+                                          connection.
+    --rel-ext-neg                         enable SOP Class Relationship
+                                          Extended Negotiation
+    --rel-sop-classes <file|url>          file path or URL of definition
+                                          of Related General SOP Classes,
+                                          resource:rel-sop-classes.propert
+                                          ies by default
+    --release-timeout <ms>                timeout in ms for receiving
+                                          A-RELEASE-RP, no timeout by
+                                          default
+    --response-timeout <ms>               timeout in ms for receiving
+                                          other outstanding DIMSE RSPs
+                                          than C-MOVE or C-GET RSPs, no
+                                          timeout by default
+ -s <[seq.]attr=value>                    specify attributes added to the
+                                          sent object(s). attr can be
+                                          specified by keyword or tag
+                                          value (in hex), e.g. PatientName
+                                          or 00100010. Attributes in
+                                          nested Datasets can be specified
+                                          by including the keyword/tag
+                                          value of the sequence attribute,
+                                          e.g. 00400275.00400009 for
+                                          Scheduled Procedure Step ID in
+                                          the Request Attributes Sequence.
+    --soclose-delay <ms>                  delay in ms after sending
+                                          A-ASSOCATE-RJ, A-RELEASE-RQ or
+                                          A-ABORT before the socket is
+                                          closed; 50ms by default
+    --sorcv-buffer <length>               set SO_RCVBUF socket option to
+                                          specified value
+    --sosnd-buffer <length>               set SO_SNDBUF socket option to
+                                          specified value
+    --ssl2Hello                           send/accept SSLv3/TLS
+                                          ClientHellos encapsulated in a
+                                          SSLv2 ClientHello packet;
+                                          equivalent to --tls-protocol
+                                          SSLv2Hello --tls-protocol SSLv3
+                                          --tls-protocol TLSv1
+                                          --tls-protocol TLSv1.1
+                                          --tls-protocol TLSv1.2
+    --ssl3                                enable only TLS/SSL protocol
+                                          SSLv3; equivalent to
+                                          --tls-protocol SSLv3
+    --store-tc <cuid:tsuid[(,|;)...]>     specifies Storage Transfer
+                                          Capability offered additionally
+                                          to the Verification SOP Class if
+                                          no DICOM file is specified,
+                                          probing the Association
+                                          Acceptance Policy of the Storage
+                                          SCP. SOP Class and Transfer
+                                          Syntaxes can be specified by its
+                                          UID or its name in camel-Case
+                                          (e.g. 1.2.840.10008.5.1.4.1.1.2
+                                          or CTImageStorage). Semicolon
+                                          separated Transfer Syntaxes will
+                                          be offered in separate
+                                          Presentation Contexts, where
+                                          comma separated Transfer
+                                          Syntaxes will be offered in one
+                                          Presentation Context.
+    --store-tcs <file|url>                specifies file which defines
+                                          negotiated Storage Transfer
+                                          Capabilities offered
+                                          additionally to the Verification
+                                          SOP Class if no DICOM file is
+                                          specified, probing the
+                                          Association Acceptance Policy of
+                                          the Storage SCP. Storage
+                                          Transfer Capabilities are
+                                          formatted as values of option
+                                          --store-tc.
+    --store-timeout <ms>                  timeout in ms for sending
+                                          C-STORE sRQ, no timeout by
+                                          default
+    --tcp-delay                           set TCP_NODELAY socket option to
+                                          false, true by default
+    --tls                                 enable TLS connection without
+                                          encryption or with AES or 3DES
+                                          encryption; equivalent to
+                                          --tls-cipher
+                                          SSL_RSA_WITH_NULL_SHA
+                                          --tls-cipher
+                                          TLS_RSA_WITH_AES_128_CBC_SHA
+                                          --tls-cipher
+                                          SSL_RSA_WITH_3DES_EDE_CBC_SHA
+    --tls-3des                            enable TLS connection with 3DES
+                                          encryption; equivalent to
+                                          --tls-cipher
+                                          SSL_RSA_WITH_3DES_EDE_CBC_SHA
+    --tls-aes                             enable TLS connection with AES
+                                          or 3DES encryption; equivalent
+                                          to --tls-cipher
+                                          TLS_RSA_WITH_AES_128_CBC_SHA
+                                          --tls-cipher
+                                          SSL_RSA_WITH_3DES_EDE_CBC_SHA
+    --tls-cipher <cipher>                 enable TLS connection with
+                                          specified Cipher Suite. Multiple
+                                          Cipher Suites may be enabled by
+                                          multiple --tls-cipher options
+    --tls-eia-https                       enable server endpoint
+                                          identification according RFC
+                                          2818: HTTP Over TLS
+    --tls-eia-ldaps                       enable server endpoint
+                                          identification according RFC
+                                          2830: LDAP Extension for TLS
+    --tls-noauth                          disable client authentification
+                                          for TLS
+    --tls-null                            enable TLS connection without
+                                          encryption; equivalent to
+                                          --tls-cipher
+                                          SSL_RSA_WITH_NULL_SHA
+    --tls-protocol <protocol>             TLS/SSL protocol to use.
+                                          Multiple TLS/SSL protocols may
+                                          be enabled by multiple
+                                          --tls-protocol options.
+                                          Supported values by Java 11:
+                                          TLSv1, TLSv1.1, TLSv1.2,
+                                          TLSv1.3, SSLv3, SSLv2Hello. By
+                                          default, only TLSv1.2 is
+                                          enabled.
+    --tls1                                enable only TLS/SSL protocol
+                                          TLSv1; equivalent to
+                                          --tls-protocol TLSv1
+    --tls11                               enable only TLS/SSL protocol
+                                          TLSv1.1; equivalent to
+                                          --tls-protocol TLSv1.1
+    --tls12                               enable only TLS/SSL protocol
+                                          TLSv1.2; equivalent to
+                                          --tls-protocol TLSv1.2
+    --tls13                               enable only TLS/SSL protocol
+                                          TLSv1.3; equivalent to
+                                          --tls-protocol TLSv1.3
+    --tmp-file-dir <directory>            directory were temporary file
+                                          with File Meta Information from
+                                          scanned files is stored; if not
+                                          specified, the file is stored
+                                          into the default temporary-file
+                                          directory
+    --tmp-file-prefix <prefix>            prefix for generated file name
+                                          for temporary file; 'storescu-'
+                                          by default
+    --tmp-file-suffix <suffix>            suffix for generated file name
+                                          for temporary file; '.tmp' by
+                                          default
+    --trust-store <file|url>              file path of key store
+                                          containing trusted certificates,
+                                          resource:cacerts.p12 by default
+    --trust-store-pass <password>         password for key store with
+                                          trusted certificates, 'secret'
+                                          by default
+    --trust-store-type <storetype>        type of key store with trusted
+                                          certificates, PKCS12 by default
+    --uid-suffix <suffix>                 specify suffix to be appended to
+                                          the Study, Series and SOP
+                                          Instance UID of the sent
+                                          object(s).
+    --user <name>                         negotiate user identity with
+                                          specified user name
+    --user-jwt <token>                    negotiate user identity with
+                                          specified JSON Web Token
+    --user-pass <password>                negotiate user identity with
+                                          specified password
+    --user-rsp                            negotiate user identity with
+                                          positive response requested
+    --user-saml <assertion>               negotiate user identity with
+                                          specified SAML Assertion
+ -V,--version                             output version information and
+                                          exit
+-
+Example: storescu -c STORESCP@localhost:11112 image.dcm
+=> Send DICOM image image.dcm to Storage Service Class Provider STORESCP,
+listening on local port 11112.
+```

--- a/dcm4che-tool/dcm4che-tool-dcmassoc/README.md
+++ b/dcm4che-tool/dcm4che-tool-dcmassoc/README.md
@@ -1,13 +1,8 @@
 ```
-usage: storescu [options] -c <aet>@<host>:<port> [<file>..][<directory>..]
+usage: dcmassoc [options] -c <aet>@<host>:<port>
 
-The storescu application implements a Service Class User (SCU) for the
-Storage Service Class and for the Verification SOP Class. For each DICOM
-file on the command line it sends a C-STORE message to a Storage Service
-Class Provider (SCP) and waits for a response. If no DICOM file is
-specified, it sends a DICOM C-ECHO message and waits for a response. The
-application can be used to transmit DICOM images and other DICOM composite
-objects and to verify basic DICOM connectivity.
+The dcmassoc application creates an association request to a remote AE,
+allowing full control over the presentation contexts offered.
 -
 Options:
     --accept-timeout <ms>                 timeout in ms for receiving
@@ -16,7 +11,7 @@ Options:
  -b,--bind <aet[@ip]>                     specify AE Title, local address
                                           of the Application Entity
                                           provided by this application;
-                                          use STORESCU and pick up any
+                                          use DCMASSOC and pick up any
                                           valid local address to bind the
                                           socket by default.
  -c,--connect <aet@host:port>             specify AE Title, remote address
@@ -70,39 +65,27 @@ Options:
                                           P-Data-TF PDU; pack command and
                                           data PDV in one P-DATA-TF PDU by
                                           default
-    --prior-high                          set HIGH priority in invoked
-                                          DIMSE-C operation, MEDIUM by
-                                          default
-    --prior-low                           set LOW priority in invoked
-                                          DIMSE-C operation, MEDIUM by
-                                          default
+    --pc <number:cuid:tsuid[(,|;)...]>    specifies Presentation Contexts
+                                          to be negotiated probing the
+                                          Association Acceptance Policy of
+                                          the DICOM SCP. SOP Class and
+                                          Transfer Syntaxes can be
+                                          specified by its UID or its name
+                                          in camel-case (e.g.
+                                          1.2.840.10008.5.1.4.1.1.2 or
+                                          CTImageStorage). Semicolon
+                                          separated Transfer Syntaxes will
+                                          be offered in separate
+                                          Presentation Contexts, where
+                                          comma separated Transfer
+                                          Syntaxes will be offered in one
+                                          Presentation Context.
     --proxy <[user:password@]host:port>   specify host and port of the
                                           HTTP Proxy to tunnel the DICOM
                                           connection.
-    --rel-ext-neg                         enable SOP Class Relationship
-                                          Extended Negotiation
-    --rel-sop-classes <file|url>          file path or URL of definition
-                                          of Related General SOP Classes,
-                                          resource:rel-sop-classes.propert
-                                          ies by default
     --release-timeout <ms>                timeout in ms for receiving
                                           A-RELEASE-RP, no timeout by
                                           default
-    --response-timeout <ms>               timeout in ms for receiving
-                                          other outstanding DIMSE RSPs
-                                          than C-MOVE or C-GET RSPs, no
-                                          timeout by default
- -s <[seq.]attr=value>                    specify attributes added to the
-                                          sent object(s). attr can be
-                                          specified by keyword or tag
-                                          value (in hex), e.g. PatientName
-                                          or 00100010. Attributes in
-                                          nested Datasets can be specified
-                                          by including the keyword/tag
-                                          value of the sequence attribute,
-                                          e.g. 00400275.00400009 for
-                                          Scheduled Procedure Step ID in
-                                          the Request Attributes Sequence.
     --soclose-delay <ms>                  delay in ms after sending
                                           A-ASSOCATE-RJ, A-RELEASE-RQ or
                                           A-ABORT before the socket is
@@ -122,37 +105,6 @@ Options:
     --ssl3                                enable only TLS/SSL protocol
                                           SSLv3; equivalent to
                                           --tls-protocol SSLv3
-    --store-tc <cuid:tsuid[(,|;)...]>     specifies Storage Transfer
-                                          Capability offered additionally
-                                          to the Verification SOP Class if
-                                          no DICOM file is specified,
-                                          probing the Association
-                                          Acceptance Policy of the Storage
-                                          SCP. SOP Class and Transfer
-                                          Syntaxes can be specified by its
-                                          UID or its name in camel-Case
-                                          (e.g. 1.2.840.10008.5.1.4.1.1.2
-                                          or CTImageStorage). Semicolon
-                                          separated Transfer Syntaxes will
-                                          be offered in separate
-                                          Presentation Contexts, where
-                                          comma separated Transfer
-                                          Syntaxes will be offered in one
-                                          Presentation Context.
-    --store-tcs <file|url>                specifies file which defines
-                                          negotiated Storage Transfer
-                                          Capabilities offered
-                                          additionally to the Verification
-                                          SOP Class if no DICOM file is
-                                          specified, probing the
-                                          Association Acceptance Policy of
-                                          the Storage SCP. Storage
-                                          Transfer Capabilities are
-                                          formatted as values of option
-                                          --store-tc.
-    --store-timeout <ms>                  timeout in ms for sending
-                                          C-STORE sRQ, no timeout by
-                                          default
     --tcp-delay                           set TCP_NODELAY socket option to
                                           false, true by default
     --tls                                 enable TLS connection without
@@ -211,18 +163,6 @@ Options:
     --tls13                               enable only TLS/SSL protocol
                                           TLSv1.3; equivalent to
                                           --tls-protocol TLSv1.3
-    --tmp-file-dir <directory>            directory were temporary file
-                                          with File Meta Information from
-                                          scanned files is stored; if not
-                                          specified, the file is stored
-                                          into the default temporary-file
-                                          directory
-    --tmp-file-prefix <prefix>            prefix for generated file name
-                                          for temporary file; 'storescu-'
-                                          by default
-    --tmp-file-suffix <suffix>            suffix for generated file name
-                                          for temporary file; '.tmp' by
-                                          default
     --trust-store <file|url>              file path of key store
                                           containing trusted certificates,
                                           resource:cacerts.p12 by default
@@ -231,10 +171,6 @@ Options:
                                           by default
     --trust-store-type <storetype>        type of key store with trusted
                                           certificates, PKCS12 by default
-    --uid-suffix <suffix>                 specify suffix to be appended to
-                                          the Study, Series and SOP
-                                          Instance UID of the sent
-                                          object(s).
     --user <name>                         negotiate user identity with
                                           specified user name
     --user-jwt <token>                    negotiate user identity with
@@ -248,7 +184,12 @@ Options:
  -V,--version                             output version information and
                                           exit
 -
-Example: storescu -c STORESCP@localhost:11112 image.dcm
-=> Send DICOM image image.dcm to Storage Service Class Provider STORESCP,
-listening on local port 11112.
+Example: dcmassoc -c STORESCP@localhost:11112 -pc
+1:CTImageStorage:ImplicitVRLittleEndian -pc
+3:MRImageStorage:ImplicitVRLittleEndian,ExplicitVRLittleEndian
+=> Probe association to Storage Service Class Provider STORESCP listening
+on remote port 11112 offering CTImageStorage with ImplicitVRLittleEndian
+in first presentation context and MRImageStorage with
+ImplicitVRLittleEndian and ExplicitVRLittleEndian in third presentation
+context.
 ```

--- a/dcm4che-tool/dcm4che-tool-dcmassoc/pom.xml
+++ b/dcm4che-tool/dcm4che-tool-dcmassoc/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ***** BEGIN LICENSE BLOCK ***** - Version: MPL 1.1/GPL 2.0/LGPL 2.1 
+  - - The contents of this file are subject to the Mozilla Public License Version 
+  - 1.1 (the "License"); you may not use this file except in compliance with 
+  - the License. You may obtain a copy of the License at - http://www.mozilla.org/MPL/ 
+  - - Software distributed under the License is distributed on an "AS IS" basis, 
+  - WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License 
+  - for the specific language governing rights and limitations under the - 
+  License. - - The Original Code is part of dcm4che, an implementation of DICOM(TM) 
+  in - Java(TM), hosted at https://github.com/dcm4che. - - The Initial
+  Developer of the Original Code is - Agfa Healthcare. - Portions created by 
+  the Initial Developer are Copyright (C) 2011 - the Initial Developer. All 
+  Rights Reserved. - - Contributor(s): - Gunter Zeilinger <gunterze@gmail.com> 
+  - - Alternatively, the contents of this file may be used under the terms 
+  of - either the GNU General Public License Version 2 or later (the "GPL"), 
+  or - the GNU Lesser General Public License Version 2.1 or later (the "LGPL"), 
+  - in which case the provisions of the GPL or the LGPL are applicable instead 
+  - of those above. If you wish to allow use of your version of this file only 
+  - under the terms of either the GPL or the LGPL, and not to allow others 
+  to - use your version of this file under the terms of the MPL, indicate your 
+  - decision by deleting the provisions above and replace them with the notice 
+  - and other provisions required by the GPL or the LGPL. If you do not delete 
+  - the provisions above, a recipient may use your version of this file under 
+  - the terms of any one of the MPL, the GPL or the LGPL. - - ***** END LICENSE 
+  BLOCK ***** -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>dcm4che-tool</artifactId>
+    <groupId>org.dcm4che.tool</groupId>
+    <version>5.31.0</version>
+  </parent>
+  <artifactId>dcm4che-tool-dcmassoc</artifactId>
+  <name>dcm4che-tool-dcmassoc</name>
+  <description>Create custom association to test DICOM SCPs</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.dcm4che</groupId>
+      <artifactId>dcm4che-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.dcm4che</groupId>
+      <artifactId>dcm4che-imageio</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.dcm4che</groupId>
+      <artifactId>dcm4che-net</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.dcm4che.tool</groupId>
+      <artifactId>dcm4che-tool-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/dcm4che-tool/dcm4che-tool-dcmassoc/src/main/java/org/dcm4che3/tool/dcmassoc/DcmAssoc.java
+++ b/dcm4che-tool/dcm4che-tool-dcmassoc/src/main/java/org/dcm4che3/tool/dcmassoc/DcmAssoc.java
@@ -1,0 +1,192 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is part of dcm4che, an implementation of DICOM(TM) in
+ * Java(TM), hosted at https://github.com/dcm4che.
+ *
+ * The Initial Developer of the Original Code is
+ * Agfa Healthcare.
+ * Portions created by the Initial Developer are Copyright (C) 2011
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ * See @authors listed below
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+package org.dcm4che3.tool.dcmassoc;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.dcm4che3.data.UID;
+import org.dcm4che3.net.*;
+import org.dcm4che3.net.pdu.AAssociateRQ;
+import org.dcm4che3.net.pdu.PresentationContext;
+import org.dcm4che3.tool.common.CLIUtils;
+import org.dcm4che3.util.StringUtils;
+
+import java.io.*;
+import java.security.GeneralSecurityException;
+import java.text.MessageFormat;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * @author Leandros Athanasiadis <leandre84@gmail.com>
+ */
+public class DcmAssoc {
+
+    private static ResourceBundle rb = ResourceBundle
+            .getBundle("org.dcm4che3.tool.dcmassoc.messages");
+
+    private final ApplicationEntity ae;
+    private final Connection remote;
+    private final AAssociateRQ rq = new AAssociateRQ();
+    private Association as;
+
+    public DcmAssoc(ApplicationEntity ae) throws IOException {
+        this.remote = new Connection();
+        this.ae = ae;
+    }
+
+    public AAssociateRQ getAAssociateRQ() {
+        return rq;
+    }
+
+    public Connection getRemoteConnection() {
+        return remote;
+    }
+
+
+    private static CommandLine parseComandLine(String[] args)
+            throws ParseException {
+        Options opts = new Options();
+        CLIUtils.addConnectOption(opts);
+        CLIUtils.addBindClientOption(opts, "DCMASSOC");
+        CLIUtils.addAEOptions(opts);
+        CLIUtils.addCommonOptions(opts);
+        addPCOptions(opts);
+        return CLIUtils.parseComandLine(args, opts, rb, DcmAssoc.class);
+    }
+
+    private static void addPCOptions(Options opts) {
+        opts.addOption(Option.builder()
+                .hasArg()
+                .argName("number:cuid:tsuid[(,|;)...]")
+                .desc(rb.getString("pc"))
+                .longOpt("pc")
+                .build());
+    }
+
+    public static void main(String[] args) {
+        long t1, t2;
+        try {
+            CommandLine cl = parseComandLine(args);
+            Device device = new Device("dcmassoc");
+            Connection conn = new Connection();
+            device.addConnection(conn);
+            ApplicationEntity ae = new ApplicationEntity("DCMASSOC");
+            device.addApplicationEntity(ae);
+            ae.addConnection(conn);
+            DcmAssoc main = new DcmAssoc(ae);
+            CLIUtils.configureConnect(main.remote, main.rq, cl);
+            CLIUtils.configureBind(conn, ae, cl);
+            CLIUtils.configure(conn, cl);
+            main.remote.setTlsProtocols(conn.getTlsProtocols());
+            main.remote.setTlsCipherSuites(conn.getTlsCipherSuites());
+            configureStorageSOPClasses(main, cl);
+
+            ExecutorService executorService = Executors
+                    .newSingleThreadExecutor();
+            ScheduledExecutorService scheduledExecutorService = Executors
+                    .newSingleThreadScheduledExecutor();
+            device.setExecutor(executorService);
+            device.setScheduledExecutor(scheduledExecutorService);
+            try {
+                t1 = System.currentTimeMillis();
+                main.open();
+                t2 = System.currentTimeMillis();
+                System.out.println(MessageFormat.format(
+                        rb.getString("connected"), main.as.getRemoteAET(), t2
+                                - t1));
+
+            } finally {
+                main.close();
+                executorService.shutdown();
+                scheduledExecutorService.shutdown();
+            }
+        } catch (ParseException e) {
+            System.err.println("dcmassoc: " + e.getMessage());
+            System.err.println(rb.getString("try"));
+            System.exit(2);
+        } catch (Exception e) {
+            System.err.println("dcmassoc: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(2);
+        }
+    }
+
+    private static void configureStorageSOPClasses(DcmAssoc main, CommandLine cl)
+            throws Exception {
+        String[] pcs = cl.getOptionValues("pc");
+        if (pcs != null) {
+            for (String pc : pcs) {
+                String[] ss = StringUtils.split(pc, ':');
+                configureStorageSOPClass(main, Integer.parseInt(ss[0]), ss[1], ss[2]);
+            }
+        }
+        else {
+            configureStorageSOPClass(main, 1, UID.Verification, UID.ImplicitVRLittleEndian);
+        }    
+    }
+
+    private static void configureStorageSOPClass(DcmAssoc main, int pos, String cuid, String tsuids0) {
+        for (String tsuids2 : StringUtils.split(tsuids0, ';')) {
+            main.addOfferedStorageSOPClass(pos, CLIUtils.toUID(cuid), CLIUtils.toUIDs(tsuids2));
+        }
+    }
+
+    public void addOfferedStorageSOPClass(int pos, String cuid, String... tsuids) {
+        rq.addPresentationContext(new PresentationContext(pos, cuid, tsuids));
+    }
+
+    public void close() throws IOException, InterruptedException {
+        if (as != null) {
+            if (as.isReadyForDataTransfer())
+                as.release();
+            as.waitForSocketClose();
+        }
+    }
+
+    public void open() throws IOException, InterruptedException,
+            IncompatibleConnectionException, GeneralSecurityException {
+        as = ae.connect(remote, rq);
+    }
+
+}

--- a/dcm4che-tool/dcm4che-tool-dcmassoc/src/main/resources/org/dcm4che3/tool/dcmassoc/messages.properties
+++ b/dcm4che-tool/dcm4che-tool-dcmassoc/src/main/resources/org/dcm4che3/tool/dcmassoc/messages.properties
@@ -1,0 +1,19 @@
+usage=dcmassoc [options] -c <aet>@<host>:<port>
+try=Try `dcmassoc --help' for more information.
+description=\n\
+The dcmassoc application creates an association request to a remote AE, \
+allowing full control over the presentation contexts offered.\n\-\n\
+Options:
+example=-\n\
+Example: dcmassoc -c STORESCP@localhost:11112 \
+-pc 1:CTImageStorage:ImplicitVRLittleEndian \
+-pc 3:MRImageStorage:ImplicitVRLittleEndian,ExplicitVRLittleEndian \n\
+=> Probe association to Storage Service Class Provider STORESCP listening on remote port 11112 \
+offering CTImageStorage with ImplicitVRLittleEndian in first presentation context \
+and MRImageStorage with ImplicitVRLittleEndian and ExplicitVRLittleEndian in third presentation context.
+pc=specifies Presentation Contexts to be negotiated probing the Association Acceptance Policy of the DICOM SCP. \
+SOP Class and Transfer Syntaxes can be specified by its UID or its name in camel-case \
+(e.g. 1.2.840.10008.5.1.4.1.1.2 or CTImageStorage). Semicolon separated Transfer Syntaxes will be \
+offered in separate Presentation Contexts, where comma separated Transfer Syntaxes will be offered \
+in one Presentation Context.
+connected=Connected to {0} in {1}ms

--- a/dcm4che-tool/pom.xml
+++ b/dcm4che-tool/pom.xml
@@ -60,6 +60,7 @@
     <module>dcm4che-tool-dcm2pdf</module>
     <module>dcm4che-tool-dcm2str</module>
     <module>dcm4che-tool-dcm2xml</module>
+    <module>dcm4che-tool-dcmassoc</module>
     <module>dcm4che-tool-dcmbenchmark</module>
     <module>dcm4che-tool-dcmdir</module>
     <module>dcm4che-tool-dcmdump</module>


### PR DESCRIPTION
I created a new tool called dcmassoc that enables full control over presentation contexts in an association request to a DICOM SCP, for testing purposes. dcmassoc allows creation of "illegal" PCs like outlined below (note even numbers of PCs, out-of-sequence numbering of PCs and same TS offered multiple times in PC #5):

`19:39:24.770 DEBUG - A-ASSOCIATE-RQ[
  calledAET: DULEO
  callingAET: DCMASSOC
  applicationContext: 1.2.840.10008.3.1.1.1 - DICOM Application Context Name
  implClassUID: 1.2.40.0.13.1.3
  implVersionName: dcm4che-5.31.0
  maxPDULength: 16378
  maxOpsInvoked/maxOpsPerformed: 0/0
  PresentationContext[id: 3
    as: 1.2.840.10008.5.1.4.1.1.2 - CT Image Storage
    ts: 1.2.840.10008.1.2 - Implicit VR Little Endian
  ]
  PresentationContext[id: 5
    as: 1.2.840.10008.5.1.4.1.1.4 - MR Image Storage
    ts: 1.2.840.10008.1.2 - Implicit VR Little Endian
    ts: 1.2.840.10008.1.2.1 - Explicit VR Little Endian
    ts: 1.2.840.10008.1.2 - Implicit VR Little Endian
    ts: 1.2.3.4 - ?
  ]
  PresentationContext[id: 2
    as: 1234.1.2 - ?
    ts: 1.2.840.10008.1.2 - Implicit VR Little Endian
  ]
  PresentationContext[id: 4
    as: 2.16.840.1.113883.2.16.3.1.14.4.1.1.99.33 - ?
    ts: 1.2.840.10008.1.2 - Implicit VR Little Endian
  ]
]
`