### PR TITLE
Fix JPEG XL Lossless compression with Bits Stored other than 8 or 16

### DIFF
--- a/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJXLImageWriter.java
+++ b/dcm4che-imageio-opencv/src/main/java/org/dcm4che3/opencv/NativeJXLImageWriter.java
@@ -123,6 +123,7 @@ class NativeJXLImageWriter extends ImageWriter {
                 mat = ImageConversion.toMat(renderedImage, param.getSourceRegion(), true);
 
                 int bitCompressed = desc.getBitsCompressed();
+                bitCompressed = ((bitCompressed + 7) / 8) * 8;
                 int cvType = mat.type();
                 int channels = CvType.channels(cvType);
                 int epi = channels == 1 ? Imgcodecs.EPI_Monochrome2 : Imgcodecs.EPI_RGB;


### PR DESCRIPTION
See https://github.com/dcm4che/dcm4che/issues/1540