### PR TITLE
Update native codecs to 4.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <slf4j.version>2.0.1</slf4j.version>
     <logback.version>1.4.4</logback.version>
-    <weasis.core.img.version>4.8.0.1</weasis.core.img.version>
-    <weasis.opencv.native.version>4.8.0-dcm</weasis.opencv.native.version>
+    <weasis.core.img.version>4.8.1</weasis.core.img.version>
+    <weasis.opencv.native.version>4.8.1-dcm</weasis.opencv.native.version>
     <keycloak.version>22.0.4</keycloak.version>
     <jbossws-cxf-client.version>6.2.0.Final</jbossws-cxf-client.version>
     <apache-cxf.version>4.0.0</apache-cxf.version>


### PR DESCRIPTION
- Fix wrong color rendering of  jpeg2000 with YBR_FULL color model when the JP2 file header is not sent in the JPEG 2000 bit stream that is encapsulated in DICOM
- Update to java 17 and use only java.lang.Cleaner for native memory management instead finalize() which is depracted for removal since java 18.