### PR TITLE
Use system properties for default TO_STRING_LIMI and TO_STRING_WIDTH in Attributes.toString()

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/Attributes.java
@@ -99,8 +99,8 @@ public class Attributes implements Serializable {
             LoggerFactory.getLogger(Attributes.class);
 
     private static final int INIT_CAPACITY = 16;
-    private static final int TO_STRING_LIMIT = 50;
-    private static final int TO_STRING_WIDTH = 78;
+    private static final int TO_STRING_LIMIT = Integer.getInteger("org.dcm4che3.Attributes.toString.limit", 50);
+    private static final int TO_STRING_WIDTH = Integer.getInteger("org.dcm4che3.Attributes.toString.width", 78);
     private transient Attributes parent;
     private transient String parentSequencePrivateCreator;
     private transient int parentSequenceTag;


### PR DESCRIPTION
The TO_STRING_LIMIT and TO_STRING_WIDTH properties can only be changed using an override of `Attributes.toString()`. This PR first looks for system property values `org.dcm4che3.Atributes.toString.limit` and `org.dcm4che3.Attributes.toString.width` to use as default values, falling back to the current default values if those properties are not found.