### PR TITLE
Add HTJ2K encode support via OpenJPH native library

### DIFF
--- a/dcm4che-assembly/pom.xml
+++ b/dcm4che-assembly/pom.xml
@@ -255,6 +255,11 @@
     </dependency>
     <dependency>
       <groupId>org.dcm4che</groupId>
+      <artifactId>dcm4che-imageio-openjph</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.dcm4che</groupId>
       <artifactId>dcm4che-imageio-rle</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -648,6 +653,30 @@
       <artifactId>opencv_java</artifactId>
       <type>dll</type>
       <classifier>windows-x86-64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.dcm4che</groupId>
+      <artifactId>dcm4che-openjph-native</artifactId>
+      <type>so</type>
+      <classifier>linux-x86-64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.dcm4che</groupId>
+      <artifactId>dcm4che-openjph-native</artifactId>
+      <type>so</type>
+      <classifier>linux-aarch64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.dcm4che</groupId>
+      <artifactId>dcm4che-openjph-native</artifactId>
+      <type>dll</type>
+      <classifier>windows-x86-64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.dcm4che</groupId>
+      <artifactId>dcm4che-openjph-native</artifactId>
+      <type>dylib</type>
+      <classifier>macosx-aarch64</classifier>
     </dependency>
   </dependencies>
 </project>

--- a/dcm4che-assembly/src/main/assembly/component.xml
+++ b/dcm4che-assembly/src/main/assembly/component.xml
@@ -121,6 +121,7 @@
         <include>org.dcm4che:dcm4che-image</include>
         <include>org.dcm4che:dcm4che-imageio</include>
         <include>org.dcm4che:dcm4che-imageio-opencv</include>
+        <include>org.dcm4che:dcm4che-imageio-openjph</include>
         <include>org.dcm4che:dcm4che-imageio-rle</include>
         <include>org.dcm4che:dcm4che-json</include>
         <include>org.dcm4che:dcm4che-mime</include>
@@ -238,6 +239,17 @@
       <includes>
         <include>*:*:so:linux-x86-64:*</include>
       </includes>
+      <excludes>
+        <exclude>org.dcm4che:dcm4che-openjph-native</exclude>
+      </excludes>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <outputFileNameMapping>libopenjph_jni.${artifact.extension}</outputFileNameMapping>
+      <outputDirectory>lib/linux-x86-64</outputDirectory>
+      <includes>
+        <include>org.dcm4che:dcm4che-openjph-native:so:linux-x86-64:*</include>
+      </includes>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
     <dependencySet>
@@ -253,6 +265,17 @@
       <outputDirectory>lib/linux-aarch64</outputDirectory>
       <includes>
         <include>*:*:so:linux-aarch64:*</include>
+      </includes>
+      <excludes>
+        <exclude>org.dcm4che:dcm4che-openjph-native</exclude>
+      </excludes>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <outputFileNameMapping>libopenjph_jni.${artifact.extension}</outputFileNameMapping>
+      <outputDirectory>lib/linux-aarch64</outputDirectory>
+      <includes>
+        <include>org.dcm4che:dcm4che-openjph-native:so:linux-aarch64:*</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
@@ -270,6 +293,17 @@
       <includes>
         <include>*:*:dylib:macosx-aarch64:*</include>
       </includes>
+      <excludes>
+        <exclude>org.dcm4che:dcm4che-openjph-native</exclude>
+      </excludes>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <outputFileNameMapping>libopenjph_jni.${artifact.extension}</outputFileNameMapping>
+      <outputDirectory>lib/macosx-aarch64</outputDirectory>
+      <includes>
+        <include>org.dcm4che:dcm4che-openjph-native:dylib:macosx-aarch64:*</include>
+      </includes>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
     <dependencySet>
@@ -285,6 +319,17 @@
       <outputDirectory>lib/windows-x86-64</outputDirectory>
       <includes>
         <include>*:*:dll:windows-x86-64:*</include>
+      </includes>
+      <excludes>
+        <exclude>org.dcm4che:dcm4che-openjph-native</exclude>
+      </excludes>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <outputFileNameMapping>openjph_jni.${artifact.extension}</outputFileNameMapping>
+      <outputDirectory>lib/windows-x86-64</outputDirectory>
+      <includes>
+        <include>org.dcm4che:dcm4che-openjph-native:dll:windows-x86-64:*</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>

