### PR TITLE
Avoid NullPointerException when setting a null Date value

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/StringValueType.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/StringValueType.java
@@ -553,6 +553,9 @@ enum StringValueType implements ValueType {
         if (ds == null || ds.length == 0)
             return Value.NULL;
 
+        if (ds.length == 1 && ds[0] == null)
+            return Value.NULL;
+
         if (ds.length == 1)
             return temporalType.format(tz, ds[0], precision);
 

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTemporalTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTemporalTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests the Date and Time handling of {@link Attributes}.
@@ -68,6 +69,20 @@ public class AttributesTemporalTest {
                 DateUtils.parseDT(null, "20110404150000.000", new DatePrecision()));
         assertEquals("20110404", a.getString(Tag.StudyDate, null));
         assertEquals("150000.000", a.getString(Tag.StudyTime, null));
+    }
+
+    /**
+     * Test method for {@link org.dcm4che3.data.Attributes#setDate(int, VR, Date...)}.
+     */
+    @Test
+    public void testSetDateNullValue() {
+        Attributes a = new Attributes();
+        a.setDate(Tag.StudyDate, VR.DA, (Date) null);
+        assertNull(a.getDate(Tag.StudyDate));
+
+        Date nullValue = null;
+        a.setDate(Tag.StudyDate, nullValue);
+        assertNull(a.getDate(Tag.StudyDate));
     }
 
     /**


### PR DESCRIPTION
Given the following code:
`
Date nullValue = null;
a.setDate(Tag.StudyDate, nullValue);
`
a NullPointer is thrown since the nullValue is handled as an array with one null item (varargs)

I propose a simple check to handle this case