### PR TITLE
IEI-190865 Align EI Implementation Class UID with Agfa's UID root

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Implementation.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Implementation.java
@@ -43,7 +43,7 @@ package org.dcm4che3.data;
  */
 public class Implementation {
 
-    private static final String IMPL_CLASS_UID = "1.2.40.0.13.1.3";
+    private static final String IMPL_CLASS_UID = "1.3.51.0.42.1.1";
     private static final String IMPL_VERS_NAME = versionName();
     private static String versionName() {
 


### PR DESCRIPTION
Align EI Implementation Class UID with Agfa's UID root- association negotiation

Update DICOM Implementation Class UID uses in association negotiation to use the new EI Implementation Class UID (based on the new Agfa UID root): 1.3.51.0.42.1.1