### PR TITLE
Update to openCV 4.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ dcm4che uses a native library for the compression and decompression of images. H
 | System  | Architecture | Package        | Requirement            |
 |:--------|:-------------|:---------------|:-----------------------|
 | Linux   | x86 64-bit   | linux-x86-64   | GLIBC_2.17             |
-| Linux   | x86 32-bit   | linux-x86      | GLIBC_2.17             |
 | Linux   | ARM 64-bit   | linux-aarch64  | GLIBC_2.27             |
-| Linux   | ARM 32-bit   | linux-armv7a   | GLIBC_2.17             |
-| Linux   | s390x        | linux-s390x    | GLIBC_2.17             |
+| Linux   | ARM 32-bit   | linux-armv7a   | GLIBC_2.28             |
 | Windows | x86 64-bit   | windows-x86-64 | Windows 7 or higher    |
 | Windows | x86 32-bit   | windows-x86    | Windows 7 or higher    |
 | Mac OS  | x86 64-bit   | macosx-x86-64  | Mac OS 10.13 or higher |

--- a/dcm4che-assembly/pom.xml
+++ b/dcm4che-assembly/pom.xml
@@ -128,6 +128,48 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>exportAntProperties</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <target>
+                <!-- <echoproperties />-->
+                <!-- <echo>some.libopencv_java.path=${org.weasis.thirdparty.org.opencv:libopencv_java:so:linux-x86-64}</echo>-->
+              </target>
+              <exportAntProperties>true</exportAntProperties>
+              <!-- @NOTE : exportAntProperties is required for build-helper-maven to read the supplied value property ${groupId:artifactId:type[:classifier]}-->
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>resolve weasis.opencv.native.version - property</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>weasis.opencv.native.version</name>
+              <!--suppress UnresolvedMavenProperty -->
+              <value>${org.weasis.thirdparty.org.opencv:libopencv_java:so:linux-x86-64}</value>
+              <regex>.*libopencv_java\/(.*)\/libopencv_java.*</regex>
+              <replacement>$1</replacement>
+              <failIfNoMatch>true</failIfNoMatch>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>
@@ -568,63 +610,42 @@
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>so</type>
       <classifier>linux-x86-64</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
-      <type>so</type>
-      <classifier>linux-x86</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.weasis.thirdparty.org.opencv</groupId>
-      <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
-      <type>so</type>
-      <classifier>linux-s390x</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.weasis.thirdparty.org.opencv</groupId>
-      <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>so</type>
       <classifier>linux-armv7a</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>so</type>
       <classifier>linux-aarch64</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>dylib</type>
       <classifier>macosx-x86-64</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>dylib</type>
       <classifier>macosx-aarch64</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>opencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>dll</type>
       <classifier>windows-x86</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>opencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>dll</type>
       <classifier>windows-x86-64</classifier>
     </dependency>

--- a/dcm4che-assembly/src/main/assembly/component.xml
+++ b/dcm4che-assembly/src/main/assembly/component.xml
@@ -242,22 +242,6 @@
     </dependencySet>
     <dependencySet>
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
-      <outputDirectory>lib/linux-x86</outputDirectory>
-      <includes>
-        <include>*:*:so:linux-x86:*</include>
-      </includes>
-      <useProjectArtifact>false</useProjectArtifact>
-    </dependencySet>
-    <dependencySet>
-      <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
-      <outputDirectory>lib/linux-s390x</outputDirectory>
-      <includes>
-        <include>*:*:so:linux-s390x:*</include>
-      </includes>
-      <useProjectArtifact>false</useProjectArtifact>
-    </dependencySet>
-    <dependencySet>
-      <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
       <outputDirectory>lib/linux-armv7a</outputDirectory>
       <includes>
         <include>*:*:so:linux-armv7a:*</include>

--- a/dcm4che-imageio-opencv/pom.xml
+++ b/dcm4che-imageio-opencv/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>org.weasis.core</groupId>
       <artifactId>weasis-core-img</artifactId>
