### PR TITLE
Override missing toBytes(long l, byte[] b, int off, boolean bigEndian…

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/BinaryValueType.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/BinaryValueType.java
@@ -69,6 +69,11 @@ enum BinaryValueType implements ValueType {
             b[off] = (byte) i;
             return b;
         }
+
+        @Override
+        protected byte[] toBytes(long l, byte[] b, int off, boolean bigEndian) {
+            return toBytes((int) l, b, off, bigEndian);
+        }
     },
     SHORT(2, 2) {
 

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
@@ -824,4 +824,13 @@ public class AttributesTest {
 
         assertEquals(5, attributes.size());
     }
+
+    @Test
+    public void setString_GivenAttributeWithOBVR_SetsAttributeSuccessfully() throws IOException {
+        Attributes attributes = new Attributes();
+        attributes.setString(Tag.FileMetaInformationVersion, VR.OB, "00", "01");
+        byte[] expected = {0, 1};
+        byte[] actual = attributes.getBytes(Tag.FileMetaInformationVersion);
+        assertArrayEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
Override missing toBytes(long l, byte[] b, int off, boolean bigEndian) method in BYTE BinaryValueType #1537