### PR TITLE
BulkData.getFile() fails on UNC/WSL file paths for encapsulated DICOM

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/data/BulkData.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/data/BulkData.java
@@ -38,6 +38,7 @@
 
 package org.dcm4che3.data;
 
+import java.util.Locale;
 import org.dcm4che3.io.DicomEncodingOptions;
 import org.dcm4che3.io.DicomOutputStream;
 import org.dcm4che3.util.ByteUtils;
@@ -48,6 +49,7 @@ import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Paths;
 
 /**
  * @author Gunter Zeilinger <gunterze@gmail.com>
@@ -140,10 +142,14 @@ public class BulkData implements Value, Serializable {
 
     public File getFile() {
         try {
-            return new File(new URI(uriWithoutOffsetAndLength()));
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException("uri: " + uri);
-        } catch (IllegalArgumentException e) {
+            URI u = new URI(uriWithoutOffsetAndLength());
+            if (u.getAuthority() != null && System.getProperty("os.name")
+                .toLowerCase(Locale.ENGLISH).startsWith("windows")) {
+                // UNC path (e.g. file://wsl.localhost/... or file://server/share/...)
+                return new File("\\\\" + u.getAuthority() + u.getPath());
+            }
+            return Paths.get(u).toFile();
+        } catch (URISyntaxException | IllegalArgumentException e) {
             throw new IllegalStateException("uri: " + uri);
         }
     }

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/BulkDataTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/BulkDataTest.java
@@ -1,11 +1,13 @@
 package org.dcm4che3.data;
 
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
@@ -67,6 +69,8 @@ public class BulkDataTest {
 
     @Test
     public void getFile_uncPathWithAuthority() {
+        Assume.assumeTrue("UNC paths only work on Windows",
+                System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows"));
         // Reproduces https://github.com/dcm4che/dcm4che/issues/1562
         // file: URI with authority component (e.g. WSL or network share)
         String uri = "file://wsl.localhost/Ubuntu-24.04/home/spe/test/AIRAmed%20Demo%20MS/test.pdf";
@@ -77,6 +81,8 @@ public class BulkDataTest {
 
     @Test
     public void getFile_uncPathWithAuthorityAndOffsetLength() {
+        Assume.assumeTrue("UNC paths only work on Windows",
+                System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows"));
         String uri = "file://wsl.localhost/Ubuntu-24.04/home/spe/test/AIRAmed%20Demo%20MS/test.pdf";
         BulkData bd = new BulkData(uri, 1030, 2820688, false);
         File result = bd.getFile();

--- a/dcm4che-core/src/test/java/org/dcm4che3/data/BulkDataTest.java
+++ b/dcm4che-core/src/test/java/org/dcm4che3/data/BulkDataTest.java
@@ -1,0 +1,86 @@
+package org.dcm4che3.data;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link BulkData}, specifically getFile() with special characters in paths.
+ */
+public class BulkDataTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void getFile_simplePath() throws IOException {
+        File f = tempFolder.newFile("test.dcm");
+        String uri = f.toURI().toString();
+        BulkData bd = new BulkData(null, uri, false);
+        assertEquals(f, bd.getFile());
+    }
+
+    @Test
+    public void getFile_pathWithSpaces() throws IOException {
+        File dir = tempFolder.newFolder("path with spaces");
+        File f = new File(dir, "test.dcm");
+        f.createNewFile();
+        String uri = f.toURI().toString();
+        // URI will contain %20 for spaces
+        assert uri.contains("%20") : "URI should encode spaces as %20: " + uri;
+        BulkData bd = new BulkData(null, uri, false);
+        assertEquals(f, bd.getFile());
+    }
+
+    @Test
+    public void getFile_pathWithSpecialChars() throws IOException {
+        File dir = tempFolder.newFolder("données été");
+        File f = new File(dir, "test.dcm");
+        f.createNewFile();
+        String uri = f.toURI().toString();
+        BulkData bd = new BulkData(null, uri, false);
+        assertEquals(f, bd.getFile());
+    }
+
+    @Test
+    public void getFile_withOffsetAndLength() throws IOException {
+        File f = tempFolder.newFile("test.dcm");
+        String uri = f.toURI().toString();
+        BulkData bd = new BulkData(uri, 128, 1024, false);
+        assertEquals(f, bd.getFile());
+    }
+
+    @Test
+    public void getFile_pathWithSpacesAndOffsetLength() throws IOException {
+        File dir = tempFolder.newFolder("my folder");
+        File f = new File(dir, "test.dcm");
+        f.createNewFile();
+        String uri = f.toURI().toString();
+        BulkData bd = new BulkData(uri, 128, 1024, false);
+        assertEquals(f, bd.getFile());
+    }
+
+    @Test
+    public void getFile_uncPathWithAuthority() {
+        // Reproduces https://github.com/dcm4che/dcm4che/issues/1562
+        // file: URI with authority component (e.g. WSL or network share)
+        String uri = "file://wsl.localhost/Ubuntu-24.04/home/spe/test/AIRAmed%20Demo%20MS/test.pdf";
+        BulkData bd = new BulkData(null, uri, false);
+        File result = bd.getFile();
+        assertEquals(new File("\\\\wsl.localhost/Ubuntu-24.04/home/spe/test/AIRAmed Demo MS/test.pdf"), result);
+    }
+
+    @Test
+    public void getFile_uncPathWithAuthorityAndOffsetLength() {
+        String uri = "file://wsl.localhost/Ubuntu-24.04/home/spe/test/AIRAmed%20Demo%20MS/test.pdf";
+        BulkData bd = new BulkData(uri, 1030, 2820688, false);
+        File result = bd.getFile();
+        assertEquals(new File("\\\\wsl.localhost/Ubuntu-24.04/home/spe/test/AIRAmed Demo MS/test.pdf"), result);
+    }
+}
+