-      <version>${weasis.core.img.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/dcm4che-imageio-test/pom.xml
+++ b/dcm4che-imageio-test/pom.xml
@@ -241,7 +241,6 @@
                 <artifactItem>
                   <groupId>org.weasis.thirdparty.org.opencv</groupId>
                   <artifactId>${lib-file-name}</artifactId>
-                  <version>${weasis.opencv.native.version}</version>
                   <type>${lib-file-ext}</type>
                   <classifier>${os-name}-${cpu-name}</classifier>
                   <overWrite>false</overWrite>

--- a/dcm4che-jboss-modules/pom.xml
+++ b/dcm4che-jboss-modules/pom.xml
@@ -162,61 +162,46 @@
     <dependency>
       <groupId>org.weasis.core</groupId>
       <artifactId>weasis-core-img</artifactId>
-      <version>${weasis.core.img.version}</version>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>so</type>
       <classifier>linux-x86-64</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
-      <type>so</type>
-      <classifier>linux-x86</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.weasis.thirdparty.org.opencv</groupId>
-      <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>so</type>
       <classifier>linux-armv7a</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>so</type>
       <classifier>linux-aarch64</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>dylib</type>
       <classifier>macosx-x86-64</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>libopencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>dylib</type>
       <classifier>macosx-aarch64</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>opencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>dll</type>
       <classifier>windows-x86</classifier>
     </dependency>
     <dependency>
       <groupId>org.weasis.thirdparty.org.opencv</groupId>
       <artifactId>opencv_java</artifactId>
-      <version>${weasis.opencv.native.version}</version>
       <type>dll</type>
       <classifier>windows-x86-64</classifier>
     </dependency>

--- a/dcm4che-jboss-modules/src/main/assembly/modules.xml
+++ b/dcm4che-jboss-modules/src/main/assembly/modules.xml
@@ -155,14 +155,6 @@
     </dependencySet>
     <dependencySet>
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
-      <outputDirectory>/modules/org/dcm4che/imageio/main/lib/linux-i686</outputDirectory>
-      <includes>
-        <include>*:*:so:linux-x86:*</include>
-      </includes>
-      <useProjectArtifact>false</useProjectArtifact>
-    </dependencySet>
-    <dependencySet>
-      <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
       <outputDirectory>/modules/org/dcm4che/imageio/main/lib/linux-x86_64</outputDirectory>
       <includes>
         <include>*:*:so:linux-x86-64:*</include>

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <slf4j.version>2.0.9</slf4j.version>
     <logback.version>1.4.14</logback.version>
-    <weasis.core.img.version>4.8.1</weasis.core.img.version>
-    <weasis.opencv.native.version>4.8.1-dcm</weasis.opencv.native.version>
+    <weasis.core.img.version>4.9.0.1</weasis.core.img.version>
     <keycloak.version>24.0.1</keycloak.version>
     <jbossws-cxf-client.version>7.0.0.Final</jbossws-cxf-client.version>
     <apache-cxf.version>4.0.0</apache-cxf.version>
@@ -333,6 +332,18 @@
         <groupId>com.sun.xml.ws</groupId>
         <artifactId>rt</artifactId>
         <version>${jakarta.xml.ws.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.weasis.core</groupId>
+        <artifactId>weasis-core-img-bom</artifactId>
+        <version>${weasis.core.img.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.weasis.core</groupId>
+        <artifactId>weasis-core-img</artifactId>
+        <version>${weasis.core.img.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
- Update to OpenCV 4.9.0
- Update to OpenJPEG 2.5.2
- Remove linux-x86 (JDK 17 32-bit is not distributed anymore)
- Remove linux-s390x (removed until build issue will be fixed)
- Fix #1405
- Import weasis-core-img-bom in dependencyMgmt to get weasis.opencv.native.version transitively

This last point allows retrieving automatically the native version. This reduces the risk of inconsistent versions between weais-core-img and its native part.