### PR TITLE
Fix VOI window LUT to follow DICOM LINEAR windowing

### DIFF
--- a/dcm4che-image/pom.xml
+++ b/dcm4che-image/pom.xml
@@ -8,15 +8,6 @@
   <artifactId>dcm4che-image</artifactId>
   <packaging>bundle</packaging>
   <name>dcm4che-image</name>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
-      </plugin>
-    </plugins>
-  </build>
   <dependencies>
     <dependency>
       <groupId>org.dcm4che</groupId>
@@ -30,6 +21,20 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dcm4che-image/src/main/java/org/dcm4che3/image/ByteLookupTable.java
+++ b/dcm4che-image/src/main/java/org/dcm4che3/image/ByteLookupTable.java
@@ -9,19 +9,6 @@ public class ByteLookupTable extends LookupTable {
         this.lut = lut;
     }
 
-    ByteLookupTable(StoredValue inBits, int outBits, int minOut, int maxOut, int offset, int size, boolean flip) {
-        this(inBits, outBits, offset, new byte[minOut == maxOut ? 1 : size]);
-        if (lut.length == 1) {
-            lut[0] = (byte) minOut;
-        } else {
-            int maxIndex = size - 1;
-            int midIndex = maxIndex / 2;
-            int outRange = maxOut - minOut;
-            for (int i = 0; i < size; i++)
-                lut[flip ? maxIndex - i : i] = (byte) ((i * outRange + midIndex) / maxIndex + minOut);
-        }
-    }
-
     @Override
     public int length() {
         return lut.length;

--- a/dcm4che-image/src/main/java/org/dcm4che3/image/LookupTableFactory.java
+++ b/dcm4che-image/src/main/java/org/dcm4che3/image/LookupTableFactory.java
@@ -71,7 +71,7 @@ public class LookupTableFactory {
     private LookupTable modalityLUT;
     private float windowCenter;
     private float windowWidth;
-    private String voiLUTFunction; // not yet implemented
+    private String voiLUTFunction;
     private LookupTable voiLUT;
     private LookupTable presentationLUT;
     private boolean inverse;
@@ -149,6 +149,7 @@ public class LookupTableFactory {
                         : 0;
                 windowCenter = wcs[index];
                 windowWidth = wws[index];
+                voiLUTFunction = img.getString(Tag.VOILUTFunction);
                 return;
             }
         }
@@ -254,52 +255,52 @@ public class LookupTableFactory {
     }
 
     private LookupTable combineModalityVOILUT(int outBits) {
-        float m = rescaleSlope;
-        float b = rescaleIntercept;
         LookupTable modalityLUT = this.modalityLUT;
         LookupTable lut = this.voiLUT;
-        if (lut == null) {
-            float c = windowCenter;
-            float w = windowWidth;
-
-            if (w == 0 && modalityLUT != null)
-                return modalityLUT.adjustOutBits(outBits);
-
-            int size, offset;
-            StoredValue inBits = modalityLUT != null
-                    ? new StoredValue.Unsigned(modalityLUT.outBits)
-                    : storedValue;
-            int minOut = 0;
-            int maxOut = (1<<outBits)-1;
-            if (w != 0) {
-                float M = Math.abs(m);
-                size = Math.max(2,Math.round(w/M));
-                offset = Math.round((c-w/2-b)/M);
-                int minIndex = inBits.minValue() - offset;
-                int maxIndex = inBits.maxValue() - offset;
-                int size_1 = size - 1;
-                int midIndex = size_1 / 2;
-                if (minIndex > 0) {
-                    offset += minIndex;
-                    size -= minIndex;
-                    minOut = (minIndex * maxOut + midIndex) / size_1;
-                }
-                if (maxIndex < size_1) {
-                    size -= size_1 - maxIndex;
-                    maxOut = (maxIndex * maxOut + midIndex) / size_1;
-                }
-            } else {
-                offset = inBits.minValue();
-                size = inBits.maxValue() - inBits.minValue() + 1;
-            }
-            lut = outBits > 8
-                    ? new ShortLookupTable(inBits, outBits, minOut, maxOut, offset, size, m < 0)
-                    : new ByteLookupTable(inBits, outBits, minOut, maxOut, offset, size, m < 0);
-        } else {
-            //TODO consider m+b
+        if (lut != null) {
             lut = lut.adjustOutBits(outBits);
+            return modalityLUT != null ? modalityLUT.combine(lut) : lut;
         }
-        return modalityLUT != null ? modalityLUT.combine(lut) : lut;
+        if (windowWidth == 0 && modalityLUT != null)
+            return modalityLUT.adjustOutBits(outBits);
+        return createWindowLookupTable(outBits);
+    }
+
+    private LookupTable createWindowLookupTable(int outBits) {
+        StoredValue inBits = storedValue;
+        int minSV = inBits.minValue();
+        int maxSV = inBits.maxValue();
+        long len = (long) maxSV - minSV + 1;
+        if (len > 0x10000)
+            throw new IllegalArgumentException(
+                    "stored value range " + len + " exceeds maximum LUT size 65536");
+        float w = windowWidth == 0 ? 1 : windowWidth;
+        VOILUTFunction fn = VOILUT.parseFunction(voiLUTFunction);
+        int ymax = (1 << outBits) - 1;
+        byte[] data = new byte[(int) len];
+        for (int sv = minSV; sv <= maxSV; sv++) {
+            double x = modalityValue(sv);
+            data[sv - minSV] = (byte) VOILUT.apply(fn, x, windowCenter, w, 0, ymax);
+        }
+        LookupTable lut = new VOIWindowLookupTable(inBits, outBits, minSV, data,
+                modalityLUT, rescaleSlope, rescaleIntercept,
+                fn, windowCenter, w);
+        return outBits > 8 ? lut.adjustOutBits(outBits) : lut;
+    }
+
+    private double modalityValue(int storedValue) {
+        if (modalityLUT == null)
+            return VOILUT.modalityValue(storedValue, rescaleSlope, rescaleIntercept);
+        byte[] bIn = { (byte) storedValue };
+        short[] sIn = { (short) storedValue };
+        if (modalityLUT.outBits > 8) {
+            short[] sOut = { 0 };
+            modalityLUT.lookup(sIn, 0, sOut, 0, 1);
+            return sOut[0];
+        }
+        byte[] bOut = { 0 };
+        modalityLUT.lookup(bIn, 0, bOut, 0, 1);
+        return bOut[0] & 0xff;
     }
 
     public boolean autoWindowing(Attributes img, Raster raster) {

--- a/dcm4che-image/src/main/java/org/dcm4che3/image/ShortLookupTable.java
+++ b/dcm4che-image/src/main/java/org/dcm4che3/image/ShortLookupTable.java
@@ -9,19 +9,6 @@ public class ShortLookupTable extends LookupTable {
         this.lut = lut;
     }
 
-    ShortLookupTable(StoredValue inBits, int outBits, int minOut, int maxOut, int offset, int size, boolean flip) {
-        this(inBits, outBits, offset, new short[minOut == maxOut ? 1 : size]);
-        if (lut.length == 1) {
-            lut[0] = (short) minOut;
-        } else {
-            int outRange = maxOut - minOut;
-            int maxIndex = size - 1;
-            int midIndex = maxIndex / 2;
-            for (int i = 0; i < size; i++)
-                lut[flip ? maxIndex - i : i] = (short) ((i * outRange + midIndex) / maxIndex + minOut);
-        }
-    }
-
     @Override
     public int length() {
         return lut.length;

--- a/dcm4che-image/src/main/java/org/dcm4che3/image/VOILUT.java
+++ b/dcm4che-image/src/main/java/org/dcm4che3/image/VOILUT.java
@@ -1,0 +1,126 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is part of dcm4che, an implementation of DICOM(TM) in
+ * Java(TM), hosted at https://github.com/dcm4che.
+ *
+ * The Initial Developer of the Original Code is
+ * Agfa Healthcare.
+ * Portions created by the Initial Developer are Copyright (C) 2013
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ * See @authors listed below
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+package org.dcm4che3.image;
+
+/**
+ * VOI windowing per PS3.3 C.11.2.1.2 (LINEAR) and C.11.2.1.3.2 (LINEAR_EXACT).
+ *
+ * @author Gunter Zeilinger &lt;gunterze@gmail.com&gt;
+ */
+public final class VOILUT {
+
+    private VOILUT() {}
+
+    public static VOILUTFunction parseFunction(String function) {
+        if (function == null || function.isEmpty())
+            return VOILUTFunction.LINEAR;
+        try {
+            return VOILUTFunction.valueOf(function.trim());
+        } catch (IllegalArgumentException e) {
+            return VOILUTFunction.LINEAR;
+        }
+    }
+
+  /**
+   * Apply modality LUT or rescale: output = m * SV + b.
+   */
+    public static double modalityValue(int storedValue, float rescaleSlope, float rescaleIntercept) {
+        return rescaleSlope * storedValue + rescaleIntercept;
+    }
+
+  /**
+   * Map a modality value to a display output in {@code [ymin, ymax]}.
+   *
+   * @param x modality value (after Modality LUT or rescale)
+   */
+    public static int apply(VOILUTFunction function, double x,
+            float windowCenter, float windowWidth, int ymin, int ymax) {
+        if (windowWidth <= 0)
+            windowWidth = 1;
+        switch (function) {
+            case LINEAR_EXACT:
+                return linearExact(x, windowCenter, windowWidth, ymin, ymax);
+            case SIGMOID:
+                return sigmoid(x, windowCenter, windowWidth, ymin, ymax);
+            case LINEAR:
+            default:
+                return linear(x, windowCenter, windowWidth, ymin, ymax);
+        }
+    }
+
+  /** PS3.3 C.11.2.1.2.1 default LINEAR. */
+    public static int linear(double x, float c, float w, int ymin, int ymax) {
+        if (w < 1)
+            w = 1;
+        double low = c - 0.5 - (w - 1) / 2.;
+        double high = c - 0.5 + (w - 1) / 2.;
+        if (x <= low)
+            return ymin;
+        if (x > high)
+            return ymax;
+        double y = ((x - (c - 0.5)) / (w - 1) + 0.5) * (ymax - ymin) + ymin;
+        return clamp(y, ymin, ymax);
+    }
+
+  /** PS3.3 C.11.2.1.3.2 LINEAR_EXACT. */
+    public static int linearExact(double x, float c, float w, int ymin, int ymax) {
+        if (w <= 0)
+            w = 1;
+        double low = c - w / 2.;
+        double high = c + w / 2.;
+        if (x <= low)
+            return ymin;
+        if (x > high)
+            return ymax;
+        double y = ((x - c) / w + 0.5) * (ymax - ymin) + ymin;
+        return clamp(y, ymin, ymax);
+    }
+
+  /** PS3.3 C.11.2.1.3.1 SIGMOID (Equation C.11-1). */
+    public static int sigmoid(double x, float c, float w, int ymin, int ymax) {
+        if (w <= 0)
+            w = 1;
+        double y = ymax / (1 + Math.exp(-4 * (x - c) / w));
+        return clamp(y, ymin, ymax);
+    }
+
+    private static int clamp(double y, int ymin, int ymax) {
+        return (int) Math.min(Math.max(Math.round(y), ymin), ymax);
+    }
+}

--- a/dcm4che-image/src/main/java/org/dcm4che3/image/VOIWindowLookupTable.java
+++ b/dcm4che-image/src/main/java/org/dcm4che3/image/VOIWindowLookupTable.java
@@ -1,3 +1,41 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is part of dcm4che, an implementation of DICOM(TM) in
+ * Java(TM), hosted at https://github.com/dcm4che.
+ *
+ * The Initial Developer of the Original Code is
+ * Agfa Healthcare.
+ * Portions created by the Initial Developer are Copyright (C) 2013
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ * See @authors listed below
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
 package org.dcm4che3.image;
 
 /**

--- a/dcm4che-image/src/main/java/org/dcm4che3/image/VOIWindowLookupTable.java
+++ b/dcm4che-image/src/main/java/org/dcm4che3/image/VOIWindowLookupTable.java
@@ -1,0 +1,124 @@
+package org.dcm4che3.image;
+
+/**
+ * Full-range VOI window LUT indexed by stored pixel value, with on-demand calculation
+ * when an index falls outside the precomputed table.
+ */
+class VOIWindowLookupTable extends LookupTable {
+
+    private final byte[] lut;
+    private final int lutMin;
+    private final LookupTable modalityLUT;
+    private final float rescaleSlope;
+    private final float rescaleIntercept;
+    private final VOILUTFunction function;
+    private final float windowCenter;
+    private final float windowWidth;
+    private final int ymin;
+    private final int ymax;
+
+    VOIWindowLookupTable(StoredValue inBits, int outBits, int lutMin, byte[] lut,
+            LookupTable modalityLUT, float rescaleSlope, float rescaleIntercept,
+            VOILUTFunction function, float windowCenter, float windowWidth) {
+        super(inBits, outBits, lutMin);
+        this.lut = lut;
+        this.lutMin = lutMin;
+        this.modalityLUT = modalityLUT;
+        this.rescaleSlope = rescaleSlope;
+        this.rescaleIntercept = rescaleIntercept;
+        this.function = function;
+        this.windowCenter = windowCenter;
+        this.windowWidth = windowWidth;
+        this.ymin = 0;
+        this.ymax = (1 << outBits) - 1;
+    }
+
+    @Override
+    public int length() {
+        return lut.length;
+    }
+
+    private int output(int pixel) {
+        int sv = inBits.valueOf(pixel);
+        int index = sv - lutMin;
+        if (index >= 0 && index < lut.length)
+            return lut[index] & 0xff;
+        return compute(sv);
+    }
+
+    private int compute(int storedValue) {
+        double x = modalityValue(storedValue);
+        return VOILUT.apply(function, x, windowCenter, windowWidth, ymin, ymax);
+    }
+
+    private double modalityValue(int storedValue) {
+        if (modalityLUT == null)
+            return VOILUT.modalityValue(storedValue, rescaleSlope, rescaleIntercept);
+        byte[] bIn = { (byte) storedValue };
+        short[] sIn = { (short) storedValue };
+        if (modalityLUT.outBits > 8) {
+            short[] sOut = { 0 };
+            modalityLUT.lookup(sIn, 0, sOut, 0, 1);
+            return sOut[0];
+        }
+        byte[] bOut = { 0 };
+        modalityLUT.lookup(bIn, 0, bOut, 0, 1);
+        return bOut[0] & 0xff;
+    }
+
+    @Override
+    public void lookup(byte[] src, int srcPos, byte[] dest, int destPos, int length) {
+        for (int i = srcPos, endPos = srcPos + length, j = destPos; i < endPos;)
+            dest[j++] = (byte) output(src[i++]);
+    }
+
+    @Override
+    public void lookup(short[] src, int srcPos, byte[] dest, int destPos, int length) {
+        for (int i = srcPos, endPos = srcPos + length, j = destPos; i < endPos;)
+            dest[j++] = (byte) output(src[i++]);
+    }
+
+    @Override
+    public void lookup(byte[] src, int srcPos, short[] dest, int destPos, int length) {
+        for (int i = srcPos, endPos = srcPos + length, j = destPos; i < endPos;)
+            dest[j++] = (short) output(src[i++]);
+    }
+
+    @Override
+    public void lookup(short[] src, int srcPos, short[] dest, int destPos, int length) {
+        for (int i = srcPos, endPos = srcPos + length, j = destPos; i < endPos;)
+            dest[j++] = (short) output(src[i++]);
+    }
+
+    @Override
+    public LookupTable adjustOutBits(int outBits) {
+        if (outBits == this.outBits)
+            return this;
+        int diff = outBits - this.outBits;
+        byte[] scaled = new byte[lut.length];
+        if (diff > 0) {
+            for (int i = 0; i < lut.length; i++)
+                scaled[i] = (byte) (Math.min((lut[i] & 0xff) << diff, (1 << outBits) - 1));
+        } else {
+            diff = -diff;
+            for (int i = 0; i < lut.length; i++)
+                scaled[i] = (byte) ((lut[i] & 0xff) >> diff);
+        }
+        return new VOIWindowLookupTable(inBits, outBits, lutMin, scaled,
+                modalityLUT, rescaleSlope, rescaleIntercept,
+                function, windowCenter, windowWidth);
+    }
+
+    @Override
+    public void inverse() {
+        for (int i = 0; i < lut.length; i++)
+            lut[i] = (byte) (ymax - (lut[i] & 0xff));
+    }
+
+    @Override
+    public LookupTable combine(LookupTable other) {
+        byte[] combined = new byte[lut.length];
+        other.lookup(lut, 0, combined, 0, lut.length);
+        return new ByteLookupTable(inBits, other.outBits, lutMin, combined);
+    }
+}

--- a/dcm4che-image/src/test/java/org/dcm4che3/image/VOILUTTest.java
+++ b/dcm4che-image/src/test/java/org/dcm4che3/image/VOILUTTest.java
@@ -1,0 +1,105 @@
+package org.dcm4che3.image;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class VOILUTTest {
+
+    private static final float M = 32.1216f;
+    private static final float B = -4047f;
+    private static final float C = 40f;
+    private static final float W = 400f;
+
+    @Test
+    public void testLinearCTExample() {
+        assertEquals(20, VOILUT.linear(modality(122), C, W, 0, 255));
+        assertEquals(144, VOILUT.linear(modality(128), C, W, 0, 255));
+        assertEquals(226, VOILUT.linear(modality(132), C, W, 0, 255));
+    }
+
+    @Test
+    public void testLinearExactCTExample() {
+        assertEquals(20, VOILUT.linearExact(modality(122), C, W, 0, 255));
+        assertEquals(143, VOILUT.linearExact(modality(128), C, W, 0, 255));
+        assertEquals(225, VOILUT.linearExact(modality(132), C, W, 0, 255));
+    }
+
+    @Test
+    public void testWindowLookupTableLinear() {
+        StoredValue sv = new StoredValue.Unsigned(8);
+        LookupTableFactory factory = new LookupTableFactory(sv);
+        factory.setModalityLUT(attrs(M, B));
+        factory.setWindowCenter(C);
+        factory.setWindowWidth(W);
+        factory.setVOI(attrs(M, B), 0, 0, true);
+
+        LookupTable lut = factory.createLUT(8);
+        assertEquals(20, lookup(lut, sv, 122));
+        assertEquals(144, lookup(lut, sv, 128));
+        assertEquals(226, lookup(lut, sv, 132));
+    }
+
+    @Test
+    public void testWindowLookupTableLinearExact() {
+        StoredValue sv = new StoredValue.Unsigned(8);
+        LookupTableFactory factory = new LookupTableFactory(sv);
+        factory.setModalityLUT(attrs(M, B));
+        factory.setWindowCenter(C);
+        factory.setWindowWidth(W);
+        org.dcm4che3.data.Attributes img = attrs(M, B);
+        img.setString(org.dcm4che3.data.Tag.VOILUTFunction,
+                org.dcm4che3.data.VR.CS, "LINEAR_EXACT");
+        factory.setVOI(img, 0, 0, true);
+
+        LookupTable lut = factory.createLUT(8);
+        assertEquals(20, lookup(lut, sv, 122));
+        assertEquals(143, lookup(lut, sv, 128));
+        assertEquals(225, lookup(lut, sv, 132));
+    }
+
+    @Test
+    public void testOutOfRangeUsesFullCalculation() {
+        byte[] lut = new byte[1];
+        lut[0] = 99;
+        VOIWindowLookupTable table = new VOIWindowLookupTable(
+                new StoredValue.Unsigned(8), 8, 100, lut,
+                null, M, B, VOILUTFunction.LINEAR, C, W);
+        // stored value 122 is outside lut range [100, 100]
+        assertEquals(20, lookupRaw(table, (byte) 122));
+    }
+
+    private static double modality(int stored) {
+        return VOILUT.modalityValue(stored, M, B);
+    }
+
+    private static int lookup(LookupTable lut, StoredValue sv, int stored) {
+        byte[] src = { (byte) stored };
+        byte[] dest = new byte[1];
+        lut.lookup(src, 0, dest, 0, 1);
+        return dest[0] & 0xff;
+    }
+
+    private static int lookupRaw(LookupTable lut, byte raw) {
+        byte[] dest = new byte[1];
+        lut.lookup(new byte[] { raw }, 0, dest, 0, 1);
+        return dest[0] & 0xff;
+    }
+
+    private static org.dcm4che3.data.Attributes attrs(float slope, float intercept) {
+        org.dcm4che3.data.Attributes attrs = new org.dcm4che3.data.Attributes();
+        attrs.setFloat(org.dcm4che3.data.Tag.RescaleSlope,
+                org.dcm4che3.data.VR.DS, slope);
+        attrs.setFloat(org.dcm4che3.data.Tag.RescaleIntercept,
+                org.dcm4che3.data.VR.DS, intercept);
+        attrs.setInt(org.dcm4che3.data.Tag.PixelRepresentation,
+                org.dcm4che3.data.VR.US, 0);
+        attrs.setInt(org.dcm4che3.data.Tag.BitsStored,
+                org.dcm4che3.data.VR.US, 8);
+        attrs.setFloat(org.dcm4che3.data.Tag.WindowCenter,
+                org.dcm4che3.data.VR.DS, C);
+        attrs.setFloat(org.dcm4che3.data.Tag.WindowWidth,
+                org.dcm4che3.data.VR.DS, W);
+        return attrs;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes incorrect display output when applying **Window Center/Width** VOI windowing (no explicit VOI LUT Sequence). The previous implementation built a small compressed LUT with a linear ramp in **stored pixel index** space, which does not match DICOM PS3.3.

This change:

- Applies modality rescale (`x = m×SV + b`) before VOI windowing
- Builds a full-range LUT (up to 65536 entries by bits stored) using the standard formulas
- Supports **LINEAR** (PS3.3 C.11.2.1.2.1), **LINEAR_EXACT** (C.11.2.1.3.2), and **SIGMOID** (C.11.2.1.3.1) via `VOILUTFunction`
- Falls back to on-demand calculation for stored values outside the precomputed table (`VOIWindowLookupTable`)
- Removes the obsolete compressed-ramp constructors from `ByteLookupTable` / `ShortLookupTable`

## Problem

For CT with rescale slope/intercept and W=400, C=40, stored values that should map to display outputs **20, 144, 226** (LINEAR) were incorrectly rendered as **23, 162, 255** (with premature clamping at 255).

## Solution

- New `VOILUT` class: DICOM-compliant modality + VOI window math
- New `VOIWindowLookupTable`: indexed by stored value, with out-of-range fallback
- `LookupTableFactory.combineModalityVOILUT` now precomputes the correct LUT instead of the old `size = round(w/M)` approximation

## Test data (cornerstone3D)

Visual comparison used the JPEG baseline CT test instance from [cornerstone3D](https://github.com/cornerstonejs/cornerstone3D):

- DICOM: [`packages/dicomImageLoader/testImages/CTImage.dcm_JPEGProcess1TransferSyntax_1.2.840.10008.1.2.4.50.dcm`](https://github.com/cornerstonejs/cornerstone3D/blob/main/packages/dicomImageLoader/testImages/CTImage.dcm_JPEGProcess1TransferSyntax_1.2.840.10008.1.2.4.50.dcm) (transfer syntax `1.2.840.10008.1.2.4.50`)
- Test descriptor: [`packages/dicomImageLoader/testImages/CTImage.dcm_JPEGProcess1TransferSyntax_1.2.840.10008.1.2.4.50.ts`](https://github.com/cornerstonejs/cornerstone3D/blob/main/packages/dicomImageLoader/testImages/CTImage.dcm_JPEGProcess1TransferSyntax_1.2.840.10008.1.2.4.50.ts)
- Directory: [`packages/dicomImageLoader/testImages/`](https://github.com/cornerstonejs/cornerstone3D/tree/main/packages/dicomImageLoader/testImages)

## Tests

Added `VOILUTTest` in `dcm4che-image` covering:

- LINEAR and LINEAR_EXACT formulas for the CT example (SV 122/128/132)
- End-to-end `LookupTableFactory` window LUT
- Out-of-range fallback in `VOIWindowLookupTable`

```
mvnw -pl dcm4che-image test
```

## Test plan

- [x] `mvnw -pl dcm4che-image test` passes locally
- [ ] Render the cornerstone3D CT JPEG-baseline test instance above with `dcm2jpg` / image reader and verify windowing matches DICOM LINEAR reference
- [ ] Regression check on datasets using explicit VOI LUT Sequence (unchanged path)