--- a/dcm4che-net/src/main/java/org/dcm4che3/net/service/InstanceLocator.java
+++ b/dcm4che-net/src/main/java/org/dcm4che3/net/service/InstanceLocator.java
@@ -42,6 +42,8 @@ import java.io.File;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Locale;
 
 
 /**
@@ -76,9 +78,15 @@ public class InstanceLocator implements Serializable {
 
     public File getFile() {
         try {
-            return new File(new URI(uri));
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException(e);
+            URI u = new URI(uri);
+            if (u.getAuthority() != null && System.getProperty("os.name")
+                .toLowerCase(Locale.ENGLISH).startsWith("windows")) {
+                // UNC path (e.g. file://server/share/...)
+                return new File("\\\\" + u.getAuthority() + u.getPath());
+            }
+            return Paths.get(u).toFile();
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            throw new IllegalStateException("uri: " + uri);
         }
     }
 }


### PR DESCRIPTION
This is a proposal to fix BulkData.getFile() and InstanceLocator.getFile() to handle file: URIs containing an authority component, such as UNC paths from WSL or network shares.

### Problem
When DICOM files are accessed via UNC paths (e.g. file://wsl.localhost/Ubuntu-24.04/home/.../AIRAmed%20Demo%20MS/test.pdf), BulkData.getFile() throws IllegalArgumentException
See: https://github.com/nroduit/Weasis/issues/778 and #1562

### Changes
BulkData.getFile(): On Windows, when the URI contains an authority component, construct the File directly as a UNC path (\\authority\path). For standard file URIs, use Paths.get(URI).toFile() (modern API replacing new File(URI)).
InstanceLocator.getFile(): Same fix applied (identical new File(new URI(...)) pattern).

### ⚠️ Important caveats
This fix needs to be validated in the specific context (Windows + WSL, Windows + SMB shares) where the original issue occurs.
Also, this fix will not solve all issues related to mounted filesystems using specific protocols (GVFS/FUSE over SMB, SSHFS, etc.). In particular, some mount protocols do not support FileChannel.size() or byte-level skip/seek operations on streams, which causes IOException: Invalid argument during bulk data extraction. In those cases, the encapsulated document or pixel data needs to be fully extracted to a local temporary file rather than accessed via offset-based stream reading. That is a separate concern that must be handled at the application level (e.g. in Weasis).