### PR TITLE
IEI-390328 Frequent ClassCastExceptions in server logs - failing storage

### DIFF
--- a/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/AttributesTest.java
@@ -949,6 +949,28 @@ public class AttributesTest {
             assertEquals("CODE" + i, modifiedAttributes.getString(Tag.ValueType));
         }
     }
+    
+    @Test
+    public void updateRecursive_GivenSequenceWithOneItemAndSequenceWithNullInOriginal_UpdatesEntireSequence() {
+    	Attributes original = new Attributes();
+    	original.setValue(Tag.ContentSequence, VR.SQ, Value.NULL);
+        Attributes updated = new Attributes();
+        Sequence updatedSequence = updated.ensureSequence(Tag.ContentSequence, 1);
+
+        Attributes updatedContentItem = new Attributes();
+        updatedContentItem.setString(Tag.ValueType, VR.CS, "TEXT");
+        updatedContentItem.setString(Tag.TextValue, VR.UT, "Text Value");
+        updatedSequence.add(updatedContentItem);
+        
+        original.updateRecursive(updated);
+
+        Sequence sequence = original.getSequence(Tag.ContentSequence);
+        assertEquals(1, sequence.size());
+
+        Attributes attributes = sequence.get(0);
+        assertEquals("TEXT", attributes.getString(Tag.ValueType));
+        assertEquals("Text Value", attributes.getString(Tag.TextValue));
+    }
 
     @Test
     public void setString_GivenAttributeWithOBVR_SetsAttributeSuccessfully() throws IOException {


### PR DESCRIPTION
- Fix ClassCastExceptions when updating an existing value with a Sequence value and the existing value is Value.NULL

(cherry picked from commit 475c57a006bf01b489d5faa03f923e79ed49aac9) IEI-390338 CLONE [8.4.4] - Frequent ClassCastExceptions in server logss - failing storage