--- a/dcm4che-imageio-openjph/pom.xml
+++ b/dcm4che-imageio-openjph/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.dcm4che</groupId>
+    <artifactId>dcm4che-parent</artifactId>
+    <version>5.34.3</version>
+  </parent>
+  <artifactId>dcm4che-imageio-openjph</artifactId>
+  <name>dcm4che-imageio-openjph</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.dcm4che</groupId>
+      <artifactId>dcm4che-imageio</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/HTJ2kImageWriteParam.java
+++ b/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/HTJ2kImageWriteParam.java
@@ -1,0 +1,130 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is part of dcm4che, an implementation of DICOM(TM) in
+ * Java(TM), hosted at https://github.com/dcm4che.
+ *
+ * The Initial Developer of the Original Code is
+ * J4Care.
+ * Portions created by the Initial Developer are Copyright (C) 2025
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ * See @authors listed below
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+package org.dcm4che3.openjph;
+
+import java.util.Locale;
+
+import javax.imageio.ImageWriteParam;
+
+/**
+ * Write parameters for HTJ2K encoding via OpenJPH.
+ *
+ * @since Feb 2025
+ */
+public class HTJ2kImageWriteParam extends ImageWriteParam {
+
+    private static final String[] COMPRESSION_TYPES = { "LOSSY", "LOSSLESS" };
+
+    private int compressionRatiofactor;
+    private int progressionOrder;
+    private int decompositions;
+
+    public HTJ2kImageWriteParam(Locale locale) {
+        super(locale);
+        super.canWriteCompressed = true;
+        super.compressionMode = MODE_EXPLICIT;
+        super.compressionType = "LOSSY";
+        super.compressionTypes = COMPRESSION_TYPES;
+        this.compressionRatiofactor = 10;
+        this.progressionOrder = OpenJPH.PROGRESSION_LRCP;
+        this.decompositions = 5;
+    }
+
+    @Override
+    public void setCompressionType(String compressionType) {
+        super.setCompressionType(compressionType);
+        if (isCompressionLossless()) {
+            this.compressionRatiofactor = 0;
+        }
+    }
+
+    @Override
+    public boolean isCompressionLossless() {
+        return compressionType.equals("LOSSLESS");
+    }
+
+    public int getCompressionRatiofactor() {
+        return compressionRatiofactor;
+    }
+
+    /**
+     * Set the lossy compression ratio factor.
+     *
+     * Near-lossless compression ratios of 5:1 to 20:1 (e.g. compressionRatiofactor = 10)
+     *
+     * Lossy compression with acceptable degradation can have ratios of 30:1 to 100:1
+     * (e.g. compressionRatiofactor = 50)
+     *
+     * @param compressionRatiofactor the compression ratio
+     */
+    public void setCompressionRatiofactor(int compressionRatiofactor) {
+        this.compressionRatiofactor = compressionRatiofactor;
+    }
+
+    public int getProgressionOrder() {
+        return progressionOrder;
+    }
+
+    /**
+     * Set the progression order.
+     *
+     * @param progressionOrder one of the {@code OpenJPH.PROGRESSION_*} constants
+     * @see OpenJPH#PROGRESSION_LRCP
+     * @see OpenJPH#PROGRESSION_RPCL
+     */
+    public void setProgressionOrder(int progressionOrder) {
+        if (progressionOrder < OpenJPH.PROGRESSION_LRCP || progressionOrder > OpenJPH.PROGRESSION_CPRL) {
+            throw new IllegalArgumentException("Invalid progression order: " + progressionOrder);
+        }
+        this.progressionOrder = progressionOrder;
+    }
+
+    public int getDecompositions() {
+        return decompositions;
+    }
+
+    /**
+     * Set the number of DWT decomposition levels.
+     *
+     * @param decompositions number of decomposition levels (default 5)
+     */
+    public void setDecompositions(int decompositions) {
+        this.decompositions = decompositions;
+    }
+}

