### PR TITLE
Improve JPEG Parser

### DIFF
--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/XPEGParserException.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/XPEGParserException.java
@@ -51,4 +51,8 @@ public class XPEGParserException extends IOException {
     public XPEGParserException(String message) {
         super(message);
     }
+
+    public XPEGParserException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }


### PR DESCRIPTION
This commit improves the JPEG parser. The main changes are:

- Enhanced the JPEG parsing logic to better handle different JPEG markers and color interpretations, including support for RGB and JFIF detection.
- Updated the handling of SOF markers and SOS parameters to more robustly determine the correct DICOM Transfer Syntax UID for various JPEG formats.
- Improved error handling and added more specific exceptions for missing or invalid JPEG segments.
- Modified the logic for setting the Photometric Interpretation, supporting cases for MONOCHROME2, RGB, YBR_FULL, and YBR_FULL_422.
- Made Params accessible.
- Added a constructor to XPEGParserException to allow attaching a cause (Throwable).

These changes were made in relation to this [test class](https://github.com/nroduit/weasis-dicom-tools/blob/refactor/weasis-dicom-tools/src/test/java/org/dcm4che3/imageio/codec/TransferSyntaxTypeTest.java), which also includes integration tests with real image samples.