### PR TITLE
IEI-371387 Performance: DCM4CHE compressor writes to output stream one byte at a time

### DIFF
--- a/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Compressor.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che3/imageio/codec/Compressor.java
@@ -336,6 +336,11 @@ public class Compressor implements Closeable {
         public void set(OutputStream out) {
             this.out = out;
         }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+        	out.write(b, off, len);
+        }
     }
 
     private static class FlushlessMemoryCacheImageOutputStream extends MemoryCacheImageOutputStream {

--- a/dcm4che-imageio/src/test/java/org/dcm4che3/imageio/codec/CompressorTest.java
+++ b/dcm4che-imageio/src/test/java/org/dcm4che3/imageio/codec/CompressorTest.java
@@ -1,0 +1,61 @@
+package org.dcm4che3.imageio.codec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.Tag;
+import org.dcm4che3.data.UID;
+import org.dcm4che3.io.DicomInputStream;
+import org.dcm4che3.io.DicomOutputStream;
+import org.junit.Test;
+
+public class CompressorTest {
+
+    @Test
+    public void testCompress_GivenMultiframeImage_WritesMostDataUsingBuffers() throws Exception {
+        
+        try (CountOutputStream cos = new CountOutputStream()) {
+            test("cplx_p02.dcm", cos, UID.JPEGBaseline8Bit);
+
+            assertTrue("Individual bytes written", cos.byteCount < 80000 && cos.byteCount > 0);
+            assertTrue("Bytes written using buffers", cos.bufferCount > 80000);
+        }
+    }
+
+    private void test(String inputFileName, OutputStream outputStream, String outTransferSyntax) throws IOException {
+        File inputFile = new File("target/test-data/" + inputFileName);
+
+        try (DicomInputStream dis = new DicomInputStream(inputFile)) {
+        	Attributes attributes = dis.readDataset();
+            try (Compressor compressor = new Compressor(attributes,
+            		dis.getFileMetaInformation().getString(Tag.TransferSyntaxUID), outTransferSyntax)) {
+            	compressor.compress();
+
+            	try (DicomOutputStream dos = new DicomOutputStream(outputStream, outTransferSyntax)) {
+            		Attributes newFmi = attributes.createFileMetaInformation(outTransferSyntax);
+            		dos.writeDataset(newFmi, attributes);
+            	}
+            }
+        }
+    }
+    
+    private static class CountOutputStream extends OutputStream {
+    	public int byteCount;
+    	public int bufferCount;
+    	
+    	@Override
+    	public void write(byte[] b, int off, int len) {
+    		bufferCount += len;
+    	}
+
+		@Override
+		public void write(int b) throws IOException {
+			byteCount++;
+		}
+    }
+}


### PR DESCRIPTION
- Added write(byte b[], int off, int len) method to class so that bytes are not written one byte at a time.