--- a/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/NativeHTJ2kImageWriter.java
+++ b/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/NativeHTJ2kImageWriter.java
@@ -1,0 +1,299 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is part of dcm4che, an implementation of DICOM(TM) in
+ * Java(TM), hosted at https://github.com/dcm4che.
+ *
+ * The Initial Developer of the Original Code is
+ * J4Care.
+ * Portions created by the Initial Developer are Copyright (C) 2025
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ * See @authors listed below
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+package org.dcm4che3.openjph;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.ComponentSampleModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
+import java.awt.image.DataBufferShort;
+import java.awt.image.DataBufferUShort;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import java.io.IOException;
+import java.nio.ByteOrder;
+
+import javax.imageio.IIOException;
+import javax.imageio.IIOImage;
+import javax.imageio.ImageTypeSpecifier;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.metadata.IIOMetadata;
+import javax.imageio.spi.ImageWriterSpi;
+import javax.imageio.stream.ImageOutputStream;
+
+import org.dcm4che3.imageio.codec.BytesWithImageImageDescriptor;
+import org.dcm4che3.imageio.codec.ImageDescriptor;
+
+/**
+ * HTJ2K image writer using OpenJPH native library via JNI.
+ *
+ * <p>Unlike the OpenCV-based writers, this writer extracts raw pixel bytes
+ * directly from {@link RenderedImage} using pure Java AWT APIs, avoiding
+ * any OpenCV/weasis-core-img dependency.</p>
+ *
+ * @since Feb 2025
+ */
+class NativeHTJ2kImageWriter extends ImageWriter {
+
+    NativeHTJ2kImageWriter(ImageWriterSpi originatingProvider) {
+        super(originatingProvider);
+    }
+
+    @Override
+    public ImageWriteParam getDefaultWriteParam() {
+        return new HTJ2kImageWriteParam(getLocale());
+    }
+
+    @Override
+    public void write(IIOMetadata streamMetadata, IIOImage image, ImageWriteParam param) throws IOException {
+        if (output == null) {
+            throw new IllegalStateException("output cannot be null");
+        }
+        if (!(output instanceof ImageOutputStream)) {
+            throw new IllegalArgumentException("output is not an ImageOutputStream!");
+        }
+        ImageOutputStream stream = (ImageOutputStream) output;
+        stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
+
+        HTJ2kImageWriteParam htj2kParams = (HTJ2kImageWriteParam) param;
+
+        if (!(stream instanceof BytesWithImageImageDescriptor)) {
+            throw new IllegalArgumentException("stream does not implement BytesWithImageImageDescriptor!");
+        }
+        ImageDescriptor desc = ((BytesWithImageImageDescriptor) stream).getImageDescriptor();
+
+        RenderedImage renderedImage = image.getRenderedImage();
+
+        try {
+            int width = renderedImage.getWidth();
+            int height = renderedImage.getHeight();
+            int samples = desc.getSamples();
+            int bitsStored = desc.getBitsCompressed();
+            boolean signed = desc.isSigned();
+
+            byte[] rawPixelData = extractPixelData(renderedImage, width, height, samples, bitsStored, signed);
+
+            boolean reversible = htj2kParams.isCompressionLossless();
+            float compressionRatio = reversible ? 0.0f : (float) htj2kParams.getCompressionRatiofactor();
+            int progressionOrder = htj2kParams.getProgressionOrder();
+            int decompositions = htj2kParams.getDecompositions();
+
+            byte[] encoded = OpenJPH.encode(
+                    rawPixelData,
+                    width,
+                    height,
+                    samples,
+                    bitsStored,
+                    signed,
+                    reversible,
+                    compressionRatio,
+                    progressionOrder,
+                    decompositions);
+
+            stream.write(encoded);
+        } catch (OpenJPHException e) {
+            throw new IIOException("Native HTJ2K encoding error", e);
+        } catch (Throwable t) {
+            throw new IIOException("Native HTJ2K encoding error", t);
+        }
+    }
+
+    /**
+     * Extract raw pixel data from a RenderedImage into a byte array
+     * in pixel-interleaved layout suitable for OpenJPH.
+     *
+     * <p>Uses direct access to backing arrays when possible to avoid
+     * unnecessary memory copies. Falls back to {@code getSamples()} for
+     * non-standard raster layouts.</p>
+     */
+    private static byte[] extractPixelData(RenderedImage ri, int width, int height,
+                                           int samples, int bitsStored, boolean signed) {
+        // BufferedImage.getRaster() returns the live raster (no copy).
+        // RenderedImage.getData() creates a full copy of the raster.
+        Raster raster;
+        if (ri instanceof BufferedImage) {
+            raster = ((BufferedImage) ri).getRaster();
+        } else {
+            raster = ri.getData();
+        }
+        int dataType = raster.getDataBuffer().getDataType();
+
+        if (dataType == DataBuffer.TYPE_BYTE) {
+            return extractBytePixelData(raster, width, height, samples);
+        } else if (dataType == DataBuffer.TYPE_USHORT || dataType == DataBuffer.TYPE_SHORT) {
+            return extractShortPixelData(raster, width, height, samples);
+        } else {
+            throw new IllegalArgumentException("Unsupported DataBuffer type: " + dataType);
+        }
+    }
+
+    private static byte[] extractBytePixelData(Raster raster, int width, int height, int samples) {
+        int pixelCount = width * height;
+        int totalBytes = pixelCount * samples;
+
+        // Fast path: direct access to backing byte[] avoids int[] intermediates
+        DataBuffer dataBuffer = raster.getDataBuffer();
+        SampleModel sm = raster.getSampleModel();
+        if (dataBuffer instanceof DataBufferByte && sm instanceof ComponentSampleModel) {
+            ComponentSampleModel csm = (ComponentSampleModel) sm;
+            byte[] bank = ((DataBufferByte) dataBuffer).getData();
+            if (bank.length == totalBytes) {
+                if (samples == 1
+                        && csm.getPixelStride() == 1
+                        && csm.getScanlineStride() == width) {
+                    return bank;
+                }
+                if (samples > 1
+                        && csm.getPixelStride() == samples
+                        && csm.getScanlineStride() == width * samples
+                        && hasSequentialBandOffsets(csm.getBandOffsets(), samples)) {
+                    return bank;
+                }
+            }
+        }
+
+        // Fallback: getSamples() returns int[] (4x memory for 8-bit data)
+        byte[] result = new byte[totalBytes];
+        if (samples == 1) {
+            int[] pixels = raster.getSamples(0, 0, width, height, 0, (int[]) null);
+            for (int i = 0; i < pixels.length; i++) {
+                result[i] = (byte) pixels[i];
+            }
+        } else {
+            int[][] bands = new int[samples][];
+            for (int b = 0; b < samples; b++) {
+                bands[b] = raster.getSamples(0, 0, width, height, b, (int[]) null);
+            }
+            for (int i = 0; i < pixelCount; i++) {
+                for (int b = 0; b < samples; b++) {
+                    result[i * samples + b] = (byte) bands[b][i];
+                }
+            }
+        }
+        return result;
+    }
+
+    private static byte[] extractShortPixelData(Raster raster, int width, int height, int samples) {
+        int pixelCount = width * height;
+        byte[] result = new byte[pixelCount * samples * 2];
+
+        // Fast path: convert directly from backing short[] to little-endian byte[]
+        // Avoids the int[] intermediate from getSamples() (saves 2x memory per sample)
+        DataBuffer dataBuffer = raster.getDataBuffer();
+        SampleModel sm = raster.getSampleModel();
+        if (sm instanceof ComponentSampleModel) {
+            ComponentSampleModel csm = (ComponentSampleModel) sm;
+            short[] bank = null;
+            if (dataBuffer instanceof DataBufferUShort) {
+                bank = ((DataBufferUShort) dataBuffer).getData();
+            } else if (dataBuffer instanceof DataBufferShort) {
+                bank = ((DataBufferShort) dataBuffer).getData();
+            }
+            if (bank != null) {
+                boolean contiguous = samples == 1
+                        ? csm.getPixelStride() == 1 && csm.getScanlineStride() == width
+                        : csm.getPixelStride() == samples
+                                && csm.getScanlineStride() == width * samples
+                                && hasSequentialBandOffsets(csm.getBandOffsets(), samples);
+                if (contiguous && bank.length == pixelCount * samples) {
+                    for (int i = 0; i < bank.length; i++) {
+                        int val = bank[i] & 0xFFFF;
+                        result[i * 2] = (byte) val;
+                        result[i * 2 + 1] = (byte) (val >>> 8);
+                    }
+                    return result;
+                }
+            }
+        }
+
+        // Fallback: getSamples() returns int[] (4 bytes per sample value)
+        if (samples == 1) {
+            int[] pixels = raster.getSamples(0, 0, width, height, 0, (int[]) null);
+            for (int i = 0; i < pixels.length; i++) {
+                int val = pixels[i];
+                result[i * 2] = (byte) (val & 0xFF);
+                result[i * 2 + 1] = (byte) ((val >> 8) & 0xFF);
+            }
+        } else {
+            int[][] bands = new int[samples][];
+            for (int b = 0; b < samples; b++) {
+                bands[b] = raster.getSamples(0, 0, width, height, b, (int[]) null);
+            }
+            for (int i = 0; i < pixelCount; i++) {
+                for (int b = 0; b < samples; b++) {
+                    int val = bands[b][i];
+                    int offset = (i * samples + b) * 2;
+                    result[offset] = (byte) (val & 0xFF);
+                    result[offset + 1] = (byte) ((val >> 8) & 0xFF);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static boolean hasSequentialBandOffsets(int[] bandOffsets, int samples) {
+        if (bandOffsets.length != samples) return false;
+        for (int i = 0; i < samples; i++) {
+            if (bandOffsets[i] != i) return false;
+        }
+        return true;
+    }
+
+    @Override
+    public IIOMetadata getDefaultStreamMetadata(ImageWriteParam param) {
+        return null;
+    }
+
+    @Override
+    public IIOMetadata getDefaultImageMetadata(ImageTypeSpecifier imageType, ImageWriteParam param) {
+        return null;
+    }
+
+    @Override
+    public IIOMetadata convertStreamMetadata(IIOMetadata inData, ImageWriteParam param) {
+        return null;
+    }
+
+    @Override
+    public IIOMetadata convertImageMetadata(IIOMetadata inData, ImageTypeSpecifier imageType, ImageWriteParam param) {
+        return null;
+    }
+}

--- a/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/NativeHTJ2kImageWriterSpi.java
+++ b/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/NativeHTJ2kImageWriterSpi.java
@@ -1,0 +1,86 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is part of dcm4che, an implementation of DICOM(TM) in
+ * Java(TM), hosted at https://github.com/dcm4che.
+ *
+ * The Initial Developer of the Original Code is
+ * J4Care.
+ * Portions created by the Initial Developer are Copyright (C) 2025
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ * See @authors listed below
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+package org.dcm4che3.openjph;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import javax.imageio.ImageTypeSpecifier;
+import javax.imageio.ImageWriter;
+import javax.imageio.spi.ImageWriterSpi;
+import javax.imageio.stream.ImageOutputStream;
+
+/**
+ * SPI registration for the OpenJPH-based HTJ2K image writer.
+ *
+ * @since Feb 2025
+ */
+public class NativeHTJ2kImageWriterSpi extends ImageWriterSpi {
+
+    static final String[] NAMES = { "htj2k-openjph" };
+    static final String[] SUFFIXES = { "jhc", "j2c", "jph" };
+    static final String[] MIMES = { "image/jphc" };
+
+    public NativeHTJ2kImageWriterSpi() {
+        super("dcm4che.org", "1.0", NAMES, SUFFIXES, MIMES,
+            NativeHTJ2kImageWriter.class.getName(),
+            new Class[] { ImageOutputStream.class },
+            null, false, null, null, null, null, false, null, null, null, null);
+    }
+
+    @Override
+    public boolean canEncodeImage(ImageTypeSpecifier type) {
+        int bands = type.getNumBands();
+        int dataType = type.getSampleModel().getDataType();
+        return (bands == 1 || bands == 3)
+                && (dataType == java.awt.image.DataBuffer.TYPE_BYTE
+                    || dataType == java.awt.image.DataBuffer.TYPE_USHORT
+                    || dataType == java.awt.image.DataBuffer.TYPE_SHORT);
+    }
+
+    @Override
+    public String getDescription(Locale locale) {
+        return "Natively-accelerated HTJ2K Image Writer (OpenJPH based)";
+    }
+
+    @Override
+    public ImageWriter createWriterInstance(Object extension) throws IOException {
+        return new NativeHTJ2kImageWriter(this);
+    }
+}

--- a/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/OpenJPH.java
+++ b/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/OpenJPH.java
@@ -1,0 +1,97 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is part of dcm4che, an implementation of DICOM(TM) in
+ * Java(TM), hosted at https://github.com/dcm4che.
+ *
+ * The Initial Developer of the Original Code is
+ * J4Care.
+ * Portions created by the Initial Developer are Copyright (C) 2025
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ * See @authors listed below
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+package org.dcm4che3.openjph;
+
+/**
+ * JNI bridge to the OpenJPH HTJ2K encoding library.
+ *
+ * <p>The native method {@link #encode} wraps OpenJPH's {@code ojph::codestream} API.
+ * Raw pixel data (pixel-interleaved for multi-component images) is passed in,
+ * and a fully-formed HTJ2K codestream is returned.</p>
+ *
+ * @since Feb 2025
+ */
+public final class OpenJPH {
+
+    /** Progression order: Layer-Resolution-Component-Position */
+    public static final int PROGRESSION_LRCP = 0;
+    /** Progression order: Resolution-Layer-Component-Position */
+    public static final int PROGRESSION_RLCP = 1;
+    /** Progression order: Resolution-Position-Component-Layer */
+    public static final int PROGRESSION_RPCL = 2;
+    /** Progression order: Position-Component-Resolution-Layer */
+    public static final int PROGRESSION_PCRL = 3;
+    /** Progression order: Component-Position-Resolution-Layer */
+    public static final int PROGRESSION_CPRL = 4;
+
+    static {
+        OpenJPHNativeLoader.load();
+    }
+
+    private OpenJPH() {}
+
+    /**
+     * Encode raw pixel data to an HTJ2K codestream.
+     *
+     * @param rawPixelData pixel data in pixel-interleaved layout (R0G0B0 R1G1B1...)
+     *                     For 16-bit data, stored as little-endian byte pairs.
+     * @param width image width in pixels
+     * @param height image height in pixels
+     * @param components number of color components (1 for mono, 3 for RGB)
+     * @param bitsPerSample bits per sample (8, 12, 16, etc.)
+     * @param isSigned true if pixel values are signed
+     * @param reversible true for lossless (reversible 5/3 wavelet), false for lossy (irreversible 9/7)
+     * @param compressionRatio lossy compression ratio (e.g. 10 for 10:1); ignored if reversible is true
+     * @param progressionOrder progression order (use PROGRESSION_* constants)
+     * @param decompositions number of DWT decomposition levels (default 5)
+     * @return the encoded HTJ2K codestream bytes
+     * @throws OpenJPHException if encoding fails
+     */
+    public static native byte[] encode(
+            byte[] rawPixelData,
+            int width,
+            int height,
+            int components,
+            int bitsPerSample,
+            boolean isSigned,
+            boolean reversible,
+            float compressionRatio,
+            int progressionOrder,
+            int decompositions) throws OpenJPHException;
+}

--- a/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/OpenJPHException.java
+++ b/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/OpenJPHException.java
@@ -1,0 +1,57 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is part of dcm4che, an implementation of DICOM(TM) in
+ * Java(TM), hosted at https://github.com/dcm4che.
+ *
+ * The Initial Developer of the Original Code is
+ * J4Care.
+ * Portions created by the Initial Developer are Copyright (C) 2025
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ * See @authors listed below
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+package org.dcm4che3.openjph;
+
+/**
+ * Exception thrown when OpenJPH encoding fails.
+ *
+ * @since Feb 2025
+ */
+public class OpenJPHException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public OpenJPHException(String message) {
+        super(message);
+    }
+
+    public OpenJPHException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/OpenJPHNativeLoader.java
+++ b/dcm4che-imageio-openjph/src/main/java/org/dcm4che3/openjph/OpenJPHNativeLoader.java
@@ -1,0 +1,74 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is part of dcm4che, an implementation of DICOM(TM) in
+ * Java(TM), hosted at https://github.com/dcm4che.
+ *
+ * The Initial Developer of the Original Code is
+ * J4Care.
+ * Portions created by the Initial Developer are Copyright (C) 2025
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ * See @authors listed below
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+package org.dcm4che3.openjph;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Loads the OpenJPH JNI native library for the current platform.
+ *
+ * <p>The native library must be on {@code java.library.path}. This follows
+ * the same pattern as the OpenCV native loader used by the other dcm4che
+ * image writers.</p>
+ *
+ * @since Feb 2025
+ */
+public final class OpenJPHNativeLoader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenJPHNativeLoader.class);
+
+    private static final String LIB_BASE_NAME = "openjph_jni";
+
+    private static volatile boolean loaded = false;
+
+    private OpenJPHNativeLoader() {}
+
+    public static synchronized void load() {
+        if (loaded) return;
+
+        System.loadLibrary(LIB_BASE_NAME);
+        loaded = true;
+        LOG.info("Loaded native library: {}", LIB_BASE_NAME);
+    }
+
+    public static boolean isLoaded() {
+        return loaded;
+    }
+}

--- a/dcm4che-imageio-openjph/src/main/resources/META-INF/services/javax.imageio.spi.ImageWriterSpi
+++ b/dcm4che-imageio-openjph/src/main/resources/META-INF/services/javax.imageio.spi.ImageWriterSpi
@@ -1,0 +1,1 @@
+org.dcm4che3.openjph.NativeHTJ2kImageWriterSpi

--- a/dcm4che-imageio-test/pom.xml
+++ b/dcm4che-imageio-test/pom.xml
@@ -70,6 +70,7 @@
         <cpu-name>x86-64</cpu-name>
         <lib-file-name>libopencv_java</lib-file-name>
         <lib-file-ext>so</lib-file-ext>
+        <openjph-lib-file-name>libopenjph_jni</openjph-lib-file-name>
       </properties>
     </profile>
     <profile>
@@ -85,6 +86,7 @@
         <cpu-name>aarch64</cpu-name>
         <lib-file-name>libopencv_java</lib-file-name>
         <lib-file-ext>so</lib-file-ext>
+        <openjph-lib-file-name>libopenjph_jni</openjph-lib-file-name>
       </properties>
     </profile>
     <profile>
@@ -115,6 +117,7 @@
         <cpu-name>x86-64</cpu-name>
         <lib-file-name>libopencv_java</lib-file-name>
         <lib-file-ext>dylib</lib-file-ext>
+        <openjph-lib-file-name>libopenjph_jni</openjph-lib-file-name>
       </properties>
     </profile>
     <profile>
@@ -130,6 +133,7 @@
         <cpu-name>aarch64</cpu-name>
         <lib-file-name>libopencv_java</lib-file-name>
         <lib-file-ext>dylib</lib-file-ext>
+        <openjph-lib-file-name>libopenjph_jni</openjph-lib-file-name>
       </properties>
     </profile>
     <profile>
@@ -145,6 +149,7 @@
         <cpu-name>x86-64</cpu-name>
         <lib-file-name>opencv_java</lib-file-name>
         <lib-file-ext>dll</lib-file-ext>
+        <openjph-lib-file-name>openjph_jni</openjph-lib-file-name>
       </properties>
     </profile>
     <profile>
@@ -160,7 +165,46 @@
         <cpu-name>x86</cpu-name>
         <lib-file-name>opencv_java</lib-file-name>
         <lib-file-ext>dll</lib-file-ext>
+        <openjph-lib-file-name>openjph_jni</openjph-lib-file-name>
       </properties>
+    </profile>
+    <profile>
+      <id>with-openjph-native</id>
+      <activation>
+        <property>
+          <name>openjph.native.available</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-openjph</id>
+                <phase>generate-test-resources</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.dcm4che</groupId>
+                      <artifactId>dcm4che-openjph-native</artifactId>
+                      <version>${openjph.native.version}</version>
+                      <type>${lib-file-ext}</type>
+                      <classifier>${os-name}-${cpu-name}</classifier>
+                      <overWrite>false</overWrite>
+                      <outputDirectory>${project.build.directory}/lib/${os-name}-${cpu-name}</outputDirectory>
+                      <destFileName>${openjph-lib-file-name}.${lib-file-ext}</destFileName>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>test-coverage</id>
@@ -279,6 +323,11 @@
     <dependency>
       <groupId>org.dcm4che</groupId>
       <artifactId>dcm4che-imageio-opencv</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.dcm4che</groupId>
+      <artifactId>dcm4che-imageio-openjph</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/dcm4che-imageio-test/src/test/java/org/dcm4che3/imageio/codec/TranscoderTest.java
+++ b/dcm4che-imageio-test/src/test/java/org/dcm4che3/imageio/codec/TranscoderTest.java
@@ -209,6 +209,46 @@ public class TranscoderTest {
     }
 
     @Test
+    public void testCompressToHTJ2KLossless() throws Exception {
+        test("MR2_UNC", "MR2_UNC-HTJ2K-lossless.dcm", UID.HTJ2KLossless, true);
+    }
+
+    @Test
+    public void testCompressToHTJ2KLosslessRPCL() throws Exception {
+        test("MR2_UNC", "MR2_UNC-HTJ2K-lossless-rpcl.dcm", UID.HTJ2KLosslessRPCL, true);
+    }
+
+    @Test
+    public void testCompressToHTJ2KLossy() throws Exception {
+        test("MR2_UNC", "MR2_UNC-HTJ2K-lossy.dcm", UID.HTJ2K, true);
+    }
+
+    @Test
+    public void testCompressRGBToHTJ2KLossless() throws Exception {
+        test("US-RGB-8-esopecho", "US-RGB-8-esopecho-HTJ2K-lossless.dcm", UID.HTJ2KLossless, true);
+    }
+
+    @Test
+    public void testCompressSigned16ToHTJ2KLossless() throws Exception {
+        test("test16signed.dcm", "test16signed-HTJ2K-lossless.dcm", UID.HTJ2KLossless, true);
+    }
+
+    @Test
+    public void testRoundTripHTJ2KLosslessMono() throws Exception {
+        test("MR2_UNC", UID.HTJ2KLossless, UID.ExplicitVRLittleEndian);
+    }
+
+    @Test
+    public void testRoundTripHTJ2KLosslessRGB() throws Exception {
+        test("US-RGB-8-esopecho", UID.HTJ2KLossless, UID.ExplicitVRLittleEndian);
+    }
+
+    @Test
+    public void testRoundTripHTJ2KLosslessSigned() throws Exception {
+        test("test16signed.dcm", UID.HTJ2KLossless, UID.ExplicitVRLittleEndian);
+    }
+
+    @Test
     public void testConvertToJxlLossyJpegRecompression() throws Exception {
       test("test16signed.dcm", "test-signed-jxl-recompression.dcm", UID.JPEGXLJPEGRecompression, true);
       test("YBR_422.dcm", "YBR_422-jxl-recompression.dcm", UID.JPEGXLJPEGRecompression, true);

--- a/dcm4che-imageio/src/main/resources/org/dcm4che3/imageio/codec/ImageWriterFactory.properties
+++ b/dcm4che-imageio/src/main/resources/org/dcm4che3/imageio/codec/ImageWriterFactory.properties
@@ -8,6 +8,9 @@
 1.2.840.10008.1.2.4.81:jpeg-ls-cv:org.dcm4che3.opencv.NativeJLSImageWriter::bitsCompressed=-16;nearLossless=2
 1.2.840.10008.1.2.4.90:jpeg2000-cv:org.dcm4che3.opencv.NativeJ2kImageWriter::compressionType=LOSSLESS
 1.2.840.10008.1.2.4.91:jpeg2000-cv:org.dcm4che3.opencv.NativeJ2kImageWriter::compressionRatiofactor=10
+1.2.840.10008.1.2.4.201:htj2k-openjph:org.dcm4che3.openjph.NativeHTJ2kImageWriter::compressionType=LOSSLESS
+1.2.840.10008.1.2.4.202:htj2k-openjph:org.dcm4che3.openjph.NativeHTJ2kImageWriter::compressionType=LOSSLESS;progressionOrder=2
+1.2.840.10008.1.2.4.203:htj2k-openjph:org.dcm4che3.openjph.NativeHTJ2kImageWriter::compressionRatiofactor=10
 1.2.840.10008.1.2.4.110:jpeg-xl-cv:org.dcm4che3.opencv.NativeJXLImageWriter::compressionType=LOSSLESS;effort=7
 1.2.840.10008.1.2.4.111:jpeg-xl-cv:org.dcm4che3.opencv.NativeJXLImageWriter::compressionType=LOSSLESS
 1.2.840.10008.1.2.4.112:jpeg-xl-cv:org.dcm4che3.opencv.NativeJXLImageWriter::compressionType=LOSSY;compressionQuality=0.85

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
     <org.jvnet.mimepull.version>1.10.0</org.jvnet.mimepull.version>
     <org.jvnet.staxex.version>2.1.0</org.jvnet.staxex.version>
     <commons-cli.version>1.9.0</commons-cli.version>
+    <openjph.native.version>0.26.0</openjph.native.version>
 
     <!-- for SonarCloud / SonarQube -->
     <sonar.organization>dcm4che</sonar.organization>
@@ -205,6 +206,7 @@
     <module>dcm4che-image</module>
     <module>dcm4che-imageio</module>
     <module>dcm4che-imageio-opencv</module>
+    <module>dcm4che-imageio-openjph</module>
     <module>dcm4che-imageio-rle</module>
     <module>dcm4che-imageio-test</module>
     <module>dcm4che-json</module>
@@ -344,6 +346,34 @@
         <groupId>org.weasis.core</groupId>
         <artifactId>weasis-core-img</artifactId>
         <version>${weasis.core.img.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.dcm4che</groupId>
+        <artifactId>dcm4che-openjph-native</artifactId>
+        <version>${openjph.native.version}</version>
+        <type>so</type>
+        <classifier>linux-x86-64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.dcm4che</groupId>
+        <artifactId>dcm4che-openjph-native</artifactId>
+        <version>${openjph.native.version}</version>
+        <type>so</type>
+        <classifier>linux-aarch64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.dcm4che</groupId>
+        <artifactId>dcm4che-openjph-native</artifactId>
+        <version>${openjph.native.version}</version>
+        <type>dll</type>
+        <classifier>windows-x86-64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.dcm4che</groupId>
+        <artifactId>dcm4che-openjph-native</artifactId>
+        <version>${openjph.native.version}</version>
+        <type>dylib</type>
+        <classifier>macosx-aarch64</classifier>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Addresses https://github.com/dcm4che/dcm4che/issues/1376

I'm unsure if DCM4CHE will be interested in including this module, so I wanted to propose it as a Draft PR to gauge interest. I assumed there would be some community interest in an alternate HTJ2K encode solution until OpenCV/OpenJPEG provide direct support. Due to DCM4CHE's use of SPI, the additional OpenJPH module doesn't need to be bundled directly with DCM4CHE, and can instead be utilized by DCM4CHE dependent projects if this concept is all together rejected.

This PR introduces a new module (`dcm4che-imageio-openjph`) which provides HTJ2K encoding using OpenJPH via JNI. Supports lossless (TS 1.2.840.10008.1.2.4.201, 1.2.840.10008.1.2.4.202) and lossy (TS 1.2.840.10008.1.2.4.203) transfer syntaxes. No changes to core classes, integrates entirely through ImageWriterFactory.properties and SPI, and HTJ2K decode support is unaffected by this change.

 ---

**Native Library Dependency**

This PR depends on a separate native JNI library currently located [here](https://github.com/jknocek/dcm4che-openjph-native) that wraps [OpenJPH](https://github.com/aous72/OpenJPH) for HTJ2K encoding. Although Weasis maintains the existing native binaries utilized by DCM4CHE, I'm unsure if Weasis will be interested in this tooling as it exclusively adds HTJ2K encode support only. If desired, I would be happy to donate this native library to the DCM4CHE GitHub org, or to Weasis.

The native library:
- Provides a thin C/JNI bridge over OpenJPH's ojph::codestream C++ encoding API
- Statically links OpenJPH into a single shared library per platform, no runtime dependencies
- Builds via CMake + GitHub Actions for 4 platforms: Linux x86_64, Linux aarch64, Windows x86_64, macOS aarch64

I have not yet run the action to publish artifacts, and have been testing with them exclusively within my local maven repo at this point.

The native library must be on java.library.path at runtime, following the same deployment pattern as the OpenCV native library used by the existing image writers. If the native library is not present, HTJ2K encoding will fail with UnsatisfiedLinkError, other transfer syntaxes are unaffected.

Disclaimer, while I'm a professional Java developer, I'm not well versed in C/C++. Claude was used extensively to get a functional solution. That said, the solution has been working well in my tests so far. I would certainly request that someone with more experience in this area reviews this solution extensively.