### PR TITLE
Fix: Unknown tag vr should default to UN

### DIFF
--- a/dcm4che-json/src/main/java/org/dcm4che3/json/JSONReader.java
+++ b/dcm4che-json/src/main/java/org/dcm4che3/json/JSONReader.java
@@ -203,6 +203,9 @@ public class JSONReader {
         expect(JsonParser.Event.END_OBJECT);
         if (el.vr == null) {
             el.vr = ElementDictionary.getStandardElementDictionary().vrOf(tag);
+            if (el.vr == null) {
+                el.vr = VR.UN;
+            }
             LOG.info("Missing property: vr at {} - treat as '{}'", parser.getLocation(), el.vr);
         }
         if (el.isEmpty())


### PR DESCRIPTION
Small fix to set UN as the VR for unknown tag values.  This allows parsing of invalid DICOM JSON files with privates not having a correct VR set.