### PR TITLE
Removed whitespace in the application name used in MessageBuilder.writeHeader method

### DIFF
--- a/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
+++ b/dcm4che-net-audit/src/main/java/org/dcm4che3/net/audit/AuditLogger.java
@@ -984,7 +984,7 @@ public class AuditLogger {
             else
                 write('-');
             write(' ');
-            write(applicationName().getBytes(encoding));
+            write(applicationName().replaceAll("\\s", "").getBytes(encoding));
             write(' ');
             write(processID.getBytes(encoding));
             write(' ');


### PR DESCRIPTION
Remove whitespace from the header used for syslog to avoid compatibility problems with 3rd party solutions that check the syslog header for validity.