### PR TITLE
DateUtils parseTM with millis is erroneous fix #1270 - generic_config

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/util/DateUtils.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/util/DateUtils.java
@@ -208,7 +208,7 @@ public class DateUtils {
     public static Date parseDA(TimeZone tz, String s, boolean ceil) {
         Calendar cal = cal(tz);
         int length = s.length();
-        if (!(length == 8 || length == 10 && !Character.isDigit(s.charAt(4)) && !Character.isDigit(s.charAt(7))))
+        if (!(length == 8 || length == 10 && !Character.isDigit(s.charAt(4)) && s.charAt(7) == s.charAt(4)))
             throw new IllegalArgumentException(s);
         int pos = 0;
         cal.set(Calendar.YEAR,
@@ -216,11 +216,11 @@ public class DateUtils {
                 parseDigit(s, pos++) * 100 +
                 parseDigit(s, pos++) * 10 +
                 parseDigit(s, pos++));
-        if (!Character.isDigit(s.charAt(pos)))
+        if (length == 10)
             pos++;
         cal.set(Calendar.MONTH,
                 parseDigit(s, pos++) * 10 + parseDigit(s, pos++) - 1);
-        if (!Character.isDigit(s.charAt(pos)))
+        if (length == 10)
             pos++;
         cal.set(Calendar.DAY_OF_MONTH,
                 parseDigit(s, pos++) * 10 + parseDigit(s, pos++));

--- a/dcm4che-core/src/main/java/org/dcm4che3/util/DateUtils.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/util/DateUtils.java
@@ -269,12 +269,13 @@ public class DateUtils {
                     cal.set(precision.lastField = Calendar.SECOND,
                             Integer.parseInt(s.substring(pos, pos + 2)));
                     pos += 2;
-                    if (pos < length) {
-                        float f = Float.parseFloat(s.substring(pos));
-                        if (f >= 1 || f < 0)
+                    int nffffff = length - pos;
+                    if (nffffff > 0) {
+                        int fffffff;
+                        if (s.charAt(pos++) != '.' || nffffff > 7 || (fffffff = Integer.parseInt(s.substring(pos))) < 0)
                             throw new IllegalArgumentException(s);
-                        cal.set(precision.lastField = Calendar.MILLISECOND, 
-                                (int) (f * 1000));
+                        cal.set(precision.lastField = Calendar.MILLISECOND,
+                                (fffffff * (new int[]{ 100000, 10000, 1000, 100, 10, 1 })[nffffff - 2] + 500) / 1000);
                         return cal.getTime();
                     }
                 }

--- a/dcm4che-core/src/main/java/org/dcm4che3/util/DateUtils.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/util/DateUtils.java
@@ -208,27 +208,24 @@ public class DateUtils {
     public static Date parseDA(TimeZone tz, String s, boolean ceil) {
         Calendar cal = cal(tz);
         int length = s.length();
-        if (!(length == 8 || length == 10 && !Character.isDigit(s.charAt(4))))
+        if (!(length == 8 || length == 10 && !Character.isDigit(s.charAt(4)) && !Character.isDigit(s.charAt(7))))
             throw new IllegalArgumentException(s);
-        try {
-            int pos = 0;
-            cal.set(Calendar.YEAR,
-                    Integer.parseInt(s.substring(pos, pos + 4)));
-            pos += 4;
-            if (!Character.isDigit(s.charAt(pos)))
-                pos++;
-            cal.set(Calendar.MONTH,
-                    Integer.parseInt(s.substring(pos, pos + 2)) - 1);
-            pos += 2;
-            if (!Character.isDigit(s.charAt(pos)))
-                pos++;
-            cal.set(Calendar.DAY_OF_MONTH,
-                    Integer.parseInt(s.substring(pos)));
-            if (ceil)
-                ceil(cal, Calendar.DAY_OF_MONTH);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(s);
-        }
+        int pos = 0;
+        cal.set(Calendar.YEAR,
+                parseDigit(s, pos++) * 1000 +
+                parseDigit(s, pos++) * 100 +
+                parseDigit(s, pos++) * 10 +
+                parseDigit(s, pos++));
+        if (!Character.isDigit(s.charAt(pos)))
+            pos++;
+        cal.set(Calendar.MONTH,
+                parseDigit(s, pos++) * 10 + parseDigit(s, pos++) - 1);
+        if (!Character.isDigit(s.charAt(pos)))
+            pos++;
+        cal.set(Calendar.DAY_OF_MONTH,
+                parseDigit(s, pos++) * 10 + parseDigit(s, pos++));
+        if (ceil)
+            ceil(cal, Calendar.DAY_OF_MONTH);
         return cal.getTime();
     }
 
@@ -248,44 +245,52 @@ public class DateUtils {
         if (pos + 2 > length)
             throw new IllegalArgumentException(s);
 
-        try {
-            cal.set(precision.lastField = Calendar.HOUR_OF_DAY,
-                    Integer.parseInt(s.substring(pos, pos + 2)));
-            pos += 2;
+        cal.set(precision.lastField = Calendar.HOUR_OF_DAY,
+            parseDigit(s, pos++) * 10 + parseDigit(s, pos++));
+        if (pos < length) {
+            if (!Character.isDigit(s.charAt(pos)))
+                pos++;
+            if (pos + 2 > length)
+                throw new IllegalArgumentException(s);
+
+            cal.set(precision.lastField = Calendar.MINUTE,
+                parseDigit(s, pos++) * 10 + parseDigit(s, pos++));
             if (pos < length) {
                 if (!Character.isDigit(s.charAt(pos)))
                     pos++;
                 if (pos + 2 > length)
                     throw new IllegalArgumentException(s);
-
-                cal.set(precision.lastField = Calendar.MINUTE,
-                        Integer.parseInt(s.substring(pos, pos + 2)));
-                pos += 2;
-                if (pos < length) {
-                    if (!Character.isDigit(s.charAt(pos)))
-                        pos++;
-                    if (pos + 2 > length)
+                cal.set(precision.lastField = Calendar.SECOND,
+                        parseDigit(s, pos++) * 10 + parseDigit(s, pos++));
+                int n = length - pos;
+                if (n > 0) {
+                    if (s.charAt(pos++) != '.' || n > 7)
                         throw new IllegalArgumentException(s);
-                    cal.set(precision.lastField = Calendar.SECOND,
-                            Integer.parseInt(s.substring(pos, pos + 2)));
-                    pos += 2;
-                    int nffffff = length - pos;
-                    if (nffffff > 0) {
-                        int fffffff;
-                        if (s.charAt(pos++) != '.' || nffffff > 7 || (fffffff = Integer.parseInt(s.substring(pos))) < 0)
-                            throw new IllegalArgumentException(s);
-                        cal.set(precision.lastField = Calendar.MILLISECOND,
-                                (fffffff * (new int[]{ 100000, 10000, 1000, 100, 10, 1 })[nffffff - 2] + 500) / 1000);
-                        return cal.getTime();
+
+                    int d, millis = 0;
+                    for (int i = 1; i < n; ++i) {
+                        d = parseDigit(s, pos++);
+                        if (i < 4)
+                            millis += d;
+                        else if (i == 4 & d > 4) // round up
+                            millis++;
+                        if (i < 3) millis *= 10;
                     }
+                    for (int i = n; i < 3; ++i) millis *= 10;
+                    cal.set(precision.lastField = Calendar.MILLISECOND, millis);
+                    return cal.getTime();
                 }
             }
-            if (ceil)
-                ceil(cal, precision.lastField);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(s);
         }
+        if (ceil)
+            ceil(cal, precision.lastField);
         return cal.getTime();
+    }
+
+    private static int parseDigit(String s, int index) {
+        int d = s.charAt(index) - '0';
+        if (d < 0 || d > 9) throw new IllegalArgumentException(s);
+        return d;
     }
 
     public static Date parseDT(TimeZone tz, String s, DatePrecision precision) {
@@ -337,36 +342,32 @@ public class DateUtils {
             tz = tz1;
         }
         Calendar cal = cal(tz);
-        try {
-            int pos = 0;
-            if (pos + 4 > length)
+        int pos = 0;
+        if (pos + 4 > length)
+            throw new IllegalArgumentException(s);
+        cal.set(precision.lastField = Calendar.YEAR,
+                parseDigit(s, pos++) * 1000 +
+                parseDigit(s, pos++) * 100 +
+                parseDigit(s, pos++) * 10 +
+                parseDigit(s, pos++));
+        if (pos < length) {
+            if (!Character.isDigit(s.charAt(pos)))
+                pos++;
+            if (pos + 2 > length)
                 throw new IllegalArgumentException(s);
-            cal.set(precision.lastField = Calendar.YEAR,
-                    Integer.parseInt(s.substring(pos, pos + 4)));
-            pos += 4;
+            cal.set(precision.lastField = Calendar.MONTH,
+                    parseDigit(s, pos++) * 10 + parseDigit(s, pos++) - 1);
             if (pos < length) {
                 if (!Character.isDigit(s.charAt(pos)))
                     pos++;
                 if (pos + 2 > length)
                     throw new IllegalArgumentException(s);
-                cal.set(precision.lastField = Calendar.MONTH,
-                        Integer.parseInt(s.substring(pos,  pos + 2)) - 1);
-                pos += 2;
-                if (pos < length) {
-                    if (!Character.isDigit(s.charAt(pos)))
-                        pos++;
-                    if (pos + 2 > length)
-                        throw new IllegalArgumentException(s);
-                    cal.set(precision.lastField = Calendar.DAY_OF_MONTH,
-                            Integer.parseInt(s.substring(pos, pos + 2)));
-                    pos += 2;
-                    if (pos < length)
-                        return parseTM(cal, s.substring(pos, length), ceil,
-                                precision);
-                }
+                cal.set(precision.lastField = Calendar.DAY_OF_MONTH,
+                        parseDigit(s, pos++) * 10 + parseDigit(s, pos++));
+                if (pos < length)
+                    return parseTM(cal, s.substring(pos, length), ceil,
+                            precision);
             }
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(s);
         }
         if (ceil)
             ceil(cal, precision.lastField);


### PR DESCRIPTION
We experienced parsing problems using DateUtils.parseTM when asserting for the milliseconds on the Date parsed. I noticed the problem was already fixed on master. 

This pull request is to cherry-pick the changes that fixed issue #1270 into the generic_config branch. 

The problem was caused by float arithmetic (0.251f * 1000 ==> 250.99998).