### PR TITLE
Correct SamplesPerPixel tag reference in MultiframeExtractor

### DIFF
--- a/dcm4che-emf/src/main/java/org/dcm4che3/emf/MultiframeExtractor.java
+++ b/dcm4che-emf/src/main/java/org/dcm4che3/emf/MultiframeExtractor.java
@@ -379,7 +379,7 @@ public class MultiframeExtractor {
         return src.getInt(Tag.Rows, 0)
              * src.getInt(Tag.Columns, 0)
              * (src.getInt(Tag.BitsAllocated, 8) >> 3)
-             * src.getInt(Tag.NumberOfSamples, 1);
+             * src.getInt(Tag.SamplesPerPixel, 1);
     }
 
     private String createInstanceNumber(String mfinstno, int frame) {


### PR DESCRIPTION
**Problem**
An issue was discovered in the calcFrameLength method of the MultiframeExtractor class, leading to incorrect frame length calculations.

**Root Cause**
The method incorrectly referenced tag (5000,0006) instead of the standard Tag.SamplesPerPixel (0028,0002).

**Why this happens**
This bug is often masked in grayscale images where SamplesPerPixel is 1. In those cases, the calculation might coincidentally work or the error is negligible. However, it causes critical failures in RGB images (where SamplesPerPixel is 3), leading to significant pixel data misalignment and corrupted images.

**Solution**
Corrected the tag reference to the standard Tag.SamplesPerPixel (0028,0002) to ensure accurate byte offset calculation for all image types.