### PR TITLE
Update Transcoder.java

### DIFF
--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Transcoder.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Transcoder.java
@@ -593,7 +593,8 @@ public class Transcoder implements Closeable {
                     : originalBi;
             compressFrame(i);
         }
-        dis.skipFully(padding);
+        if(decompressor == null)
+            dis.skipFully(padding);
         dos.writeHeader(Tag.SequenceDelimitationItem, null, 0);
     }
 


### PR DESCRIPTION
If reading a compressed frame the padding will always be negative and do nothing in the skipFully function because of the negative padding check. 

This is unless the compressed size is actually larger than the uncompressed size (due to bad compression algo selection) and then this will result in a positive number and cause an EOF Exception.

We should only skip if the  frame hasn't been decompressed.

Resolves https://github.com/dcm4che/dcm4che/issues/1411