### PR TITLE
fixes #1484: Use correct threshold for HEVC level

### DIFF
--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/mp4/MP4Parser.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/mp4/MP4Parser.java
@@ -166,7 +166,7 @@ public class MP4Parser implements XPEGParser {
                 }
                 throw profileLevelNotSupported("MPEG-4 AVC profile_idc/level_idc: %d/%d not supported");
             case VisualSampleEntryTypeHVC1:
-                if (level_idc <= 51) {
+                if (level_idc <= 153) {
                     switch (profile_idc) {
                         case 1: // Main Profile
                             return UID.HEVCMP51;


### PR DESCRIPTION
Correct level calculation is level times 30, which leads to 153 for level 5.1. See linked issue for more information.