### PR TITLE
WADO: 1/0 Windowing creates single value LUT with wrong value (0x00 i…

### DIFF
--- a/dcm4che-image/src/main/java/org/dcm4che3/image/LookupTableFactory.java
+++ b/dcm4che-image/src/main/java/org/dcm4che3/image/LookupTableFactory.java
@@ -275,6 +275,8 @@ public class LookupTableFactory {
                 int maxIndex = inBits.maxValue() - offset;
                 int size_1 = size - 1;
                 int midIndex = size / 2;
+                if (midIndex == size_1)
+                    midIndex--;
                 if (minIndex > 0) {
                     offset += minIndex;
                     size -= minIndex;


### PR DESCRIPTION
…nstead of 0xff)